### PR TITLE
New kv classes v2

### DIFF
--- a/docs/usage/secrets_engines/index.rst
+++ b/docs/usage/secrets_engines/index.rst
@@ -4,4 +4,6 @@ Secrets Engines
 .. toctree::
    :maxdepth: 2
 
+   kv
    kv_v1
+   kv_v2

--- a/docs/usage/secrets_engines/kv.rst
+++ b/docs/usage/secrets_engines/kv.rst
@@ -1,0 +1,42 @@
+KV - Wrapper
+============
+
+The :py:class:`hvac.api.secrets_engines.Kv` instance under the :py:attr:`Client class's kv attribute<hvac.v1.Client.kv>` is a wrapper to expose either version 1 (:py:class:`KvV1<hvac.api.secrets_engines.KvV1>`) or version 2 of the key/value secrets engines' API methods (:py:class:`KvV2<hvac.api.secrets_engines.KvV2>`). At present, this class defaults to version 2 when accessing methods on the instance.
+
+
+
+Setting the Default KV Version
+------------------------------
+
+:py:meth:`hvac.api.secrets_engines.KvV1.read_secret`
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    client.kv.default_kv_version = 1
+    client.kv.read_secret(path='hvac')  # => calls hvac.api.secrets_engines.KvV1.read_secret
+
+Explicitly Calling a KV Version Method
+--------------------------------------
+
+:py:meth:`hvac.api.secrets_engines.KvV1.list_secrets`
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    client.kv.v1.read_secret(path='hvac')
+    client.kv.v2.read_secret_version(path='hvac')
+
+
+Specific KV Version Usage
+-------------------------
+
+.. toctree::
+   :maxdepth: 2
+
+   kv_v1
+   kv_v2

--- a/docs/usage/secrets_engines/kv_v2.rst
+++ b/docs/usage/secrets_engines/kv_v2.rst
@@ -1,0 +1,320 @@
+KV - Version 2
+==============
+
+.. note::
+    Every method under the :py:attr:`Kv class's v2 attribute<hvac.api.secrets_engines.Kv>` includes a `mount_point` parameter that can be used to address the KvV2 secret engine under a custom mount path. E.g., If enabling the KvV2 secret engine using Vault's CLI commands via `vault secrets enable -path=my-kvv2 -version=2 kv`", the `mount_point` parameter in :py:meth:`hvac.api.secrets_engines.KvV2` methods would be set to "my-kvv2".
+
+Configuration
+-------------
+
+:py:meth:`hvac.api.secrets_engines.KvV2.configure`
+
+Setting the default `max_versions` for a key/value engine version 2 under a path of `kv`:
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    client.kv.v2.configure(
+        max_versions=20,
+        mount_point='kv',
+    )
+
+Setting the default `cas_required` (check-and-set required) flag under the implicit default path of `secret`:
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    client.kv.v2.configure(
+        cas_required=True,
+    )
+
+Read Configuration
+------------------
+
+:py:meth:`hvac.api.secrets_engines.KvV2.configure`
+
+Reading the configuration of a KV version 2 engine mounted under a path of `kv`:
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    kv_configuration = client.kv.v2.read_configuration(
+        mount_point='kv',
+    )
+    print('Config under path "kv": max_versions set to "{max_ver}"'.format(
+        max_ver=kv_configuration['data']['max_versions'],
+    ))
+    print('Config under path "kv": check-and-set require flag set to {cas}'.format(
+        cas=kv_configuration['data']['cas_required'],
+    ))
+
+
+Read Secret Versions
+--------------------
+
+:py:meth:`hvac.api.secrets_engines.KvV2.read_secret_version`
+
+Read the latest version of a given secret/path ("hvac"):
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    secret_version_response = client.kv.v2.read_secret_version(
+        path='hvac',
+    )
+    print('Latest version of secret under path "hvac" contains the following keys: {data}.format(
+        data=secret_version_response['data']['data'].keys(),
+    ))
+    print('Latest version of secret under path "hvac" created at: {date}.format(
+        date=secret_version_response['data']['metadata']['created_time'],
+    ))
+    print('Latest version of secret under path "hvac" is version #{ver}.format(
+        ver=secret_version_response['data']['metadata']['version'],
+    ))
+
+
+Read specific version (1) of a given secret/path ("hvac"):
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    secret_version_response = client.kv.v2.read_secret_version(
+        path='hvac',
+        version=1,
+    )
+    print('Version 1 of secret under path "hvac" contains the following keys: {data}.format(
+        data=secret_version_response['data']['data'].keys(),
+    ))
+    print('Version 1 of secret under path "hvac" created at: {date}.format(
+        date=secret_version_response['data']['metadata']['created_time'],
+    ))
+
+
+
+Create/Update Secret
+--------------------
+
+:py:meth:`hvac.api.secrets_engines.KvV2.create_or_update_secret`
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    client.kv.v2.create_or_update_secret(
+        path='hvac',
+        secret=dict(pssst='this is secret'),
+    )
+
+`cas` parameter with an argument that doesn't match the current version:
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    # Assuming a current version of "6" for the path "hvac" =>
+    client.kv.v2.create_or_update_secret(
+        path='hvac',
+        secret=dict(pssst='this is secret'),
+        cas=5,
+    )  # Raises hvac.exceptions.InvalidRequest
+
+`cas` parameter set to `0` will only succeed if the path hasn't already been written.
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    client.kv.v2.create_or_update_secret(
+        path='hvac',
+        secret=dict(pssst='this is secret #1'),
+        cas=0,
+    )
+
+    client.kv.v2.create_or_update_secret(
+        path='hvac',
+        secret=dict(pssst='this is secret #2'),
+        cas=0,
+    )  # => Raises hvac.exceptions.InvalidRequest
+
+
+Delete Latest Version of Secret
+-------------------------------
+
+:py:meth:`hvac.api.secrets_engines.KvV2.delete_latest_version_of_secret`
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    client.kv.v2.delete_latest_version_of_secret(
+        path=hvac,
+    )
+
+Delete Secret Versions
+----------------------
+
+:py:meth:`hvac.api.secrets_engines.KvV2.delete_secret_versions`
+
+Marking the first 3 versions of a secret deleted under path "hvac":
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    client.kv.v2.delete_secret_versions(
+        path='hvac',
+        versions=[1, 2, 3],
+    )
+
+Undelete Secret Versions
+------------------------
+
+:py:meth:`hvac.api.secrets_engines.KvV2.undelete_secret_versions`
+
+Marking the last 3 versions of a secret deleted under path "hvac" as "undeleted":
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    hvac_path_metadata = client.kv.v2.read_secret_metadata(
+        path='hvac',
+    )
+
+    oldest_version = hvac_path_metadata['data']['oldest_version']
+    current_version = hvac_path_metadata['data']['current_version']
+    versions_to_undelete = range(max(oldest_version, current_version - 2), current_version + 1)
+
+    client.kv.v2.undelete_secret_versions(
+        path='hvac',
+        versions=versions_to_undelete,
+    )
+
+Destroy Secret Versions
+-----------------------
+
+:py:meth:`hvac.api.secrets_engines.KvV2.destroy_secret_versions`
+
+Destroying the first three versions of a secret under path 'hvac':
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    client.kv.v2.destroy_secret_versions(
+        path='hvac',
+        versions=[1, 2, 3],
+    )
+
+List Secrets
+------------
+
+:py:meth:`hvac.api.secrets_engines.KvV2.list_secrets`
+
+Listing secrets under the 'hvac' path prefix:
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    client.kv.v2.create_or_update_secret(
+        path='hvac/big-ole-secret',
+        secret=dict(pssst='this is a large secret'),
+    )
+
+    client.kv.v2.create_or_update_secret(
+        path='hvac/lil-secret',
+        secret=dict(pssst='this secret... not so big'),
+    )
+
+    list_response = client.kv.v2.list_secrets(
+        path='hvac',
+    )
+
+    print('The following paths are available under "hvac" prefix: {keys}'.format(
+        keys=','.join(list_response['data']['keys']),
+    ))
+
+
+Read Secret Metadata
+--------------------
+
+:py:meth:`hvac.api.secrets_engines.KvV2.read_secret_metadata`
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    hvac_path_metadata = client.kv.v2.read_secret_metadata(
+        path='hvac',
+    )
+
+    print('Secret under path hvac is on version {cur_ver}, with an oldest version of {old_ver}'.format(
+        cur_ver=hvac_path_metadata['data']['oldest_version'],
+        old_ver=hvac_path_metadata['data']['current_version'],
+    ))
+
+Update Metadata
+---------------
+
+:py:meth:`hvac.api.secrets_engines.KvV2.update_metadata`
+
+Set max versions for a given path ("hvac") to 3:
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    client.kv.v2.update_metadata(
+        path='hvac',
+        max_versions=3,
+    )
+
+Set cas (check-and-set) parameter as required for a given path ("hvac"):
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    client.kv.v2.update_metadata(
+        path='hvac',
+        cas_required=True,
+    )
+
+
+Delete Metadata and All Versions
+--------------------------------
+
+:py:meth:`hvac.api.secrets_engines.KvV2.delete_metadata_and_all_versions`
+
+Delete all versions and metadata for a given path:
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    client.kv.v2.delete_metadata_and_all_versions(
+        path='hvac',
+    )

--- a/hvac/api/secrets_engines/__init__.py
+++ b/hvac/api/secrets_engines/__init__.py
@@ -4,8 +4,10 @@ Vault secrets engines endpoints
 """
 from hvac.api.secrets_engines.kv import Kv
 from hvac.api.secrets_engines.kv_v1 import KvV1
+from hvac.api.secrets_engines.kv_v2 import KvV2
 
 __all__ = (
     'Kv',
     'KvV1',
+    'KvV2',
 )

--- a/hvac/api/secrets_engines/kv.py
+++ b/hvac/api/secrets_engines/kv.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from hvac.api.secrets_engines import kv_v1
+from hvac.api.secrets_engines import kv_v1, kv_v2
 from hvac.api.vault_api_base import VaultApiBase
 
 logger = logging.getLogger(__name__)
@@ -13,9 +13,9 @@ class Kv(VaultApiBase):
     Reference: https://www.vaultproject.io/docs/secrets/kv/index.html
 
     """
-    allowed_kv_versions = ['1']
+    allowed_kv_versions = ['1', '2']
 
-    def __init__(self, adapter, default_kv_version='1'):
+    def __init__(self, adapter, default_kv_version='2'):
         """Create a new Kv instnace.
 
         :param adapter: Instance of :py:class:`hvac.adapters.Adapter`; used for performing HTTP requests.
@@ -28,6 +28,7 @@ class Kv(VaultApiBase):
         self._default_kv_version = default_kv_version
 
         self._kv_v1 = kv_v1.KvV1(adapter=self._adapter)
+        self._kv_v2 = kv_v2.KvV2(adapter=self._adapter)
 
     @property
     def v1(self):
@@ -40,7 +41,12 @@ class Kv(VaultApiBase):
 
     @property
     def v2(self):
-        raise NotImplementedError
+        """Accessor for kv version 2 class / method. Provided via the :py:class:`hvac.api.secrets_engines.kv_v2.KvV2` class.
+
+        :return: This Kv instance's associated KvV2 instance.
+        :rtype: hvac.api.secrets_engines.kv_v2.KvV2
+        """
+        return self._kv_v2
 
     @property
     def default_kv_version(self):
@@ -66,5 +72,7 @@ class Kv(VaultApiBase):
         """
         if self.default_kv_version == '1':
             return getattr(self._kv_v1, item)
+        elif self.default_kv_version == '2':
+            return getattr(self._kv_v2, item)
 
         raise AttributeError

--- a/hvac/api/secrets_engines/kv_v1.py
+++ b/hvac/api/secrets_engines/kv_v1.py
@@ -22,7 +22,7 @@ class KvV1(VaultApiBase):
 
         :param path: Specifies the path of the secret to read. This is specified as part of the URL.
         :type path: str | unicode
-        :param mount_point: The "path" the method/backend was mounted on.
+        :param mount_point: The "path" the secret engine was mounted on.
         :type mount_point: str | unicode
         :return: The JSON response of the read_secret request.
         :rtype: dict
@@ -46,7 +46,7 @@ class KvV1(VaultApiBase):
         :param path: Specifies the path of the secrets to list.
             This is specified as part of the URL.
         :type path: str | unicode
-        :param mount_point: The "path" the method/backend was mounted on.
+        :param mount_point: The "path" the secret engine was mounted on.
         :type mount_point: str | unicode
         :return: The JSON response of the list_secrets request.
         :rtype: dict
@@ -77,7 +77,7 @@ class KvV1(VaultApiBase):
             kv secret engine. If no argument is provided for this parameter, hvac attempts to intelligently determine
             which method is appropriate.
         :type method: str | unicode
-        :param mount_point: The "path" the method/backend was mounted on.
+        :param mount_point: The "path" the secret engine was mounted on.
         :type mount_point: str | unicode
         :return: The response of the create_or_update_secret request.
         :rtype: requests.Response
@@ -122,7 +122,7 @@ class KvV1(VaultApiBase):
         :param path: Specifies the path of the secret to delete.
             This is specified as part of the URL.
         :type path: str | unicode
-        :param mount_point: The "path" the method/backend was mounted on.
+        :param mount_point: The "path" the secret engine was mounted on.
         :type mount_point: str | unicode
         :return: The response of the delete_secret request.
         :rtype: requests.Response

--- a/hvac/api/secrets_engines/kv_v2.py
+++ b/hvac/api/secrets_engines/kv_v2.py
@@ -13,7 +13,7 @@ class KvV2(VaultApiBase):
     Reference: https://www.vaultproject.io/api/secret/kv/kv-v2.html
     """
 
-    def configure(self, max_versions=10, cas_required=False, mount_point=DEFAULT_MOUNT_POINT):
+    def configure(self, max_versions=10, cas_required=None, mount_point=DEFAULT_MOUNT_POINT):
         """Configure backend level settings that are applied to every key in the key-value store.
 
         Supported methods:
@@ -33,8 +33,9 @@ class KvV2(VaultApiBase):
         """
         params = {
             'max_versions': max_versions,
-            'cas_required': cas_required,
         }
+        if cas_required is not None:
+            params['cas_required'] = cas_required
         api_path = '/v1/{mount_point}/config'.format(mount_point=mount_point)
         return self._adapter.post(
             url=api_path,

--- a/hvac/api/secrets_engines/kv_v2.py
+++ b/hvac/api/secrets_engines/kv_v2.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""KvV2 methods module."""
+from hvac import exceptions
+from hvac.api.vault_api_base import VaultApiBase
+
+DEFAULT_MOUNT_POINT = 'secret'
+
+
+class KvV2(VaultApiBase):
+    """KV Secrets Engine - Version 2 (API).
+
+    Reference: https://www.vaultproject.io/api/secret/kv/kv-v2.html
+    """
+
+    def configure(self, max_versions=10, cas_required=False, mount_point=DEFAULT_MOUNT_POINT):
+        """Configure backend level settings that are applied to every key in the key-value store.
+
+        Supported methods:
+            POST: /{mount_point}/config. Produces: 204 (empty body)
+
+
+        :param max_versions: The number of versions to keep per key. This value applies to all keys, but a key's
+            metadata setting can overwrite this value. Once a key has more than the configured allowed versions the
+            oldest version will be permanently deleted. Defaults to 10.
+        :type max_versions: int
+        :param cas_required: If true all keys will require the cas parameter to be set on all write requests.
+        :type cas_required: bool
+        :param mount_point: The "path" the secret engine was mounted on.
+        :type mount_point: str | unicode
+        :return: The response of the configure request.
+        :rtype: requests.Response
+        """
+        params = {
+            'max_versions': max_versions,
+            'cas_required': cas_required,
+        }
+        api_path = '/v1/{mount_point}/config'.format(mount_point=mount_point)
+        return self._adapter.post(
+            url=api_path,
+            json=params,
+        )
+
+    def read_configuration(self, mount_point=DEFAULT_MOUNT_POINT):
+        """Read the KV Version 2 configuration.
+
+        Supported methods:
+            GET: /auth/{mount_point}/config. Produces: 200 application/json
+
+
+        :param mount_point: The "path" the secret engine was mounted on.
+        :type mount_point: str | unicode
+        :return: The JSON response of the read_configuration request.
+        :rtype: dict
+        """
+        api_path = '/v1/{mount_point}/config'.format(
+            mount_point=mount_point,
+        )
+        response = self._adapter.get(url=api_path)
+        return response.json()
+
+    def read_secret_version(self, path, version=None, mount_point=DEFAULT_MOUNT_POINT):
+        """Retrieve the secret at the specified location.
+
+        Supported methods:
+            GET: /{mount_point}/data/{path}. Produces: 200 application/json
+
+
+        :param path: Specifies the path of the secret to read. This is specified as part of the URL.
+        :type path: str | unicode
+        :param version: Specifies the version to return. If not set the latest version is returned.
+        :type version: int
+        :param mount_point: The "path" the secret engine was mounted on.
+        :type mount_point: str | unicode
+        :return: The JSON response of the read_secret_version request.
+        :rtype: dict
+        """
+        params = {}
+        if version is not None:
+            params['version'] = version
+        api_path = '/v1/{mount_point}/data/{path}'.format(mount_point=mount_point, path=path)
+        response = self._adapter.get(
+            url=api_path,
+            params=params,
+        )
+        return response.json()
+
+    def create_or_update_secret(self, path, secret, cas=None, mount_point=DEFAULT_MOUNT_POINT):
+        """Create a new version of a secret at the specified location.
+
+        If the value does not yet exist, the calling token must have an ACL policy granting the create capability. If
+        the value already exists, the calling token must have an ACL policy granting the update capability.
+
+        Supported methods:
+            POST: /{mount_point}/data/{path}. Produces: 200 application/json
+
+        :param path: Path
+        :type path: str | unicode
+        :param cas: Set the "cas" value to use a Check-And-Set operation. If not set the write will be allowed. If set
+            to 0 a write will only be allowed if the key doesn't exist. If the index is non-zero the write will only be
+            allowed if the key's current version matches the version specified in the cas parameter.
+        :type cas: int
+        :param secret: The contents of the "secret" dict will be stored and returned on read.
+        :type secret: dict
+        :param mount_point: The "path" the secret engine was mounted on.
+        :type mount_point: str | unicode
+        :return: The JSON response of the create_or_update_secret request.
+        :rtype: dict
+        """
+        params = {
+            'options': {},
+            'data': secret,
+        }
+
+        if cas is not None:
+            params['options']['cas'] = cas
+
+        api_path = '/v1/{mount_point}/data/{path}'.format(mount_point=mount_point, path=path)
+        response = self._adapter.post(
+            url=api_path,
+            json=params,
+        )
+        return response.json()
+
+    def delete_latest_version_of_secret(self, path, mount_point=DEFAULT_MOUNT_POINT):
+        """Issue a soft delete of the secret's latest version at the specified location.
+
+        This marks the version as deleted and will stop it from being returned from reads, but the underlying data will
+        not be removed. A delete can be undone using the undelete path.
+
+        Supported methods:
+            DELETE: /{mount_point}/data/{path}. Produces: 204 (empty body)
+
+
+        :param path: Specifies the path of the secret to delete. This is specified as part of the URL.
+        :type path: str | unicode
+        :param mount_point: The "path" the secret engine was mounted on.
+        :type mount_point: str | unicode
+        :return: The response of the delete_latest_version_of_secret request.
+        :rtype: requests.Response
+        """
+        api_path = '/v1/{mount_point}/data/{path}'.format(mount_point=mount_point, path=path)
+        return self._adapter.delete(
+            url=api_path,
+        )
+
+    def delete_secret_versions(self, path, versions, mount_point=DEFAULT_MOUNT_POINT):
+        """Issue a soft delete of the specified versions of the secret.
+
+        This marks the versions as deleted and will stop them from being returned from reads,
+        but the underlying data will not be removed. A delete can be undone using the
+        undelete path.
+
+        Supported methods:
+            POST: /{mount_point}/delete/{path}. Produces: 204 (empty body)
+
+
+        :param path: Specifies the path of the secret to delete. This is specified as part of the URL.
+        :type path: str | unicode
+        :param versions: The versions to be deleted. The versioned data will not be deleted, but it will no longer be
+            returned in normal get requests.
+        :type versions: int
+        :param mount_point: The "path" the secret engine was mounted on.
+        :type mount_point: str | unicode
+        :return: The response of the delete_secret_versions request.
+        :rtype: requests.Response
+        """
+        if not isinstance(versions, list) or len(versions) == 0:
+            error_msg = 'argument to "versions" must be a list containing one or more integers, "{versions}" provided.'.format(
+                versions=versions
+            )
+            raise exceptions.ParamValidationError(error_msg)
+        params = {
+            'versions': versions,
+        }
+        api_path = '/v1/{mount_point}/delete/{path}'.format(mount_point=mount_point, path=path)
+        return self._adapter.post(
+            url=api_path,
+            json=params,
+        )
+
+    def undelete_secret_versions(self, path, versions, mount_point=DEFAULT_MOUNT_POINT):
+        """Undelete the data for the provided version and path in the key-value store.
+
+        This restores the data, allowing it to be returned on get requests.
+
+        Supported methods:
+            POST: /{mount_point}/undelete/{path}. Produces: 204 (empty body)
+
+
+        :param path: Specifies the path of the secret to undelete. This is specified as part of the URL.
+        :type path: str | unicode
+        :param versions: The versions to undelete. The versions will be restored and their data will be returned on
+            normal get requests.
+        :type versions: list of int
+        :param mount_point: The "path" the secret engine was mounted on.
+        :type mount_point: str | unicode
+        :return: The response of the undelete_secret_versions request.
+        :rtype: requests.Response
+        """
+        if not isinstance(versions, list) or len(versions) == 0:
+            error_msg = 'argument to "versions" must be a list containing one or more integers, "{versions}" provided.'.format(
+                versions=versions
+            )
+            raise exceptions.ParamValidationError(error_msg)
+        params = {
+            'versions': versions,
+        }
+        api_path = '/v1/{mount_point}/undelete/{path}'.format(mount_point=mount_point, path=path)
+        return self._adapter.post(
+            url=api_path,
+            json=params,
+        )
+
+    def destroy_secret_versions(self, path, versions, mount_point=DEFAULT_MOUNT_POINT):
+        """Permanently remove the specified version data and numbers for the provided path from the key-value store.
+
+        Supported methods:
+            POST: /{mount_point}/destroy/{path}. Produces: 204 (empty body)
+
+
+        :param path: Specifies the path of the secret to destroy.
+            This is specified as part of the URL.
+        :type path: str | unicode
+        :param versions: The versions to destroy. Their data will be
+            permanently deleted.
+        :type versions: list of int
+        :param mount_point: The "path" the secret engine was mounted on.
+        :type mount_point: str | unicode
+        :return: The response of the destroy_secret_versions request.
+        :rtype: requests.Response
+        """
+        if not isinstance(versions, list) or len(versions) == 0:
+            error_msg = 'argument to "versions" must be a list containing one or more integers, "{versions}" provided.'.format(
+                versions=versions
+            )
+            raise exceptions.ParamValidationError(error_msg)
+        params = {
+            'versions': versions,
+        }
+        api_path = '/v1/{mount_point}/destroy/{path}'.format(mount_point=mount_point, path=path)
+        return self._adapter.post(
+            url=api_path,
+            json=params,
+        )
+
+    def list_secrets(self, path, mount_point=DEFAULT_MOUNT_POINT):
+        """Return a list of key names at the specified location.
+
+        Folders are suffixed with /. The input must be a folder; list on a file will not return a value. Note that no
+        policy-based filtering is performed on keys; do not encode sensitive information in key names. The values
+        themselves are not accessible via this command.
+
+        Supported methods:
+            LIST: /{mount_point}/metadata/{path}. Produces: 200 application/json
+
+
+        :param path: Specifies the path of the secrets to list. This is specified as part of the URL.
+        :type path: str | unicode
+        :param mount_point: The "path" the secret engine was mounted on.
+        :type mount_point: str | unicode
+        :return: The JSON response of the list_secrets request.
+        :rtype: dict
+        """
+        api_path = '/v1/{mount_point}/metadata/{path}'.format(mount_point=mount_point, path=path)
+        response = self._adapter.list(
+            url=api_path,
+        )
+        return response.json()
+
+    def read_secret_metadata(self, path, mount_point=DEFAULT_MOUNT_POINT):
+        """Retrieve the metadata and versions for the secret at the specified path.
+
+        Supported methods:
+            GET: /{mount_point}/metadata/{path}. Produces: 200 application/json
+
+
+        :param path: Specifies the path of the secret to read. This is specified as part of the URL.
+        :type path: str | unicode
+        :param mount_point: The "path" the secret engine was mounted on.
+        :type mount_point: str | unicode
+        :return: The JSON response of the read_secret_metadata request.
+        :rtype: dict
+        """
+        api_path = '/v1/{mount_point}/metadata/{path}'.format(mount_point=mount_point, path=path)
+        response = self._adapter.get(
+            url=api_path,
+        )
+        return response.json()
+
+    def update_metadata(self, path, max_versions=None, cas_required=None, mount_point=DEFAULT_MOUNT_POINT):
+        """Updates the max_versions of cas_required setting on an existing path.
+
+        Supported methods:
+            POST: /{mount_point}/metadata/{path}. Produces: 204 (empty body)
+
+
+        :param path: Path
+        :type path: str | unicode
+        :param max_versions: The number of versions to keep per key. If not set, the backend's configured max version is
+            used. Once a key has more than the configured allowed versions the oldest version will be permanently
+            deleted.
+        :type max_versions: int
+        :param cas_required: If true the key will require the cas parameter to be set on all write requests. If false,
+            the backend's configuration will be used.
+        :type cas_required: bool
+        :param mount_point: The "path" the secret engine was mounted on.
+        :type mount_point: str | unicode
+        :return: The response of the update_metadata request.
+        :rtype: requests.Response
+        """
+        params = {}
+        if max_versions is not None:
+            params['max_versions'] = max_versions
+        if cas_required is not None:
+            if not isinstance(cas_required, bool):
+                error_msg = 'bool expected for cas_required param, {type} received'.format(type=type(cas_required))
+                raise exceptions.ParamValidationError(error_msg)
+            params['cas_required'] = cas_required
+        api_path = '/v1/{mount_point}/metadata/{path}'.format(mount_point=mount_point, path=path)
+        return self._adapter.post(
+            url=api_path,
+            json=params,
+        )
+
+    def delete_metadata_and_all_versions(self, path, mount_point=DEFAULT_MOUNT_POINT):
+        """Delete (permanently) the key metadata and all version data for the specified key.
+
+        All version history will be removed.
+
+        Supported methods:
+            DELETE: /{mount_point}/metadata/{path}. Produces: 204 (empty body)
+
+
+        :param path: Specifies the path of the secret to delete. This is specified as part of the URL.
+        :type path: str | unicode
+        :param mount_point: The "path" the secret engine was mounted on.
+        :type mount_point: str | unicode
+        :return: The response of the delete_metadata_and_all_versions request.
+        :rtype: requests.Response
+        """
+        api_path = '/v1/{mount_point}/metadata/{path}'.format(mount_point=mount_point, path=path)
+        return self._adapter.delete(
+            url=api_path,
+        )

--- a/hvac/api/secrets_engines/kv_v2.py
+++ b/hvac/api/secrets_engines/kv_v2.py
@@ -28,7 +28,7 @@ class KvV2(VaultApiBase):
         :type cas_required: bool
         :param mount_point: The "path" the secret engine was mounted on.
         :type mount_point: str | unicode
-        :return: The response of the configure request.
+        :return: The response of the request.
         :rtype: requests.Response
         """
         params = {
@@ -51,7 +51,7 @@ class KvV2(VaultApiBase):
 
         :param mount_point: The "path" the secret engine was mounted on.
         :type mount_point: str | unicode
-        :return: The JSON response of the read_configuration request.
+        :return: The JSON response of the request.
         :rtype: dict
         """
         api_path = '/v1/{mount_point}/config'.format(
@@ -73,7 +73,7 @@ class KvV2(VaultApiBase):
         :type version: int
         :param mount_point: The "path" the secret engine was mounted on.
         :type mount_point: str | unicode
-        :return: The JSON response of the read_secret_version request.
+        :return: The JSON response of the request.
         :rtype: dict
         """
         params = {}
@@ -105,7 +105,7 @@ class KvV2(VaultApiBase):
         :type secret: dict
         :param mount_point: The "path" the secret engine was mounted on.
         :type mount_point: str | unicode
-        :return: The JSON response of the create_or_update_secret request.
+        :return: The JSON response of the request.
         :rtype: dict
         """
         params = {
@@ -137,7 +137,7 @@ class KvV2(VaultApiBase):
         :type path: str | unicode
         :param mount_point: The "path" the secret engine was mounted on.
         :type mount_point: str | unicode
-        :return: The response of the delete_latest_version_of_secret request.
+        :return: The response of the request.
         :rtype: requests.Response
         """
         api_path = '/v1/{mount_point}/data/{path}'.format(mount_point=mount_point, path=path)
@@ -163,7 +163,7 @@ class KvV2(VaultApiBase):
         :type versions: int
         :param mount_point: The "path" the secret engine was mounted on.
         :type mount_point: str | unicode
-        :return: The response of the delete_secret_versions request.
+        :return: The response of the request.
         :rtype: requests.Response
         """
         if not isinstance(versions, list) or len(versions) == 0:
@@ -196,7 +196,7 @@ class KvV2(VaultApiBase):
         :type versions: list of int
         :param mount_point: The "path" the secret engine was mounted on.
         :type mount_point: str | unicode
-        :return: The response of the undelete_secret_versions request.
+        :return: The response of the request.
         :rtype: requests.Response
         """
         if not isinstance(versions, list) or len(versions) == 0:
@@ -228,7 +228,7 @@ class KvV2(VaultApiBase):
         :type versions: list of int
         :param mount_point: The "path" the secret engine was mounted on.
         :type mount_point: str | unicode
-        :return: The response of the destroy_secret_versions request.
+        :return: The response of the request.
         :rtype: requests.Response
         """
         if not isinstance(versions, list) or len(versions) == 0:
@@ -260,7 +260,7 @@ class KvV2(VaultApiBase):
         :type path: str | unicode
         :param mount_point: The "path" the secret engine was mounted on.
         :type mount_point: str | unicode
-        :return: The JSON response of the list_secrets request.
+        :return: The JSON response of the request.
         :rtype: dict
         """
         api_path = '/v1/{mount_point}/metadata/{path}'.format(mount_point=mount_point, path=path)
@@ -280,7 +280,7 @@ class KvV2(VaultApiBase):
         :type path: str | unicode
         :param mount_point: The "path" the secret engine was mounted on.
         :type mount_point: str | unicode
-        :return: The JSON response of the read_secret_metadata request.
+        :return: The JSON response of the request.
         :rtype: dict
         """
         api_path = '/v1/{mount_point}/metadata/{path}'.format(mount_point=mount_point, path=path)
@@ -307,7 +307,7 @@ class KvV2(VaultApiBase):
         :type cas_required: bool
         :param mount_point: The "path" the secret engine was mounted on.
         :type mount_point: str | unicode
-        :return: The response of the update_metadata request.
+        :return: The response of the request.
         :rtype: requests.Response
         """
         params = {}
@@ -337,7 +337,7 @@ class KvV2(VaultApiBase):
         :type path: str | unicode
         :param mount_point: The "path" the secret engine was mounted on.
         :type mount_point: str | unicode
-        :return: The response of the delete_metadata_and_all_versions request.
+        :return: The response of the request.
         :rtype: requests.Response
         """
         api_path = '/v1/{mount_point}/metadata/{path}'.format(mount_point=mount_point, path=path)

--- a/hvac/tests/integration_tests/api/secrets_engines/test_kv_v2.py
+++ b/hvac/tests/integration_tests/api/secrets_engines/test_kv_v2.py
@@ -31,26 +31,28 @@ class TestKvV2(utils.HvacIntegrationTestCase, TestCase):
         super(TestKvV2, cls).tearDownClass()
 
     @parameterized.expand([
-        ('default parameters',),
-        ('custom max versions', 1),
-        ('custom cas required', 10, True),
+        ('no parameters',),
+        ('set max versions', 1),
+        ('set cas required', 10, True),
+        ('set max versions and cas required', 17, True),
     ])
-    def test_configure_and_read_configuration(self, test_label, max_versions=10, cas_required=False, mount_point=DEFAULT_MOUNT_POINT):
-        self.client.kv.v2.configure(
-            max_versions=max_versions,
-            cas_required=cas_required,
-            mount_point=mount_point,
-        )
+    def test_configure_and_read_configuration(self, test_label, max_versions=10, cas_required=None):
+        configure_arguments = dict(mount_point=self.DEFAULT_MOUNT_POINT)
+        if max_versions is not None:
+            configure_arguments['max_versions'] = max_versions
+        if cas_required is not None:
+            configure_arguments['cas_required'] = cas_required
+        self.client.kv.v2.configure(**configure_arguments)
         read_configuration_response = self.client.kv.v2.read_configuration(
-            mount_point=mount_point,
+            mount_point=self.DEFAULT_MOUNT_POINT,
         )
-        logging.debug(read_configuration_response)
+        logging.debug('read_configuration_response: %s' % read_configuration_response)
         self.assertEqual(
             first=max_versions,
             second=read_configuration_response['data']['max_versions'],
         )
         self.assertEqual(
-            first=cas_required,
+            first=cas_required or False,
             second=read_configuration_response['data']['cas_required'],
         )
 

--- a/hvac/tests/integration_tests/api/secrets_engines/test_kv_v2.py
+++ b/hvac/tests/integration_tests/api/secrets_engines/test_kv_v2.py
@@ -10,10 +10,6 @@ from hvac.tests import utils
 class TestKvV2(utils.HvacIntegrationTestCase, TestCase):
     DEFAULT_MOUNT_POINT = 'kvv2'
 
-    @classmethod
-    def setUpClass(cls):
-        super(TestKvV2, cls).setUpClass()
-
     def setUp(self):
         super(TestKvV2, self).setUp()
         self.client.enable_secret_backend(
@@ -25,10 +21,6 @@ class TestKvV2(utils.HvacIntegrationTestCase, TestCase):
     def tearDown(self):
         self.client.disable_secret_backend(mount_point=self.DEFAULT_MOUNT_POINT)
         super(TestKvV2, self).tearDown()
-
-    @classmethod
-    def tearDownClass(cls):
-        super(TestKvV2, cls).tearDownClass()
 
     @parameterized.expand([
         ('no parameters',),

--- a/hvac/tests/integration_tests/api/secrets_engines/test_kv_v2.py
+++ b/hvac/tests/integration_tests/api/secrets_engines/test_kv_v2.py
@@ -97,8 +97,8 @@ class TestKvV2(utils.HvacIntegrationTestCase, TestCase):
         ('create secret with cas of 0', 'hvac', 0, False),
         ('update secret', 'hvac', None),
         ('update secret with valid cas of 1', 'hvac', 1, True),
-        ('update secret with invalid cas', 'hvac', -1, True, exceptions.InvalidRequest, 'check-and-set parameter did not match the current version'),
-        ('update with cas of 0 after path already written', 'hvac', 0, True, exceptions.InvalidRequest, 'check-and-set parameter did not match the current version'),
+        ('update secret with invalid cas', 'hvac', -1, True, exceptions.InvalidRequest, 'did not match the current version'),
+        ('update with cas of 0 after path already written', 'hvac', 0, True, exceptions.InvalidRequest, 'did not match the current version'),
     ])
     def test_create_or_update_secret(self, test_label, path, cas=None, write_secret_before_test=True, raises=None, exception_message=''):
         test_secret = {

--- a/hvac/tests/integration_tests/api/secrets_engines/test_kv_v2.py
+++ b/hvac/tests/integration_tests/api/secrets_engines/test_kv_v2.py
@@ -1,0 +1,518 @@
+import logging
+from unittest import TestCase
+
+from parameterized import parameterized
+
+from hvac import exceptions
+from hvac.tests import utils
+
+
+class TestKvV2(utils.HvacIntegrationTestCase, TestCase):
+    DEFAULT_MOUNT_POINT = 'kvv2'
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestKvV2, cls).setUpClass()
+
+    def setUp(self):
+        super(TestKvV2, self).setUp()
+        self.client.enable_secret_backend(
+            backend_type='kv',
+            mount_point=self.DEFAULT_MOUNT_POINT,
+            options=dict(version=2),
+        )
+
+    def tearDown(self):
+        self.client.disable_secret_backend(mount_point=self.DEFAULT_MOUNT_POINT)
+        super(TestKvV2, self).tearDown()
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TestKvV2, cls).tearDownClass()
+
+    @parameterized.expand([
+        ('default parameters',),
+        ('custom max versions', 1),
+        ('custom cas required', 10, True),
+    ])
+    def test_configure_and_read_configuration(self, test_label, max_versions=10, cas_required=False, mount_point=DEFAULT_MOUNT_POINT):
+        self.client.kv.v2.configure(
+            max_versions=max_versions,
+            cas_required=cas_required,
+            mount_point=mount_point,
+        )
+        read_configuration_response = self.client.kv.v2.read_configuration(
+            mount_point=mount_point,
+        )
+        logging.debug(read_configuration_response)
+        self.assertEqual(
+            first=max_versions,
+            second=read_configuration_response['data']['max_versions'],
+        )
+        self.assertEqual(
+            first=cas_required,
+            second=read_configuration_response['data']['cas_required'],
+        )
+
+    @parameterized.expand([
+        ('nonexistent secret', 'no-secret-here', None, False, exceptions.InvalidPath),
+        ('read secret version 2 back', 'top-secret', 2, 2),
+        ('read secret version 1 back', 'top-secret', 1, 5),
+        ('read current secret version', 'top-secret', None, 10),
+        ('read current secret version', 'top-secret', None, 15),
+    ])
+    def test_read_secret_version(self, test_label, path, version=None, write_secret_before_test=True, raises=None):
+        if write_secret_before_test:
+            for num in range(1, write_secret_before_test + 1):
+                test_secret = {
+                    'pssst': num,
+                }
+                self.client.kv.v2.create_or_update_secret(
+                    path=path,
+                    secret=test_secret,
+                    mount_point=self.DEFAULT_MOUNT_POINT
+                )
+        if raises:
+            with self.assertRaises(raises):
+                self.client.kv.v2.read_secret_version(
+                    path=path,
+                    version=version,
+                    mount_point=self.DEFAULT_MOUNT_POINT,
+                )
+        else:
+            read_secret_result = self.client.kv.v2.read_secret_version(
+                path=path,
+                version=version,
+                mount_point=self.DEFAULT_MOUNT_POINT,
+            )
+            logging.debug('read_secret_result: %s' % read_secret_result)
+            expected_version = version or write_secret_before_test
+            self.assertDictEqual(
+                d1=dict(pssst=expected_version),
+                d2=read_secret_result['data']['data'],
+            )
+
+    @parameterized.expand([
+        ('create secret', 'hvac', None, False),
+        ('create secret with cas of 0', 'hvac', 0, False),
+        ('update secret', 'hvac', None),
+        ('update secret with valid cas of 1', 'hvac', 1, True),
+        ('update secret with invalid cas', 'hvac', -1, True, exceptions.InvalidRequest, 'check-and-set parameter did not match the current version'),
+        ('update with cas of 0 after path already written', 'hvac', 0, True, exceptions.InvalidRequest, 'check-and-set parameter did not match the current version'),
+    ])
+    def test_create_or_update_secret(self, test_label, path, cas=None, write_secret_before_test=True, raises=None, exception_message=''):
+        test_secret = {
+            'pssst': 'hi',
+        }
+
+        if write_secret_before_test:
+            self.client.kv.v2.create_or_update_secret(
+                path=path,
+                secret=test_secret,
+                mount_point=self.DEFAULT_MOUNT_POINT,
+            )
+        if raises:
+            with self.assertRaises(raises) as cm:
+                self.client.kv.v2.create_or_update_secret(
+                    path=path,
+                    secret=test_secret,
+                    cas=cas,
+                    mount_point=self.DEFAULT_MOUNT_POINT,
+                )
+            self.assertIn(
+                member=exception_message,
+                container=str(cm.exception),
+            )
+        else:
+            create_or_update_secret_result = self.client.kv.v2.create_or_update_secret(
+                path=path,
+                secret=test_secret,
+                cas=cas,
+                mount_point=self.DEFAULT_MOUNT_POINT,
+            )
+            expected_version = 2 if write_secret_before_test else 1
+            logging.debug('create_or_update_secret_result: %s' % create_or_update_secret_result)
+            self.assertEqual(
+                first=expected_version,
+                second=create_or_update_secret_result['data']['version'],
+            )
+
+    @parameterized.expand([
+        ('successful delete one version written', 'hvac'),
+        ('successful delete two versions written', 'hvac', 2),
+        ('successful delete three versions written', 'hvac', 3),
+        ('nonexistent path', 'no-secret-here', 0, exceptions.InvalidPath),
+    ])
+    def test_delete_latest_version_of_secret(self, test_label, path, write_secret_before_test=1, raises=None, exception_message=''):
+        if write_secret_before_test:
+            for num in range(1, write_secret_before_test + 1):
+                test_secret = {
+                    'pssst': num,
+                }
+                self.client.kv.v2.create_or_update_secret(
+                    path=path,
+                    secret=test_secret,
+                    mount_point=self.DEFAULT_MOUNT_POINT
+                )
+        if raises:
+            self.client.kv.v2.delete_latest_version_of_secret(
+                path=path,
+                mount_point=self.DEFAULT_MOUNT_POINT,
+            )
+            with self.assertRaises(raises) as cm:
+                self.client.kv.v2.read_secret_metadata(
+                    path=path,
+                    mount_point=self.DEFAULT_MOUNT_POINT,
+                )
+            self.assertIn(
+                member=exception_message,
+                container=str(cm.exception),
+            )
+        else:
+            delete_latest_version_of_secret_result = self.client.kv.v2.delete_latest_version_of_secret(
+                path=path,
+                mount_point=self.DEFAULT_MOUNT_POINT,
+            )
+            logging.debug('delete_latest_version_of_secret_result: %s' % delete_latest_version_of_secret_result)
+            read_secret_metadata_result = self.client.kv.v2.read_secret_metadata(
+                path=path,
+                mount_point=self.DEFAULT_MOUNT_POINT,
+            )
+            logging.debug('read_secret_metadata_result: %s' % read_secret_metadata_result)
+            self.assertNotEqual(
+                first=read_secret_metadata_result['data']['versions'][str(write_secret_before_test)]['deletion_time'],
+                second=''
+            )
+            for num in range(1, write_secret_before_test):
+                self.assertEqual(
+                    first=read_secret_metadata_result['data']['versions'][str(num)]['deletion_time'],
+                    second='',
+                )
+
+    @parameterized.expand([
+        ('successful delete one version written', 'hvac', 1, [1]),
+        ('successful delete one out of two versions written 1', 'hvac', 2, [1]),
+        ('successful delete one out of two versions written 2', 'hvac', 2, [2]),
+        ('successful delete two out of two versions written', 'hvac', 2, [1, 2]),
+        ('successful delete three out of seven versions written 135', 'hvac', 7, [1, 3, 5]),
+        ('successful delete three out of seven versions written 137', 'hvac', 7, [1, 3, 7]),
+        ('invalid versions arg none', 'boom', 0, None, exceptions.ParamValidationError),
+        ('invalid versions arg empty', 'boom', 0, [], exceptions.ParamValidationError),
+        ('invalid versions arg not a list', 'goes', 0, '1', exceptions.ParamValidationError),
+        ('nonexistent version 1', 'no-version-here', 3, [5]),
+        ('nonexistent version 2', 'no-versions-here', 3, [7, 9]),
+        ('nonexistent version 3', 'no-versions-here', 3, [7, 12]),
+    ])
+    def test_delete_secret_versions(self, test_label, path, write_secret_before_test=1, deleted_versions=None, raises=None, exception_message=''):
+
+        if write_secret_before_test:
+            for num in range(1, write_secret_before_test + 1):
+                test_secret = {
+                    'pssst': num,
+                }
+                self.client.kv.v2.create_or_update_secret(
+                    path=path,
+                    secret=test_secret,
+                    mount_point=self.DEFAULT_MOUNT_POINT
+                )
+        if raises:
+            with self.assertRaises(raises) as cm:
+                self.client.kv.v2.delete_secret_versions(
+                    path=path,
+                    versions=deleted_versions,
+                    mount_point=self.DEFAULT_MOUNT_POINT,
+                )
+            self.assertIn(
+                member=exception_message,
+                container=str(cm.exception),
+            )
+        else:
+            delete_secret_versions_result = self.client.kv.v2.delete_secret_versions(
+                path=path,
+                versions=deleted_versions,
+                mount_point=self.DEFAULT_MOUNT_POINT,
+            )
+            logging.debug('delete_secret_versions_result: %s' % delete_secret_versions_result)
+            read_secret_metadata_result = self.client.kv.v2.read_secret_metadata(
+                path=path,
+                mount_point=self.DEFAULT_MOUNT_POINT,
+            )
+            logging.debug('read_secret_metadata_result: %s' % read_secret_metadata_result)
+
+            for deleted_version in deleted_versions:
+                if str(deleted_version) in read_secret_metadata_result['data']['versions']:
+                    self.assertNotEqual(
+                        first=read_secret_metadata_result['data']['versions'][str(deleted_version)]['deletion_time'],
+                        second='',
+                        msg='Version "{num}" should be deleted but is not. Full read metadata response versions: {metadata}'.format(
+                            num=deleted_version,
+                            metadata=read_secret_metadata_result['data']['versions'],
+                        )
+                    )
+
+            for nondeleted_version in set(range(1, write_secret_before_test + 1)) - set(deleted_versions):
+                self.assertEqual(
+                    first=read_secret_metadata_result['data']['versions'][str(nondeleted_version)]['deletion_time'],
+                    second='',
+                    msg='Version "{num}" should not be deleted but is. Full read metadata response versions: {metadata}'.format(
+                        num=nondeleted_version,
+                        metadata=read_secret_metadata_result['data']['versions'],
+                    )
+                )
+
+    @parameterized.expand([
+        ('successful undelete one version written', 'hvac', 1, [1]),
+        ('successful undelete one out of two versions written 1', 'hvac', 2, [1]),
+        ('successful undelete one out of two versions written 2', 'hvac', 2, [2]),
+        ('successful undelete two out of two versions written', 'hvac', 2, [1, 2]),
+        ('successful undelete three out of seven versions written 135', 'hvac', 7, [1, 3, 5]),
+        ('successful undelete three out of seven versions written 137', 'hvac', 7, [1, 3, 7]),
+        ('invalid versions arg none', 'boom', 0, None, exceptions.ParamValidationError),
+        ('invalid versions arg empty', 'boom', 0, [], exceptions.ParamValidationError),
+        ('invalid versions arg not a list', 'goes', 1, '1', exceptions.ParamValidationError),
+        ('nonexistent version 1', 'no-version-here', 3, [5]),
+        ('nonexistent version 2', 'no-versions-here', 3, [7, 9]),
+        ('nonexistent version 3', 'no-versions-here', 3, [7, 12]),
+    ])
+    def test_undelete_secret_versions(self, test_label, path, write_secret_before_test=1, undeleted_versions=None, raises=None, exception_message=''):
+
+        if write_secret_before_test:
+            for num in range(1, write_secret_before_test + 1):
+                test_secret = {
+                    'pssst': num,
+                }
+                self.client.kv.v2.create_or_update_secret(
+                    path=path,
+                    secret=test_secret,
+                    mount_point=self.DEFAULT_MOUNT_POINT
+                )
+                self.client.kv.v2.delete_latest_version_of_secret(
+                    path=path,
+                    mount_point=self.DEFAULT_MOUNT_POINT
+                )
+        if raises:
+            with self.assertRaises(raises) as cm:
+                self.client.kv.v2.undelete_secret_versions(
+                    path=path,
+                    versions=undeleted_versions,
+                    mount_point=self.DEFAULT_MOUNT_POINT,
+                )
+            self.assertIn(
+                member=exception_message,
+                container=str(cm.exception),
+            )
+        else:
+            delete_secret_versions_result = self.client.kv.v2.undelete_secret_versions(
+                path=path,
+                versions=undeleted_versions,
+                mount_point=self.DEFAULT_MOUNT_POINT,
+            )
+            logging.debug('delete_secret_versions_result: %s' % delete_secret_versions_result)
+            read_secret_metadata_result = self.client.kv.v2.read_secret_metadata(
+                path=path,
+                mount_point=self.DEFAULT_MOUNT_POINT,
+            )
+            logging.debug('read_secret_metadata_result: %s' % read_secret_metadata_result)
+            for deleted_version in undeleted_versions:
+                if str(deleted_version) in read_secret_metadata_result['data']['versions']:
+                    self.assertEqual(
+                        first=read_secret_metadata_result['data']['versions'][str(deleted_version)]['deletion_time'],
+                        second='',
+                        msg='Version "{num}" should be undeleted but is not. Full read metadata response versions: {metadata}'.format(
+                            num=deleted_version,
+                            metadata=read_secret_metadata_result['data']['versions'],
+                        )
+                    )
+
+            for nondeleted_version in set(range(1, write_secret_before_test + 1)) - set(undeleted_versions):
+                self.assertNotEqual(
+                    first=read_secret_metadata_result['data']['versions'][str(nondeleted_version)]['deletion_time'],
+                    second='',
+                    msg='Version "{num}" should be deleted but it is not. Full read metadata response versions: {metadata}'.format(
+                        num=nondeleted_version,
+                        metadata=read_secret_metadata_result['data']['versions'],
+                    )
+                )
+
+    @parameterized.expand([
+        ('successful destroy one version written', 'hvac', 1, [1]),
+        ('successful destroy one out of two versions written 1', 'hvac', 2, [1]),
+        ('successful destroy one out of two versions written 2', 'hvac', 2, [2]),
+        ('successful destroy two out of two versions written', 'hvac', 2, [1, 2]),
+        ('successful destroy three out of seven versions written 135', 'hvac', 7, [1, 3, 5]),
+        ('successful destroy three out of seven versions written 137', 'hvac', 7, [1, 3, 7]),
+        ('invalid versions arg None', 'boom', 0, None, exceptions.ParamValidationError),
+        ('invalid versions arg empty', 'boom', 0, [], exceptions.ParamValidationError),
+        ('invalid versions arg not a list', 'goes', 0, '1', exceptions.ParamValidationError),
+        ('nonexistent version 1', 'no-version-here', 3, [5]),
+        ('nonexistent version 2', 'no-versions-here', 3, [7, 9]),
+        ('nonexistent version 3', 'no-versions-here', 3, [7, 12]),
+    ])
+    def test_destroy_secret_versions(self, test_label, path, write_secret_before_test=1, destoryed_versions=None, raises=None, exception_message=''):
+
+        if write_secret_before_test:
+            logging.error(write_secret_before_test)
+            for num in range(1, write_secret_before_test + 1):
+                test_secret = {
+                    'pssst': num,
+                }
+                self.client.kv.v2.create_or_update_secret(
+                    path=path,
+                    secret=test_secret,
+                    mount_point=self.DEFAULT_MOUNT_POINT
+                )
+        if raises:
+            with self.assertRaises(raises) as cm:
+                self.client.kv.v2.destroy_secret_versions(
+                    path=path,
+                    versions=destoryed_versions,
+                    mount_point=self.DEFAULT_MOUNT_POINT,
+                )
+            self.assertIn(
+                member=exception_message,
+                container=str(cm.exception),
+            )
+        else:
+            destroy_secret_versions_result = self.client.kv.v2.destroy_secret_versions(
+                path=path,
+                versions=destoryed_versions,
+                mount_point=self.DEFAULT_MOUNT_POINT,
+            )
+            logging.debug('destroy_secret_versions_result: %s' % destroy_secret_versions_result)
+            read_secret_metadata_result = self.client.kv.v2.read_secret_metadata(
+                path=path,
+                mount_point=self.DEFAULT_MOUNT_POINT,
+            )
+            logging.debug('read_secret_metadata_result: %s' % read_secret_metadata_result)
+            for destoryed_version in destoryed_versions:
+                if str(destoryed_version) in read_secret_metadata_result['data']['versions']:
+                    self.assertTrue(
+                        expr=read_secret_metadata_result['data']['versions'][str(destoryed_version)]['destroyed'],
+                        msg='Version "{num}" should be destoryed but is not. Full read metadata response versions: {metadata}'.format(
+                            num=destoryed_version,
+                            metadata=read_secret_metadata_result['data']['versions'],
+                        )
+                    )
+            for nondestoryed_version in set(range(1, write_secret_before_test + 1)) - set(destoryed_versions):
+                self.assertFalse(
+                    expr=read_secret_metadata_result['data']['versions'][str(nondestoryed_version)]['destroyed'],
+                    msg='Version "{num}" should not be destoryed but is. Full read metadata response versions: {metadata}'.format(
+                        num=nondestoryed_version,
+                        metadata=read_secret_metadata_result['data']['versions'],
+                    )
+                )
+
+    @parameterized.expand([
+        ('nonexistent secret', 'hvac/no-secret-here', False, exceptions.InvalidPath),
+        ('list secret', 'hvac/top-secret'),
+    ])
+    def test_list_secrets(self, test_label, path, write_secret_before_test=True, raises=None, exception_message=''):
+        test_secret = {
+            'pssst': 'hi',
+        }
+        test_path_prefix, test_key = path.split('/')[:2]
+
+        if write_secret_before_test:
+            self.client.kv.v2.create_or_update_secret(
+                path=path,
+                secret=test_secret,
+                mount_point=self.DEFAULT_MOUNT_POINT
+            )
+        if raises:
+            with self.assertRaises(raises) as cm:
+                self.client.kv.v2.list_secrets(
+                    path=test_path_prefix,
+                    mount_point=self.DEFAULT_MOUNT_POINT
+                )
+            self.assertIn(
+                member=exception_message,
+                container=str(cm.exception),
+            )
+        else:
+            list_secrets_result = self.client.kv.v2.list_secrets(
+                path=test_path_prefix,
+                mount_point=self.DEFAULT_MOUNT_POINT
+            )
+
+            logging.debug('list_secrets_result: %s' % list_secrets_result)
+            self.assertEqual(
+                first=dict(keys=[test_key]),
+                second=list_secrets_result['data'],
+            )
+
+    @parameterized.expand([
+        ('update with no params', 'hvac'),
+        ('update max versions 7', 'hvac', 7),
+        ('update max versions 0', 'hvac', 0),
+        ('update cas_required true', 'hvac', None, True),
+        ('update cas_required false', 'hvac', None, False),
+        ('update with invalid cas_required param', 'hvac', None, 'cats', True, exceptions.ParamValidationError, 'bool expected for cas_required param'),
+    ])
+    def test_update_metadata(self, test_label, path, max_versions=None, cas_required=None, write_secret_before_test=True, raises=None, exception_message=''):
+        if write_secret_before_test:
+            test_secret = {
+                'pssst': 'hi itsame hvac',
+            }
+            self.client.kv.v2.create_or_update_secret(
+                path=path,
+                secret=test_secret,
+                mount_point=self.DEFAULT_MOUNT_POINT
+            )
+        if raises:
+            with self.assertRaises(raises) as cm:
+                self.client.kv.v2.update_metadata(
+                    path=path,
+                    max_versions=max_versions,
+                    cas_required=cas_required,
+                    mount_point=self.DEFAULT_MOUNT_POINT,
+                )
+            self.assertIn(
+                member=exception_message,
+                container=str(cm.exception),
+            )
+        else:
+            update_metadata_result = self.client.kv.v2.update_metadata(
+                path=path,
+                max_versions=max_versions,
+                cas_required=cas_required,
+                mount_point=self.DEFAULT_MOUNT_POINT,
+            )
+            logging.debug('update_metadata_result: %s' % update_metadata_result)
+            read_secret_metadata_result = self.client.kv.v2.read_secret_metadata(
+                path=path,
+                mount_point=self.DEFAULT_MOUNT_POINT,
+            )
+            logging.debug('read_secret_metadata_result: %s' % read_secret_metadata_result)
+            for key, argument in dict(max_versions=max_versions, cas_required=cas_required).items():
+                if argument is not None:
+                    self.assertEqual(
+                        first=argument,
+                        second=read_secret_metadata_result['data'][key],
+                    )
+
+    @parameterized.expand([
+        ('nonexistent secret', 'hvac/no-secret-here', False),
+        ('delete extant secret metadata', 'hvac/top-secret'),
+    ])
+    def test_delete_metadata_and_all_versions(self, test_label, path, write_secret_before_test=True):
+        test_secret = {
+            'pssst': 'hi',
+        }
+
+        if write_secret_before_test:
+            self.client.kv.v2.create_or_update_secret(
+                path=path,
+                secret=test_secret,
+                mount_point=self.DEFAULT_MOUNT_POINT
+            )
+        delete_metadata_and_all_versions_result = self.client.kv.v2.delete_metadata_and_all_versions(
+            path=path,
+            mount_point=self.DEFAULT_MOUNT_POINT
+        )
+        logging.debug('delete_metadata_and_all_versions_result: %s' % delete_metadata_and_all_versions_result)
+        with self.assertRaises(exceptions.InvalidPath):
+            read_secret_metadata_result = self.client.kv.v2.read_secret_metadata(
+                path=path,
+                mount_point=self.DEFAULT_MOUNT_POINT,
+            )
+            logging.debug('read_secret_metadata_result: %s' % read_secret_metadata_result)

--- a/hvac/tests/unit_tests/api/secrets_engines/test_kv.py
+++ b/hvac/tests/unit_tests/api/secrets_engines/test_kv.py
@@ -5,6 +5,7 @@ from parameterized import parameterized
 
 from hvac.api.secrets_engines.kv import Kv
 from hvac.api.secrets_engines.kv_v1 import KvV1
+from hvac.api.secrets_engines.kv_v2 import KvV2
 from hvac.tests import utils
 
 
@@ -21,17 +22,21 @@ class TestKv(utils.HvacIntegrationTestCase, TestCase):
     def test_v2_property(self):
         mock_adapter = MagicMock()
         kv = Kv(adapter=mock_adapter)
-        with self.assertRaises(NotImplementedError):
-            assert kv.v2
+        self.assertIsInstance(
+            obj=kv.v2,
+            cls=KvV2,
+        )
 
     @parameterized.expand([
         ('v1', '1'),
-        ('v2', '2', ValueError),
+        ('v2', '2'),
+        ('v3', '3', ValueError),
         ('invalid version', '12345', ValueError),
     ])
     def test_default_kv_version_setter(self, test_label, version, raises=False):
         version_class_map = {
             '1': KvV1,
+            '2': KvV2,
         }
         mock_adapter = MagicMock()
         kv = Kv(adapter=mock_adapter)
@@ -52,6 +57,11 @@ class TestKv(utils.HvacIntegrationTestCase, TestCase):
         self.assertEqual(
             first=kv.read_secret,
             second=kv.v1.read_secret,
+        )
+        kv = Kv(adapter=mock_adapter, default_kv_version='2')
+        self.assertEqual(
+            first=kv.read_secret_version,
+            second=kv.v2.read_secret_version,
         )
 
         kv._default_kv_version = 0

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -136,7 +136,7 @@ class Client(object):
 
     @property
     def kv(self):
-        """Accessor for the Client instance's KV methods. Provided via the :py:class:`hvac.api.secrets_engines.KV` class.
+        """Accessor for the Client instance's KV methods. Provided via the :py:class:`hvac.api.secrets_engines.Kv` class.
 
         :return: This Client instance's associated Kv instance.
         :rtype: hvac.api.secrets_engines.Kv


### PR DESCRIPTION
Second bit of KV changes started with https://github.com/hvac/hvac/pull/257. Building on the changes in that PR, this changeset adds support for version 2 of the KV secret engine.