### PR TITLE
Fix GitHub map user docstrings

### DIFF
--- a/hvac/api/auth/github.py
+++ b/hvac/api/auth/github.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Github methods module."""
+from hvac import exceptions
 from hvac.api.vault_api_base import VaultApiBase
 
 DEFAULT_MOUNT_POINT = 'github'
@@ -135,8 +136,18 @@ class Github(VaultApiBase):
         :return: The response of the map_github_users request.
         :rtype: requests.Response
         """
+        # First, perform parameter validation.
         if policies is None:
             policies = []
+        if not isinstance(policies, list) or not all([isinstance(p, str) for p in policies]):
+
+            error_msg = 'unsupported policies argument provided "{arg}" ({arg_type}), required type: List[str]"'
+            raise exceptions.ParamValidationError(error_msg.format(
+                arg=policies,
+                arg_type=type(policies),
+            ))
+
+        # Then, perform request.
         params = {
             'value': ','.join(policies),
         }

--- a/hvac/api/auth/github.py
+++ b/hvac/api/auth/github.py
@@ -89,7 +89,6 @@ class Github(VaultApiBase):
         if policies is None:
             policies = []
         if not isinstance(policies, list) or not all([isinstance(p, str) for p in policies]):
-
             error_msg = 'unsupported policies argument provided "{arg}" ({arg_type}), required type: List[str]"'
             raise exceptions.ParamValidationError(error_msg.format(
                 arg=policies,
@@ -149,7 +148,6 @@ class Github(VaultApiBase):
         if policies is None:
             policies = []
         if not isinstance(policies, list) or not all([isinstance(p, str) for p in policies]):
-
             error_msg = 'unsupported policies argument provided "{arg}" ({arg_type}), required type: List[str]"'
             raise exceptions.ParamValidationError(error_msg.format(
                 arg=policies,

--- a/hvac/api/auth/github.py
+++ b/hvac/api/auth/github.py
@@ -85,8 +85,17 @@ class Github(VaultApiBase):
         :return: The response of the map_github_teams request.
         :rtype: requests.Response
         """
+        # First, perform parameter validation.
         if policies is None:
             policies = []
+        if not isinstance(policies, list) or not all([isinstance(p, str) for p in policies]):
+
+            error_msg = 'unsupported policies argument provided "{arg}" ({arg_type}), required type: List[str]"'
+            raise exceptions.ParamValidationError(error_msg.format(
+                arg=policies,
+                arg_type=type(policies),
+            ))
+        # Then, perform request.
         params = {
             'value': ','.join(policies),
         }

--- a/hvac/api/auth/github.py
+++ b/hvac/api/auth/github.py
@@ -78,7 +78,7 @@ class Github(VaultApiBase):
         :param team_name: GitHub team name in "slugified" format
         :type team_name: str | unicode
         :param policies: Comma separated list of policies to assign
-        :type policies: list
+        :type policies: List[str]
         :param mount_point: The "path" the method/backend was mounted on.
         :type mount_point: str | unicode
         :return: The response of the map_github_teams request.
@@ -129,7 +129,7 @@ class Github(VaultApiBase):
         :param user_name: GitHub user name
         :type user_name: str | unicode
         :param policies: Comma separated list of policies to assign
-        :type policies: str | unicode
+        :type policies: List[str]
         :param mount_point: The "path" the method/backend was mounted on.
         :type mount_point: str | unicode
         :return: The response of the map_github_users request.

--- a/hvac/tests/integration_tests/api/auth/test_github.py
+++ b/hvac/tests/integration_tests/api/auth/test_github.py
@@ -181,30 +181,43 @@ class TestGithub(utils.HvacIntegrationTestCase, TestCase):
     @parameterized.expand([
         ("no policies", 204, 'hvac', None),
         ("with policy", 204, 'hvac', ['default']),
+        ("with policy incorrect type", 204, 'hvac', 'default, root', exceptions.ParamValidationError, "unsupported policies argument provided"),
         ("with policies", 204, 'hvac', ['default', 'root']),
     ])
-    def test_map_user_and_read_mapping(self, test_label, expected_status_code, user_name, policies):
-        response = self.client.github.map_user(
-            user_name=user_name,
-            policies=policies,
-        )
-        self.assertEqual(
-            first=expected_status_code,
-            second=response.status_code
-        )
+    def test_map_user_and_read_mapping(self, test_label, expected_status_code, user_name, policies, raises=False, exception_msg=''):
 
-        response = self.client.github.read_user_mapping(
-            user_name=user_name,
-        )
-        if policies is None:
-            expected_policies = ''
+        if raises:
+            with self.assertRaises(raises) as cm:
+                self.client.github.map_user(
+                    user_name=user_name,
+                    policies=policies,
+                )
+            self.assertIn(
+                member=exception_msg,
+                container=str(cm.exception),
+            )
         else:
-            expected_policies = ','.join(policies)
+            response = self.client.github.map_user(
+                user_name=user_name,
+                policies=policies,
+            )
+            self.assertEqual(
+                first=expected_status_code,
+                second=response.status_code
+            )
 
-        self.assertDictEqual(
-            d1=dict(key=user_name, value=expected_policies),
-            d2=response['data'],
-        )
+            response = self.client.github.read_user_mapping(
+                user_name=user_name,
+            )
+            if policies is None:
+                expected_policies = ''
+            else:
+                expected_policies = ','.join(policies)
+
+            self.assertDictEqual(
+                d1=dict(key=user_name, value=expected_policies),
+                d2=response['data'],
+            )
 
     @parameterized.expand([
         ("valid token", 'valid-token', None, None),

--- a/hvac/tests/integration_tests/api/auth/test_github.py
+++ b/hvac/tests/integration_tests/api/auth/test_github.py
@@ -130,30 +130,43 @@ class TestGithub(utils.HvacIntegrationTestCase, TestCase):
     @parameterized.expand([
         ("no policies", 204, 'hvac', None),
         ("with policy", 204, 'hvac', ['default']),
+        ("with policy incorrect type", 204, 'hvac', 'default, root', exceptions.ParamValidationError, "unsupported policies argument provided"),
         ("with policies", 204, 'hvac', ['default', 'root']),
     ])
-    def test_map_team_and_read_mapping(self, test_label, expected_status_code, team_name, policies):
-        response = self.client.github.map_team(
-            team_name=team_name,
-            policies=policies,
-        )
-        self.assertEqual(
-            first=expected_status_code,
-            second=response.status_code
-        )
+    def test_map_team_and_read_mapping(self, test_label, expected_status_code, team_name, policies, raises=False, exception_msg=''):
 
-        response = self.client.github.read_team_mapping(
-            team_name=team_name,
-        )
-        if policies is None:
-            expected_policies = ''
+        if raises:
+            with self.assertRaises(raises) as cm:
+                self.client.github.map_team(
+                    team_name=team_name,
+                    policies=policies,
+                )
+            self.assertIn(
+                member=exception_msg,
+                container=str(cm.exception),
+            )
         else:
-            expected_policies = ','.join(policies)
+            response = self.client.github.map_team(
+                team_name=team_name,
+                policies=policies,
+            )
+            self.assertEqual(
+                first=expected_status_code,
+                second=response.status_code
+            )
 
-        self.assertDictEqual(
-            d1=dict(key=team_name, value=expected_policies),
-            d2=response['data'],
-        )
+            response = self.client.github.read_team_mapping(
+                team_name=team_name,
+            )
+            if policies is None:
+                expected_policies = ''
+            else:
+                expected_policies = ','.join(policies)
+
+            self.assertDictEqual(
+                d1=dict(key=team_name, value=expected_policies),
+                d2=response['data'],
+            )
 
     @parameterized.expand([
         ("no policies", 204, 'hvac-user', None),


### PR DESCRIPTION
(Intended to solve for https://github.com/hvac/hvac/issues/266.)

Ideally we'd take this opportunity to start using some combination of the [typing module](https://docs.python.org/3/library/typing.html) and decorators that perform type validation to reduce the amount of code being repeated. However it looks like that it is a bit tricky to get that sort of runtime type validation implemented with universal Python support (i.e., both 2.7 and 3.x versions supported). So I'm going to hold off on exploring the route until sometime down the line.

@marinthiercelin: Please let me know if this looks sufficient to address the matter you raised in #266.