### PR TITLE
Add list method to Adapter Class

### DIFF
--- a/hvac/adapters.py
+++ b/hvac/adapters.py
@@ -127,6 +127,19 @@ class Adapter(object):
         """
         return self.request('delete', url, **kwargs)
 
+    def list(self, url, **kwargs):
+        """Performs a LIST request.
+
+        :param url: Partial URL path to send the request to. This will be joined to the end of the instance's base_uri
+            attribute.
+        :type url: str | unicode
+        :param kwargs: Additional keyword arguments to include in the requests call.
+        :type kwargs: dict
+        :return: The response of the request.
+        :rtype: requests.Response
+        """
+        return self.request('list', url, **kwargs)
+
     def auth(self, url, use_token=True, **kwargs):
         """Performs a request (typically to a path prefixed with "/v1/auth") and optionaly stores the client token sent
             in the resulting Vault response for use by the :py:meth:`hvac.adapters.Adapter` instance under the _adapater

--- a/hvac/tests/test_adapters.py
+++ b/hvac/tests/test_adapters.py
@@ -14,7 +14,7 @@ class TestRequest(TestCase):
         ("Vault address with route", 'https://example.com/vault'),
     ])
     @requests_mock.Mocker()
-    def test___request(self, test_label, test_url, requests_mocker):
+    def test_get(self, test_label, test_url, requests_mocker):
         test_path = 'v1/sys/health'
         expected_status_code = 200
         mock_url = '{0}/{1}'.format(test_url, test_path)

--- a/hvac/tests/test_adapters.py
+++ b/hvac/tests/test_adapters.py
@@ -26,7 +26,7 @@ class TestRequest(TestCase):
         response = adapter.get(
             url='v1/sys/health',
         )
-        self.assertEquals(
+        self.assertEqual(
             first=expected_status_code,
             second=response.status_code,
         )

--- a/hvac/tests/test_adapters.py
+++ b/hvac/tests/test_adapters.py
@@ -30,3 +30,40 @@ class TestRequest(TestCase):
             first=expected_status_code,
             second=response.status_code,
         )
+
+    @parameterized.expand([
+        ("kv secret lookup", 'v1/secret/some-secret'),
+    ])
+    @requests_mock.Mocker()
+    def test_list(self, test_label, test_path, requests_mocker):
+        mock_response = {
+            'auth': None,
+            'data': {
+                'keys': ['things1', 'things2']
+            },
+            'lease_duration': 0,
+            'lease_id': '',
+            'renewable': False,
+            'request_id': 'ba933afe-84d4-410f-161b-592a5c016009',
+            'warnings': None,
+            'wrap_info': None
+        }
+        expected_status_code = 200
+        mock_url = '{0}/{1}'.format(adapters.DEFAULT_BASE_URI, test_path)
+        requests_mocker.register_uri(
+            method='LIST',
+            url=mock_url,
+            json=mock_response
+        )
+        adapter = adapters.Request()
+        response = adapter.list(
+            url=test_path,
+        )
+        self.assertEqual(
+            first=expected_status_code,
+            second=response.status_code,
+        )
+        self.assertEqual(
+            first=mock_response,
+            second=response.json()
+        )


### PR DESCRIPTION
Adding another small wrapper for performing LIST requests. This will be used by classes I intend to add around kv methods in particular.

FWIW: there is already a `list()` method in the Client class. However it has some extra logic that I'm not sure will be applicable more generally. As we start migrating Client's methods to other classes as part of reducing its overall footprint, we can revisit `Client.list()` and take action if needed then.