### PR TITLE
Simplify deprecated_method a bit

### DIFF
--- a/hvac/utils.py
+++ b/hvac/utils.py
@@ -3,6 +3,7 @@ Misc utility functions and constants
 """
 
 import functools
+import inspect
 import warnings
 from textwrap import dedent
 
@@ -44,14 +45,12 @@ def raise_for_error(status_code, message=None, errors=None):
         raise exceptions.UnexpectedError(message)
 
 
-def deprecated_method(to_be_removed_in_version, new_call_path=None, new_method=None):
+def deprecated_method(to_be_removed_in_version, new_method=None):
     """This is a decorator which can be used to mark methods as deprecated. It will result in a warning being emitted
     when the function is used.
 
     :param to_be_removed_in_version: Version of this module the decorated method will be removed in.
     :type to_be_removed_in_version: str
-    :param new_call_path: Example call to replace deprecated usage.
-    :type new_call_path: str
     :param new_method: Method intended to replace the decorated method. This method's docstrings are included in the
         decorated method's docstring.
     :type new_method: function
@@ -63,8 +62,11 @@ def deprecated_method(to_be_removed_in_version, new_call_path=None, new_method=N
             old_func=method.__name__,
             version=to_be_removed_in_version,
         )
-        if new_call_path:
-            message += " Please use `{}` moving forward.".format(new_call_path)
+        if new_method:
+            message += " Please use the '{method_name}' method on the '{module_name}' class moving forward.".format(
+                method_name=new_method.__name__,
+                module_name=inspect.getmodule(new_method).__name__
+            )
 
         @functools.wraps(method)
         def new_func(*args, **kwargs):

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -2638,35 +2638,59 @@ class Client(object):
 
         return self._adapter.post(url, json=params).json()
 
-    @utils.deprecated_method(to_be_removed_in_version='0.8.0', new_call_path='_adapter.close', new_method=adapters.Request.close)
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.8.0',
+        new_method=adapters.Request.close,
+    )
     def close(self):
         return self._adapter.close()
 
-    @utils.deprecated_method(to_be_removed_in_version='0.8.0', new_call_path='_adapter.get', new_method=adapters.Request.get)
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.8.0',
+        new_method=adapters.Request.get,
+    )
     def _get(self, *args, **kwargs):
         return self._adapter.get(*args, **kwargs)
 
-    @utils.deprecated_method(to_be_removed_in_version='0.8.0', new_call_path='_adapter.post', new_method=adapters.Request.post)
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.8.0',
+        new_method=adapters.Request.post,
+    )
     def _post(self, *args, **kwargs):
         return self._adapter.post(*args, **kwargs)
 
-    @utils.deprecated_method(to_be_removed_in_version='0.8.0', new_call_path='_adapter.put', new_method=adapters.Request.put)
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.8.0',
+        new_method=adapters.Request.put,
+    )
     def _put(self, *args, **kwargs):
         return self._adapter.put(*args, **kwargs)
 
-    @utils.deprecated_method(to_be_removed_in_version='0.8.0', new_call_path='_adapter.delete', new_method=adapters.Request.delete)
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.8.0',
+        new_method=adapters.Request.delete,
+    )
     def _delete(self, *args, **kwargs):
         return self._adapter.delete(*args, **kwargs)
 
     @staticmethod
-    @utils.deprecated_method(to_be_removed_in_version='0.8.0', new_call_path='_adapter.urljoin', new_method=adapters.Request.urljoin)
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.8.0',
+        new_method=adapters.Request.urljoin,
+    )
     def urljoin(*args):
         return adapters.Request.urljoin(*args)
 
-    @utils.deprecated_method(to_be_removed_in_version='0.8.0', new_call_path='_adapter.request', new_method=adapters.Request.request)
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.8.0',
+        new_method=adapters.Request.request,
+    )
     def __request(self, *args, **kwargs):
         return self._adapter.request(*args, **kwargs)
 
-    @utils.deprecated_method(to_be_removed_in_version='0.8.0', new_call_path='hvac.utils.raise_for_error', new_method=utils.raise_for_error)
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.8.0',
+        new_method=utils.raise_for_error,
+    )
     def __raise_error(self, *args, **kwargs):
         utils.raise_for_error(*args, **kwargs)


### PR DESCRIPTION
When expanding the use of this `deprecated_method` decorator with some local changes, I realized its arguments were a bit verbose. This update removes one of the arguments without significantly changing its functionality. I.e., we still get the part of the deprecation warning message to point users to the new method's location *and* automatically pull in the new method's docstrings in for the older method being marked for deprecation.

Before/after examples:

```
# Before
In [1]: import hvac

In [2]: hvac.Client().close()
/usr/local/bin/ipython:1: DeprecationWarning: Call to deprecated function 'close'. This method will be removed in version '0.8.0' Please use `_adapter.close` moving forward.
  #!/usr/local/opt/python@2/bin/python2.7

In [3]: hvac.Client().close.__doc__
Out[3]: "Call to deprecated function 'close'. This method will be removed in version '0.8.0' Please use `_adapter.close` moving forward.\nDocstring content from this method's replacement copied below:\nClose the underlying Requests session.\n\n"

# After
In [1]: import hvac

In [2]: hvac.Client().close()
/usr/local/bin/ipython:1: DeprecationWarning: Call to deprecated function 'close'. This method will be removed in version '0.8.0' Please use the 'close' method on the 'hvac.adapters' class moving forward.
  #!/usr/local/opt/python@2/bin/python2.7

In [3]: hvac.Client().close.__doc__
Out[3]: "Call to deprecated function 'close'. This method will be removed in version '0.8.0' Please use the 'close' method on the 'hvac.adapters' class moving forward.\nDocstring content from this method's replacement copied below:\nClose the underlying Requests session.\n\n"
```