### PR TITLE
Refactor adapters, Duplicate Auth Method

### DIFF
--- a/hvac/adapters.py
+++ b/hvac/adapters.py
@@ -70,6 +70,11 @@ class Adapter(object):
 
         return '/'.join(map(lambda x: str(x).strip('/'), args))
 
+    def close(self):
+        """Close the underlying Requests session.
+        """
+        self.session.close()
+
     def get(self, url, **kwargs):
         """Performs a GET request.
 
@@ -108,11 +113,6 @@ class Adapter(object):
         :rtype: requests.Response
         """
         return self.request('put', url, **kwargs)
-
-    def close(self):
-        """Close the underlying Requests session.
-        """
-        self.session.close()
 
     def delete(self, url, **kwargs):
         """Performs a DELETE request.

--- a/hvac/adapters.py
+++ b/hvac/adapters.py
@@ -151,6 +151,20 @@ class Adapter(object):
 
     @abstractmethod
     def request(self, method, url, headers=None, **kwargs):
+        """Main method for routing HTTP requests to the configured Vault base_uri. Intended to be implement by subclasses.
+
+        :param method: HTTP method to use with the request. E.g., GET, POST, etc.
+        :type method: str
+        :param url: Partial URL path to send the request to. This will be joined to the end of the instance's base_uri
+            attribute.
+        :type url: basestring
+        :param headers: Additional headers to include with the request.
+        :type headers: dict
+        :param kwargs: Additional keyword arguments to include in the requests call.
+        :type kwargs: dict
+        :return: The response of the request.
+        :rtype: requests.Response
+        """
         raise NotImplemented
 
 
@@ -158,7 +172,7 @@ class Request(Adapter):
     """The Request adapter class"""
 
     def request(self, method, url, headers=None, **kwargs):
-        """
+        """Main method for routing HTTP requests to the configured Vault base_uri.
 
         :param method: HTTP method to use with the request. E.g., GET, POST, etc.
         :type method: str

--- a/hvac/adapters.py
+++ b/hvac/adapters.py
@@ -13,52 +13,14 @@ from abc import ABCMeta, abstractmethod
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_BASE_URI = 'http://localhost:8200'
+
 
 class Adapter(object):
     """Abstract base class used when constructing adapters for use with the Client class."""
     __metaclass__ = ABCMeta
 
-    @staticmethod
-    def urljoin(*args):
-        """Joins given arguments into a url. Trailing and leading slashes are stripped for each argument.
-
-        :param args: Multiple parts of a URL to be combined into one string.
-        :type args: str
-        :return: Full URL combining all provided arguments
-        :rtype: str
-        """
-
-        return '/'.join(map(lambda x: str(x).strip('/'), args))
-
-    @abstractmethod
-    def close(self):
-        raise NotImplemented
-
-    @abstractmethod
-    def get(self, url, **kwargs):
-        raise NotImplemented
-
-    @abstractmethod
-    def post(self, url, **kwargs):
-        raise NotImplemented
-
-    @abstractmethod
-    def put(self, url, **kwargs):
-        raise NotImplemented
-
-    @abstractmethod
-    def delete(self, url, **kwargs):
-        raise NotImplemented
-
-    @abstractmethod
-    def request(self, method, url, headers=None, **kwargs):
-        raise NotImplemented
-
-
-class Request(Adapter):
-    """The Request adapter class"""
-
-    def __init__(self, base_uri='http://localhost:8200', token=None, cert=None, verify=True, timeout=30, proxies=None,
+    def __init__(self, base_uri=DEFAULT_BASE_URI, token=None, cert=None, verify=True, timeout=30, proxies=None,
                  allow_redirects=True, session=None):
         """Create a new request adapter instance.
 
@@ -96,17 +58,24 @@ class Request(Adapter):
             'proxies': proxies,
         }
 
-    def close(self):
-        """Close the underlying Requests session.
+    @staticmethod
+    def urljoin(*args):
+        """Joins given arguments into a url. Trailing and leading slashes are stripped for each argument.
+
+        :param args: Multiple parts of a URL to be combined into one string.
+        :type args: basestring
+        :return: Full URL combining all provided arguments
+        :rtype: basestring
         """
-        self.session.close()
+
+        return '/'.join(map(lambda x: str(x).strip('/'), args))
 
     def get(self, url, **kwargs):
         """Performs a GET request.
 
         :param url: Partial URL path to send the request to. This will be joined to the end of the instance's base_uri
             attribute.
-        :type url: str
+        :type url: basestring
         :param kwargs: Additional keyword arguments to include in the requests call.
         :type kwargs: dict
         :return: The response of the request.
@@ -119,7 +88,7 @@ class Request(Adapter):
 
         :param url: Partial URL path to send the request to. This will be joined to the end of the instance's base_uri
             attribute.
-        :type url: str
+        :type url: basestring
         :param kwargs: Additional keyword arguments to include in the requests call.
         :type kwargs: dict
         :return: The response of the request.
@@ -132,7 +101,7 @@ class Request(Adapter):
 
         :param url: Partial URL path to send the request to. This will be joined to the end of the instance's base_uri
             attribute.
-        :type url: str
+        :type url: basestring
         :param kwargs: Additional keyword arguments to include in the requests call.
         :type kwargs: dict
         :return: The response of the request.
@@ -140,18 +109,31 @@ class Request(Adapter):
         """
         return self.request('put', url, **kwargs)
 
+    def close(self):
+        """Close the underlying Requests session.
+        """
+        self.session.close()
+
     def delete(self, url, **kwargs):
         """Performs a DELETE request.
 
         :param url: Partial URL path to send the request to. This will be joined to the end of the instance's base_uri
             attribute.
-        :type url: str
+        :type url: basestring
         :param kwargs: Additional keyword arguments to include in the requests call.
         :type kwargs: dict
         :return: The response of the request.
         :rtype: requests.Response
         """
         return self.request('delete', url, **kwargs)
+
+    @abstractmethod
+    def request(self, method, url, headers=None, **kwargs):
+        raise NotImplemented
+
+
+class Request(Adapter):
+    """The Request adapter class"""
 
     def request(self, method, url, headers=None, **kwargs):
         """
@@ -160,7 +142,7 @@ class Request(Adapter):
         :type method: str
         :param url: Partial URL path to send the request to. This will be joined to the end of the instance's base_uri
             attribute.
-        :type url: str
+        :type url: basestring
         :param headers: Additional headers to include with the request.
         :type headers: dict
         :param kwargs: Additional keyword arguments to include in the requests call.

--- a/hvac/adapters.py
+++ b/hvac/adapters.py
@@ -127,6 +127,28 @@ class Adapter(object):
         """
         return self.request('delete', url, **kwargs)
 
+    def auth(self, url, use_token=True, **kwargs):
+        """Performs a request (typically to a path prefixed with "/v1/auth") and optionaly stores the client token sent
+            in the resulting Vault response for use by the :py:meth:`hvac.adapters.Adapter` instance under the _adapater
+            Client attribute.
+
+        :param url: Path to send the authentication request to.
+        :type url: basestring
+        :param use_token: if True, uses the token in the response received from the auth request to set the "token"
+            attribute on the the :py:meth:`hvac.adapters.Adapter` instance under the _adapater Client attribute.
+        :type use_token: bool
+        :param kwargs: Additional keyword arguments to include in the params sent with the request.
+        :type kwargs: dict
+        :return: The response of the auth request.
+        :rtype: requests.Response
+        """
+        response = self.post(url, **kwargs).json()
+
+        if use_token:
+            self.token = response['auth']['client_token']
+
+        return response
+
     @abstractmethod
     def request(self, method, url, headers=None, **kwargs):
         raise NotImplemented

--- a/hvac/adapters.py
+++ b/hvac/adapters.py
@@ -63,9 +63,9 @@ class Adapter(object):
         """Joins given arguments into a url. Trailing and leading slashes are stripped for each argument.
 
         :param args: Multiple parts of a URL to be combined into one string.
-        :type args: basestring
+        :type args: str | unicode
         :return: Full URL combining all provided arguments
-        :rtype: basestring
+        :rtype: str | unicode
         """
 
         return '/'.join(map(lambda x: str(x).strip('/'), args))
@@ -80,7 +80,7 @@ class Adapter(object):
 
         :param url: Partial URL path to send the request to. This will be joined to the end of the instance's base_uri
             attribute.
-        :type url: basestring
+        :type url: str | unicode
         :param kwargs: Additional keyword arguments to include in the requests call.
         :type kwargs: dict
         :return: The response of the request.
@@ -93,7 +93,7 @@ class Adapter(object):
 
         :param url: Partial URL path to send the request to. This will be joined to the end of the instance's base_uri
             attribute.
-        :type url: basestring
+        :type url: str | unicode
         :param kwargs: Additional keyword arguments to include in the requests call.
         :type kwargs: dict
         :return: The response of the request.
@@ -106,7 +106,7 @@ class Adapter(object):
 
         :param url: Partial URL path to send the request to. This will be joined to the end of the instance's base_uri
             attribute.
-        :type url: basestring
+        :type url: str | unicode
         :param kwargs: Additional keyword arguments to include in the requests call.
         :type kwargs: dict
         :return: The response of the request.
@@ -119,7 +119,7 @@ class Adapter(object):
 
         :param url: Partial URL path to send the request to. This will be joined to the end of the instance's base_uri
             attribute.
-        :type url: basestring
+        :type url: str | unicode
         :param kwargs: Additional keyword arguments to include in the requests call.
         :type kwargs: dict
         :return: The response of the request.
@@ -133,7 +133,7 @@ class Adapter(object):
             Client attribute.
 
         :param url: Path to send the authentication request to.
-        :type url: basestring
+        :type url: str | unicode
         :param use_token: if True, uses the token in the response received from the auth request to set the "token"
             attribute on the the :py:meth:`hvac.adapters.Adapter` instance under the _adapater Client attribute.
         :type use_token: bool
@@ -157,7 +157,7 @@ class Adapter(object):
         :type method: str
         :param url: Partial URL path to send the request to. This will be joined to the end of the instance's base_uri
             attribute.
-        :type url: basestring
+        :type url: str | unicode
         :param headers: Additional headers to include with the request.
         :type headers: dict
         :param kwargs: Additional keyword arguments to include in the requests call.
@@ -178,7 +178,7 @@ class Request(Adapter):
         :type method: str
         :param url: Partial URL path to send the request to. This will be joined to the end of the instance's base_uri
             attribute.
-        :type url: basestring
+        :type url: str | unicode
         :param headers: Additional headers to include with the request.
         :type headers: dict
         :param kwargs: Additional keyword arguments to include in the requests call.

--- a/hvac/adapters.py
+++ b/hvac/adapters.py
@@ -165,7 +165,7 @@ class Adapter(object):
         :return: The response of the request.
         :rtype: requests.Response
         """
-        raise NotImplemented
+        raise NotImplementedError
 
 
 class Request(Adapter):

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -1707,7 +1707,7 @@ class Client(object):
             Client attribute.
 
         :param url: Path to send the authentication request to.
-        :type url: basestring
+        :type url: str | unicode
         :param use_token: if True, uses the token in the response received from the auth request to set the "token"
             attribute on the the :py:meth:`hvac.adapters.Adapter` instance under the _adapater Client attribute.
         :type use_token: bool

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -1702,23 +1702,25 @@ class Client(object):
         return self.auth('/v1/sys/wrapping/unwrap')
 
     def auth(self, url, use_token=True, **kwargs):
+        """Performs a request (typically to a path prefixed with "/v1/auth") and optionaly stores the client token sent
+            in the resulting Vault response for use by the :py:meth:`hvac.adapters.Adapter` instance under the _adapater
+            Client attribute.
+
+        :param url: Path to send the authentication request to.
+        :type url: basestring
+        :param use_token: if True, uses the token in the response received from the auth request to set the "token"
+            attribute on the the :py:meth:`hvac.adapters.Adapter` instance under the _adapater Client attribute.
+        :type use_token: bool
+        :param kwargs: Additional keyword arguments to include in the params sent with the request.
+        :type kwargs: dict
+        :return: The response of the auth request.
+        :rtype: requests.Response
         """
-
-        :param url:
-        :type url:
-        :param use_token:
-        :type use_token:
-        :param kwargs:
-        :type kwargs:
-        :return:
-        :rtype:
-        """
-        response = self._adapter.post(url, **kwargs).json()
-
-        if use_token:
-            self.token = response['auth']['client_token']
-
-        return response
+        return self._adapter.auth(
+            url=url,
+            use_token=use_token,
+            **kwargs
+        )
 
     def list_auth_backends(self):
         """GET /sys/auth


### PR DESCRIPTION
This PR intends to migrate the logic of the `Client.auth()` method into the Adapter class. This help facilitate moving auth methods (e.g., `Client.auth_aws_iam()` / `Client.auth_ec2()`) into separate classes in the future. In particular, I'm planning on breaking out aws auth method and secret backend methods into something like a `hvac.api.AWS` class in the future.

I also took this opportunity to move the logic of some of the more basic helper methods (`post()`, `get()`, etc.) into the abstract `Adapter` base class. Feels more logical to have those basic sort of methods in the base class since subclasses can still choose to override them or not as needed. Along those lines, I also moved the `Request` constructor method into the base class following the same reasoning.