### PR TITLE
Send token as a param, to avoid token been logged by the audit log

### DIFF
--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -946,10 +946,10 @@ class Client(object):
         """
         params = {
             'increment': increment,
-            'token': token,
         }
 
-        if token:
+        if token is not None:
+            params['token'] = token
             return self._adapter.post('/v1/auth/token/renew', json=params, wrap_ttl=wrap_ttl).json()
         else:
             return self._adapter.post('/v1/auth/token/renew-self', json=params, wrap_ttl=wrap_ttl).json()

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -931,7 +931,7 @@ class Client(object):
         self._adapter.post('/v1/auth/token/revoke-prefix/{0}'.format(prefix))
 
     def renew_token(self, token=None, increment=None, wrap_ttl=None):
-        """POST /auth/token/renew/<token>
+        """POST /auth/token/renew
 
         POST /auth/token/renew-self
 
@@ -946,11 +946,11 @@ class Client(object):
         """
         params = {
             'increment': increment,
+            'token': token,
         }
 
         if token:
-            path = '/v1/auth/token/renew/{0}'.format(token)
-            return self._adapter.post(path, json=params, wrap_ttl=wrap_ttl).json()
+            return self._adapter.post('/v1/auth/token/renew', json=params, wrap_ttl=wrap_ttl).json()
         else:
             return self._adapter.post('/v1/auth/token/renew-self', json=params, wrap_ttl=wrap_ttl).json()
 


### PR DESCRIPTION
Token should be sent as a parameter in a POST request to the renew endpoint. This will avoid token getting logged in an audit logs, it will also comply with current vault API policy (a warning is produced when token is sent as a URL parameter).

` Using a token in the path is unsafe as the token can be logged in many places. Please use POST or PUT with the token passed in via the "token" parameter.`