### PR TITLE
Fix policy rules fetching from json

### DIFF
--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -685,7 +685,11 @@ class Client(object):
         :rtype:
         """
         try:
-            policy = self._adapter.get('/v1/sys/policy/{0}'.format(name)).json()['rules']
+            data = self._get('/v1/sys/policy/{0}'.format(name)).json()
+            if data.get('rules'):
+                policy = data.get('rules')
+            else:
+                policy = data['data'].get('rules')
             if parse:
                 if not has_hcl_parser:
                     raise ImportError('pyhcl is required for policy parsing')


### PR DESCRIPTION
Since a few version of Hashicorp Vault, the policy rules are returned inside a `data` object in the json.
This PR add a test if rules is present at the root of the json. Else it fetch rules from the `data.rules`.

Related issue : https://github.com/TerryHowe/ansible-modules-hashivault/issues/81
