### PR TITLE
Repository migration => s_ianunruh/hvac_hvac/hvac_g

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,11 @@ See the [Advanced Usage](https://hvac.readthedocs.io/en/latest/advanced_usage.ht
 
 IMPROVEMENTS:
 
-* sphinx documentation and [readthedocs.io project](https://hvac.readthedocs.io/en/latest/) added. [GH-222](https://github.com/ianunruh/hvac/pull/222)
-* README.md included in setuptools metadata. [GH-222](https://github.com/ianunruh/hvac/pull/222)
-* All `tune_secret_backend()` parameters now accepted. [GH-215](https://github.com/ianunruh/hvac/pull/215)
-* Add `read_lease()` method [GH-218](https://github.com/ianunruh/hvac/pull/218)
-* Added adapter module with `Request` class to abstract HTTP requests away from the `Client` class. [GH-223](https://github.com/ianunruh/hvac/pull/223)
+* sphinx documentation and [readthedocs.io project](https://hvac.readthedocs.io/en/latest/) added. [GH-222](https://github.com/hvac/hvac/pull/222)
+* README.md included in setuptools metadata. [GH-222](https://github.com/hvac/hvac/pull/222)
+* All `tune_secret_backend()` parameters now accepted. [GH-215](https://github.com/hvac/hvac/pull/215)
+* Add `read_lease()` method [GH-218](https://github.com/hvac/hvac/pull/218)
+* Added adapter module with `Request` class to abstract HTTP requests away from the `Client` class. [GH-223](https://github.com/hvac/hvac/pull/223)
 
 Thanks to @bbayszczak, @jvanbrunschot-coolblue for their lovely contributions.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ The follow list uses version number `0.6.2`, this string should be updated to ma
   ```
   git checkout -b master_v0-6-2
   ```
-- [ ] Update [CHANGELOG.md](CHANGELOG.md) with a list of the included changes. Those changes can be reviewed, and their associated GitHub PR number confirmed, via GitHub's pull request diff using the previous version's tag. E.g.: [https://github.com/ianunruh/hvac/compare/v0.6.1...master](https://github.com/ianunruh/hvac/compare/v0.6.1...master)
+- [ ] Update [CHANGELOG.md](CHANGELOG.md) with a list of the included changes. Those changes can be reviewed, and their associated GitHub PR number confirmed, via GitHub's pull request diff using the previous version's tag. E.g.: [https://github.com/hvac/hvac/compare/v0.6.1...master](https://github.com/hvac/hvac/compare/v0.6.1...master)
 - [ ] Commit the changelog changes:
   ```
   git add CHANGELOG.md
@@ -78,9 +78,9 @@ The follow list uses version number `0.6.2`, this string should be updated to ma
   <verify hvac functionality>
   deactivate
   ```
-- [ ] Create a **draft** GitHub release using the contents of the new release version's [CHANGELOG.md](CHANGELOG.md) content: https://github.com/ianunruh/hvac/releases/new
+- [ ] Create a **draft** GitHub release using the contents of the new release version's [CHANGELOG.md](CHANGELOG.md) content: https://github.com/hvac/hvac/releases/new
 - [ ] Upload the sdist and whl files to the draft GitHub release as attached "binaries".
-- [ ] Push up the working branch (`git push`) and open a PR to merge the working branch into master:  [https://github.com/ianunruh/hvac/compare/master...master_v0-6-2](https://github.com/ianunruh/hvac/compare/master...master_v0-6-2)
+- [ ] Push up the working branch (`git push`) and open a PR to merge the working branch into master:  [https://github.com/hvac/hvac/compare/master...master_v0-6-2](https://github.com/hvac/hvac/compare/master...master_v0-6-2)
 - [ ] After merging the working branch into master, tag master with the release version and push that up as well:
   ```
   git checkout master
@@ -104,5 +104,5 @@ The follow list uses version number `0.6.2`, this string should be updated to ma
   deactivate
   ```
 
-- [ ] Publish the draft release on GitHub: [https://github.com/ianunruh/hvac/releases](https://github.com/ianunruh/hvac/releases)
+- [ ] Publish the draft release on GitHub: [https://github.com/hvac/hvac/releases](https://github.com/hvac/hvac/releases)
 - [ ] Update the [hvac project on readthedocs.io](https://readthedocs.org/dashboard/hvac/versions/), set the "stable" version to the new release and ensure the new tag for the release version is set as "active".

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [HashiCorp](https://hashicorp.com/) [Vault](https://www.vaultproject.io) API client for Python 2/3
 
-[![Travis CI](https://travis-ci.org/ianunruh/hvac.svg?branch=master)](https://travis-ci.org/ianunruh/hvac) [![Latest Version](https://img.shields.io/pypi/v/hvac.svg)](https://pypi.python.org/pypi/hvac/) [![Documentation Status](https://readthedocs.org/projects/hvac/badge/)](https://hvac.readthedocs.io/en/latest/?badge=latest)
+[![Travis CI](https://travis-ci.org/hvac/hvac.svg?branch=master)](https://travis-ci.org/hvac/hvac) [![Latest Version](https://img.shields.io/pypi/v/hvac.svg)](https://pypi.python.org/pypi/hvac/) [![Documentation Status](https://readthedocs.org/projects/hvac/badge/)](https://hvac.readthedocs.io/en/latest/?badge=latest)
 
 Tested against Vault v0.1.2 and HEAD. Requires v0.1.2 or later.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 hvac: Python Client Library for HashiCorp's Vault
 =================================================
 
-Source code repository hosted at `github.com/ianunruh/hvac`_.
+Source code repository hosted at `github.com/hvac/hvac`_.
 
 .. toctree::
    :glob:
@@ -25,4 +25,4 @@ Indices and tables
 * :ref:`search`
 
 
-.. _github.com/ianunruh/hvac: https://github.com/ianunruh/hvac/
+.. _github.com/hvac/hvac: https://github.com/hvac/hvac/

--- a/hvac/adapters.py
+++ b/hvac/adapters.py
@@ -186,7 +186,7 @@ class Request(Adapter):
         response = self.session.request(method, url, headers=headers,
                                         allow_redirects=False, **_kwargs)
 
-        # NOTE(ianunruh): workaround for https://github.com/ianunruh/hvac/issues/51
+        # NOTE(ianunruh): workaround for https://github.com/hvac/hvac/issues/51
         while response.is_redirect and self.allow_redirects:
             url = self.urljoin(self.base_uri, response.headers['Location'])
             response = self.session.request(method, url, headers=headers,

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     long_description_content_type="text/markdown",
     author='Ian Unruh',
     author_email='ianunruh@gmail.com',
-    url='https://github.com/ianunruh/hvac',
+    url='https://github.com/hvac/hvac',
     keywords=['hashicorp', 'vault'],
     classifiers=['License :: OSI Approved :: Apache Software License'],
     packages=find_packages(),


### PR DESCRIPTION
The maintainers of this repository have migrated the project from its original location (thanks again @ianunruh :D) to a [GitHub organization](https://github.com/hvac) to enable more granular access controls for maintainers. This PR is simply updating any references to the previous location / URL to match hvac's new home.