### PR TITLE
Rearrange System Backend Test Cases and Ensure They're Filled Out

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,11 @@ matrix:
       env:
         - TOXENV=py27
         - VAULT_VERSION=0.10.4
+    - name: 'Python v2.7, Vault v0.11.0 - Integration/Unit Tests'
+      python: '2.7'
+      env:
+        - TOXENV=py27
+        - VAULT_VERSION=0.11.0
     - name: 'Python v2.7, Vault v0.11.1 - Integration/Unit Tests'
       python: '2.7'
       env:
@@ -47,6 +52,11 @@ matrix:
       env:
         - TOXENV=py27
         - VAULT_VERSION=0.10.4
+    - name: 'Python v3.6, Vault v0.11.0 - Integration/Unit Tests'
+      python: '3.6'
+      env:
+        - TOXENV=py27
+        - VAULT_VERSION=0.11.0
     - name: 'Python v3.6, Vault v0.11.1 - Integration/Unit Tests'
       python: '3.6'
       env:
@@ -62,11 +72,21 @@ matrix:
       env:
         - TOXENV=py27-flake8
   allow_failures:
+    - name: 'Python v2.7, Vault v0.11.0 - Integration/Unit Tests'
+      python: '2.7'
+      env:
+        - TOXENV=py27
+        - VAULT_VERSION=0.11.0
     - name: 'Python v2.7, Vault HEAD ref - Integration/Unit Tests'
       python: '2.7'
       env:
         - TOXENV=py27
         - VAULT_VERSION=HEAD
+    - name: 'Python v3.6, Vault v0.11.0 - Integration/Unit Tests'
+      python: '3.6'
+      env:
+        - TOXENV=py27
+        - VAULT_VERSION=0.11.0
     - name: 'Python v3.6, Vault HEAD ref - Integration/Unit Tests'
       python: '3.6'
       env:

--- a/hvac/tests/integration_tests/v1/test_integration.py
+++ b/hvac/tests/integration_tests/v1/test_integration.py
@@ -906,7 +906,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
         self.client.token = self.manager.root_token
         self.client.disable_auth_backend(mount_point=test_mount_point)
 
-    @skipIf(utils.skip_if_vault_version('0.10.0'), "not supported in this vault version")
+    @skipIf(utils.skip_if_vault_version('0.10.0'), "KV version 2 secret engine not available before Vault version 0.10.0")
     def test_kv2_secret_backend(self):
         if 'test/' in self.client.list_secret_backends():
             self.client.disable_secret_backend('test')

--- a/hvac/tests/integration_tests/v1/test_integration.py
+++ b/hvac/tests/integration_tests/v1/test_integration.py
@@ -1,53 +1,11 @@
-import binascii
-import sys
-from base64 import b64decode
 from unittest import TestCase
-from uuid import UUID
-
-from hvac import exceptions
 from unittest import skipIf
 
+from hvac import exceptions
 from hvac.tests import utils
 
 
 class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
-
-    def test_unseal_multi(self):
-        cls = type(self)
-
-        self.client.seal()
-
-        keys = cls.manager.keys
-
-        result = self.client.unseal_multi(keys[0:2])
-
-        assert result['sealed']
-        assert result['progress'] == 2
-
-        result = self.client.unseal_reset()
-        assert result['progress'] == 0
-        result = self.client.unseal_multi(keys[1:3])
-        assert result['sealed']
-        assert result['progress'] == 2
-        self.client.unseal_multi(keys[0:1])
-        result = self.client.unseal_multi(keys[2:3])
-        assert not result['sealed']
-
-    def test_seal_unseal(self):
-        cls = type(self)
-
-        assert not self.client.is_sealed()
-
-        self.client.seal()
-
-        assert self.client.is_sealed()
-
-        cls.manager.unseal()
-
-        assert not self.client.is_sealed()
-
-    def test_ha_status(self):
-        assert 'ha_enabled' in self.client.ha_status
 
     def test_generic_secret_backend(self):
         self.client.write('secret/foo', zap='zip')
@@ -82,99 +40,8 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
         result = self.client.write('transit/decrypt/foo', ciphertext=ciphertext)
         assert result['data']['plaintext'] == plaintext
 
-    def test_wrap_write(self):
-        if 'approle/' not in self.client.list_auth_backends():
-            self.client.enable_auth_backend("approle")
-
-        self.client.write("auth/approle/role/testrole")
-        result = self.client.write('auth/approle/role/testrole/secret-id', wrap_ttl="10s")
-        assert 'token' in result['wrap_info']
-        self.client.unwrap(result['wrap_info']['token'])
-        self.client.disable_auth_backend("approle")
-
     def test_read_nonexistent_key(self):
         assert not self.client.read('secret/I/dont/exist')
-
-    def test_auth_backend_manipulation(self):
-        assert 'github/' not in self.client.list_auth_backends()
-
-        self.client.enable_auth_backend('github')
-        assert 'github/' in self.client.list_auth_backends()
-
-        self.client.token = self.manager.root_token
-        self.client.disable_auth_backend('github')
-        assert 'github/' not in self.client.list_auth_backends()
-
-    def test_secret_backend_manipulation(self):
-        assert 'test/' not in self.client.list_secret_backends()
-
-        self.client.enable_secret_backend('generic', mount_point='test')
-        assert 'test/' in self.client.list_secret_backends()
-
-        secret_backend_tuning = self.client.get_secret_backend_tuning('generic', mount_point='test')
-        self.assertEqual(secret_backend_tuning['max_lease_ttl'], 2764800)
-        self.assertEqual(secret_backend_tuning['default_lease_ttl'], 2764800)
-
-        self.client.tune_secret_backend('generic', mount_point='test', default_lease_ttl='3600s', max_lease_ttl='8600s')
-        secret_backend_tuning = self.client.get_secret_backend_tuning('generic', mount_point='test')
-
-        assert 'max_lease_ttl' in secret_backend_tuning
-        self.assertEqual(secret_backend_tuning['max_lease_ttl'], 8600)
-        assert 'default_lease_ttl' in secret_backend_tuning
-        self.assertEqual(secret_backend_tuning['default_lease_ttl'], 3600)
-
-        self.client.remount_secret_backend('test', 'foobar')
-        assert 'test/' not in self.client.list_secret_backends()
-        assert 'foobar/' in self.client.list_secret_backends()
-
-        self.client.token = self.manager.root_token
-        self.client.disable_secret_backend('foobar')
-        assert 'foobar/' not in self.client.list_secret_backends()
-
-    def test_audit_backend_manipulation(self):
-        assert 'tmpfile/' not in self.client.list_audit_backends()
-
-        options = {
-            'path': '/tmp/vault.audit.log'
-        }
-
-        self.client.enable_audit_backend('file', options=options, name='tmpfile')
-        assert 'tmpfile/' in self.client.list_audit_backends()
-
-        self.client.token = self.manager.root_token
-        self.client.disable_audit_backend('tmpfile')
-        assert 'tmpfile/' not in self.client.list_audit_backends()
-
-    def test_policy_manipulation(self):
-        assert 'root' in self.client.list_policies()
-        assert self.client.get_policy('test') is None
-        policy, parsed_policy = self.prep_policy('test')
-        assert 'test' in self.client.list_policies()
-        assert policy == self.client.get_policy('test')
-        assert parsed_policy == self.client.get_policy('test', parse=True)
-
-        self.client.delete_policy('test')
-        assert 'test' not in self.client.list_policies()
-
-    def test_json_policy_manipulation(self):
-        assert 'root' in self.client.list_policies()
-
-        policy = {
-            "path": {
-                "sys": {
-                    "policy": "deny"
-                },
-                "secret": {
-                    "policy": "write"
-                }
-            }
-        }
-
-        self.client.set_policy('test', policy)
-        assert 'test' in self.client.list_policies()
-
-        self.client.delete_policy('test')
-        assert 'test' not in self.client.list_policies()
 
     def test_auth_token_manipulation(self):
         result = self.client.create_token(lease='1h', renewable=True)
@@ -354,21 +221,6 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
 
         self.client.token = self.manager.root_token
         self.client.disable_auth_backend('app-id')
-
-    def test_cubbyhole_auth(self):
-        orig_token = self.client.token
-
-        resp = self.client.create_token(lease='6h', wrap_ttl='1h')
-        assert resp['wrap_info']['ttl'] == 3600
-
-        wrapped_token = resp['wrap_info']['token']
-        self.client.auth_cubbyhole(wrapped_token)
-        assert self.client.token != orig_token
-        assert self.client.token != wrapped_token
-        assert self.client.is_authenticated()
-
-        self.client.token = orig_token
-        assert self.client.is_authenticated()
 
     def test_create_user_id(self):
         if 'app-id/' not in self.client.list_auth_backends():
@@ -703,34 +555,6 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
         self.client.revoke_self_token()
         assert not self.client.is_authenticated()
 
-    def test_rekey_multi(self):
-        cls = type(self)
-
-        assert not self.client.rekey_status['started']
-
-        self.client.start_rekey()
-        assert self.client.rekey_status['started']
-
-        self.client.cancel_rekey()
-        assert not self.client.rekey_status['started']
-
-        result = self.client.start_rekey()
-
-        keys = cls.manager.keys
-
-        result = self.client.rekey_multi(keys, nonce=result['nonce'])
-        assert result['complete']
-
-        cls.manager.keys = result['keys']
-        cls.manager.unseal()
-
-    def test_rotate(self):
-        status = self.client.key_status
-
-        self.client.rotate()
-
-        assert self.client.key_status['term'] > status['term']
-
     def test_tls_auth(self):
         self.client.enable_auth_backend('cert')
 
@@ -772,97 +596,6 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
         # As should regular lookup
         with self.assertRaises(exceptions.Forbidden):
             lookup = self.client.lookup_token(result['auth']['client_token'])
-
-    def test_wrapped_token_success(self):
-        wrap = self.client.create_token(wrap_ttl='1m')
-
-        # Unwrap token
-        result = self.client.unwrap(wrap['wrap_info']['token'])
-        assert result['auth']['client_token']
-
-        # Validate token
-        lookup = self.client.lookup_token(result['auth']['client_token'])
-        assert result['auth']['client_token'] == lookup['data']['id']
-
-    def test_wrapped_token_intercept(self):
-        wrap = self.client.create_token(wrap_ttl='1m')
-
-        # Intercept wrapped token
-        self.client.unwrap(wrap['wrap_info']['token'])
-
-        # Attempt to retrieve the token after it's been intercepted
-        with self.assertRaises(exceptions.InvalidRequest):
-            self.client.unwrap(wrap['wrap_info']['token'])
-
-    def test_wrapped_token_cleanup(self):
-        wrap = self.client.create_token(wrap_ttl='1m')
-
-        _token = self.client.token
-        self.client.unwrap(wrap['wrap_info']['token'])
-        assert self.client.token == _token
-
-    def test_wrapped_token_revoke(self):
-        wrap = self.client.create_token(wrap_ttl='1m')
-
-        # Revoke token before it's unwrapped
-        self.client.revoke_token(wrap['wrap_info']['wrapped_accessor'], accessor=True)
-
-        # Unwrap token anyway
-        result = self.client.unwrap(wrap['wrap_info']['token'])
-        assert result['auth']['client_token']
-
-        # Attempt to validate token
-        with self.assertRaises(exceptions.Forbidden):
-            self.client.lookup_token(result['auth']['client_token'])
-
-    def test_wrapped_client_token_success(self):
-        wrap = self.client.create_token(wrap_ttl='1m')
-        self.client.token = wrap['wrap_info']['token']
-
-        # Unwrap token
-        result = self.client.unwrap()
-        assert result['auth']['client_token']
-
-        # Validate token
-        self.client.token = result['auth']['client_token']
-        lookup = self.client.lookup_token(result['auth']['client_token'])
-        assert result['auth']['client_token'] == lookup['data']['id']
-
-    def test_wrapped_client_token_intercept(self):
-        wrap = self.client.create_token(wrap_ttl='1m')
-        self.client.token = wrap['wrap_info']['token']
-
-        # Intercept wrapped token
-        self.client.unwrap()
-
-        # Attempt to retrieve the token after it's been intercepted
-        with self.assertRaises(exceptions.InvalidRequest):
-            self.client.unwrap()
-
-    def test_wrapped_client_token_cleanup(self):
-        wrap = self.client.create_token(wrap_ttl='1m')
-
-        _token = self.client.token
-        self.client.token = wrap['wrap_info']['token']
-        self.client.unwrap()
-
-        assert self.client.token != wrap
-        assert self.client.token != _token
-
-    def test_wrapped_client_token_revoke(self):
-        wrap = self.client.create_token(wrap_ttl='1m')
-
-        # Revoke token before it's unwrapped
-        self.client.revoke_token(wrap['wrap_info']['wrapped_accessor'], accessor=True)
-
-        # Unwrap token anyway
-        self.client.token = wrap['wrap_info']['token']
-        result = self.client.unwrap()
-        assert result['auth']['client_token']
-
-        # Attempt to validate token
-        with self.assertRaises(exceptions.Forbidden):
-            self.client.lookup_token(result['auth']['client_token'])
 
     def test_create_token_explicit_max_ttl(self):
 
@@ -1089,63 +822,6 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
 
         self.client.disable_auth_backend('aws-ec2')
 
-    def test_start_generate_root_with_completion(self):
-        test_otp = 'RSMGkAqBH5WnVLrDTbZ+UQ=='
-
-        self.assertFalse(self.client.generate_root_status['started'])
-        response = self.client.start_generate_root(
-            key=test_otp,
-            otp=True,
-        )
-        self.assertTrue(self.client.generate_root_status['started'])
-
-        nonce = response['nonce']
-        for key in self.manager.keys[0:3]:
-            response = self.client.generate_root(
-                key=key,
-                nonce=nonce,
-            )
-        self.assertFalse(self.client.generate_root_status['started'])
-
-        # Decode the token provided in the last response. Root token decoding logic derived from:
-        # https://github.com/hashicorp/vault/blob/284600fbefc32d8ab71b6b9d1d226f2f83b56b1d/command/operator_generate_root.go#L289
-        b64decoded_root_token = b64decode(response['encoded_root_token'])
-        if sys.version_info > (3, 0):
-            # b64decoding + bytes XOR'ing to decode the new root token in python 3.x
-            int_encoded_token = int.from_bytes(b64decoded_root_token, sys.byteorder)
-            int_otp = int.from_bytes(b64decode(test_otp), sys.byteorder)
-            xord_otp_and_token = int_otp ^ int_encoded_token
-            token_hex_string = xord_otp_and_token.to_bytes(len(b64decoded_root_token), sys.byteorder).hex()
-        else:
-            # b64decoding + bytes XOR'ing to decode the new root token in python 2.7
-            otp_and_token = zip(b64decode(test_otp), b64decoded_root_token)
-            xord_otp_and_token = ''.join(chr(ord(y) ^ ord(x)) for (x, y) in otp_and_token)
-            token_hex_string = binascii.hexlify(xord_otp_and_token)
-
-        new_root_token = str(UUID(token_hex_string))
-
-        # Assert our new root token is properly formed and authenticated
-        self.client.token = new_root_token
-        if self.client.is_authenticated():
-            self.manager.root_token = new_root_token
-        else:
-            # If our new token was unable to authenticate, set the test client's token back to the original value
-            self.client.token = self.manager.root_token
-            self.fail('Unable to authenticate with the newly generated root token.')
-
-    def test_start_generate_root_then_cancel(self):
-        test_otp = 'RSMGkAqBH5WnVLrDTbZ+UQ=='
-
-        self.assertFalse(self.client.generate_root_status['started'])
-        self.client.start_generate_root(
-            key=test_otp,
-            otp=True,
-        )
-        self.assertTrue(self.client.generate_root_status['started'])
-
-        self.client.cancel_generate_root()
-        self.assertFalse(self.client.generate_root_status['started'])
-
     def test_auth_ec2_alternate_mount_point_with_no_client_token_exception(self):
         test_mount_point = 'aws-custom-path'
         # Turn on the aws-ec2 backend with a custom mount_point path specified.
@@ -1228,42 +904,6 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
 
         # Reset test state.
         self.client.token = self.manager.root_token
-        self.client.disable_auth_backend(mount_point=test_mount_point)
-
-    def test_tune_auth_backend(self):
-        test_backend_type = 'approle'
-        test_mount_point = 'tune-approle'
-        test_description = 'this is a test auth backend'
-        test_max_lease_ttl = 12345678
-        if '{0}/'.format(test_mount_point) in self.client.list_auth_backends():
-            self.client.disable_auth_backend(test_mount_point)
-        self.client.enable_auth_backend(
-            backend_type='approle',
-            mount_point=test_mount_point
-        )
-
-        expected_status_code = 204
-        response = self.client.tune_auth_backend(
-            backend_type=test_backend_type,
-            mount_point=test_mount_point,
-            description=test_description,
-            max_lease_ttl=test_max_lease_ttl,
-        )
-        self.assertEqual(
-            first=expected_status_code,
-            second=response.status_code,
-        )
-
-        response = self.client.get_auth_backend_tuning(
-            backend_type=test_backend_type,
-            mount_point=test_mount_point
-        )
-
-        self.assertEqual(
-            first=test_max_lease_ttl,
-            second=response['data']['max_lease_ttl']
-        )
-
         self.client.disable_auth_backend(mount_point=test_mount_point)
 
     @skipIf(utils.skip_if_vault_version('0.10.0'), "not supported in this vault version")
@@ -1525,23 +1165,3 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
 
         # Reset integration test state
         self.client.disable_auth_backend(mount_point=test_mount_point)
-
-    def test_read_lease(self):
-        # Set up a test pki backend and issue a cert against some role so we.
-        self.configure_test_pki()
-        pki_issue_response = self.client.write(
-            path='pki/issue/my-role',
-            common_name='test.hvac.com',
-        )
-
-        # Read the lease of our test cert that was just issued.
-        read_lease_response = self.client.read_lease(pki_issue_response['lease_id'])
-
-        # Validate we received the expected lease ID back in our response.
-        self.assertEquals(
-            first=pki_issue_response['lease_id'],
-            second=read_lease_response['data']['id'],
-        )
-
-        # Reset integration test state.
-        self.disable_test_pki()

--- a/hvac/tests/integration_tests/v1/test_system_backend.py
+++ b/hvac/tests/integration_tests/v1/test_system_backend.py
@@ -1,0 +1,386 @@
+import binascii
+import sys
+from base64 import b64decode
+from unittest import TestCase
+from uuid import UUID
+
+from hvac import exceptions
+from hvac.tests import utils
+
+
+class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
+
+    def test_unseal_multi(self):
+        cls = type(self)
+
+        self.client.seal()
+
+        keys = cls.manager.keys
+
+        result = self.client.unseal_multi(keys[0:2])
+
+        assert result['sealed']
+        assert result['progress'] == 2
+
+        result = self.client.unseal_reset()
+        assert result['progress'] == 0
+        result = self.client.unseal_multi(keys[1:3])
+        assert result['sealed']
+        assert result['progress'] == 2
+        self.client.unseal_multi(keys[0:1])
+        result = self.client.unseal_multi(keys[2:3])
+        assert not result['sealed']
+
+    def test_seal_unseal(self):
+        cls = type(self)
+
+        assert not self.client.is_sealed()
+
+        self.client.seal()
+
+        assert self.client.is_sealed()
+
+        cls.manager.unseal()
+
+        assert not self.client.is_sealed()
+
+    def test_ha_status(self):
+        assert 'ha_enabled' in self.client.ha_status
+
+    def test_wrap_write(self):
+        if 'approle/' not in self.client.list_auth_backends():
+            self.client.enable_auth_backend("approle")
+
+        self.client.write("auth/approle/role/testrole")
+        result = self.client.write('auth/approle/role/testrole/secret-id', wrap_ttl="10s")
+        assert 'token' in result['wrap_info']
+        self.client.unwrap(result['wrap_info']['token'])
+        self.client.disable_auth_backend("approle")
+
+    def test_auth_backend_manipulation(self):
+        assert 'github/' not in self.client.list_auth_backends()
+
+        self.client.enable_auth_backend('github')
+        assert 'github/' in self.client.list_auth_backends()
+
+        self.client.token = self.manager.root_token
+        self.client.disable_auth_backend('github')
+        assert 'github/' not in self.client.list_auth_backends()
+
+    def test_secret_backend_manipulation(self):
+        assert 'test/' not in self.client.list_secret_backends()
+
+        self.client.enable_secret_backend('generic', mount_point='test')
+        assert 'test/' in self.client.list_secret_backends()
+
+        secret_backend_tuning = self.client.get_secret_backend_tuning('generic', mount_point='test')
+        self.assertEqual(secret_backend_tuning['max_lease_ttl'], 2764800)
+        self.assertEqual(secret_backend_tuning['default_lease_ttl'], 2764800)
+
+        self.client.tune_secret_backend('generic', mount_point='test', default_lease_ttl='3600s', max_lease_ttl='8600s')
+        secret_backend_tuning = self.client.get_secret_backend_tuning('generic', mount_point='test')
+
+        assert 'max_lease_ttl' in secret_backend_tuning
+        self.assertEqual(secret_backend_tuning['max_lease_ttl'], 8600)
+        assert 'default_lease_ttl' in secret_backend_tuning
+        self.assertEqual(secret_backend_tuning['default_lease_ttl'], 3600)
+
+        self.client.remount_secret_backend('test', 'foobar')
+        assert 'test/' not in self.client.list_secret_backends()
+        assert 'foobar/' in self.client.list_secret_backends()
+
+        self.client.token = self.manager.root_token
+        self.client.disable_secret_backend('foobar')
+        assert 'foobar/' not in self.client.list_secret_backends()
+
+    def test_audit_backend_manipulation(self):
+        assert 'tmpfile/' not in self.client.list_audit_backends()
+
+        options = {
+            'path': '/tmp/vault.audit.log'
+        }
+
+        self.client.enable_audit_backend('file', options=options, name='tmpfile')
+        assert 'tmpfile/' in self.client.list_audit_backends()
+
+        self.client.token = self.manager.root_token
+        self.client.disable_audit_backend('tmpfile')
+        assert 'tmpfile/' not in self.client.list_audit_backends()
+
+    def test_policy_manipulation(self):
+        assert 'root' in self.client.list_policies()
+        assert self.client.get_policy('test') is None
+        policy, parsed_policy = self.prep_policy('test')
+        assert 'test' in self.client.list_policies()
+        assert policy == self.client.get_policy('test')
+        assert parsed_policy == self.client.get_policy('test', parse=True)
+
+        self.client.delete_policy('test')
+        assert 'test' not in self.client.list_policies()
+
+    def test_json_policy_manipulation(self):
+        assert 'root' in self.client.list_policies()
+
+        policy = {
+            "path": {
+                "sys": {
+                    "policy": "deny"
+                },
+                "secret": {
+                    "policy": "write"
+                }
+            }
+        }
+
+        self.client.set_policy('test', policy)
+        assert 'test' in self.client.list_policies()
+
+        self.client.delete_policy('test')
+        assert 'test' not in self.client.list_policies()
+
+    def test_cubbyhole_auth(self):
+        orig_token = self.client.token
+
+        resp = self.client.create_token(lease='6h', wrap_ttl='1h')
+        assert resp['wrap_info']['ttl'] == 3600
+
+        wrapped_token = resp['wrap_info']['token']
+        self.client.auth_cubbyhole(wrapped_token)
+        assert self.client.token != orig_token
+        assert self.client.token != wrapped_token
+        assert self.client.is_authenticated()
+
+        self.client.token = orig_token
+        assert self.client.is_authenticated()
+
+    def test_rekey_multi(self):
+        cls = type(self)
+
+        assert not self.client.rekey_status['started']
+
+        self.client.start_rekey()
+        assert self.client.rekey_status['started']
+
+        self.client.cancel_rekey()
+        assert not self.client.rekey_status['started']
+
+        result = self.client.start_rekey()
+
+        keys = cls.manager.keys
+
+        result = self.client.rekey_multi(keys, nonce=result['nonce'])
+        assert result['complete']
+
+        cls.manager.keys = result['keys']
+        cls.manager.unseal()
+
+    def test_rotate(self):
+        status = self.client.key_status
+
+        self.client.rotate()
+
+        assert self.client.key_status['term'] > status['term']
+
+    def test_wrapped_token_success(self):
+        wrap = self.client.create_token(wrap_ttl='1m')
+
+        # Unwrap token
+        result = self.client.unwrap(wrap['wrap_info']['token'])
+        assert result['auth']['client_token']
+
+        # Validate token
+        lookup = self.client.lookup_token(result['auth']['client_token'])
+        assert result['auth']['client_token'] == lookup['data']['id']
+
+    def test_wrapped_token_intercept(self):
+        wrap = self.client.create_token(wrap_ttl='1m')
+
+        # Intercept wrapped token
+        self.client.unwrap(wrap['wrap_info']['token'])
+
+        # Attempt to retrieve the token after it's been intercepted
+        with self.assertRaises(exceptions.InvalidRequest):
+            self.client.unwrap(wrap['wrap_info']['token'])
+
+    def test_wrapped_token_cleanup(self):
+        wrap = self.client.create_token(wrap_ttl='1m')
+
+        _token = self.client.token
+        self.client.unwrap(wrap['wrap_info']['token'])
+        assert self.client.token == _token
+
+    def test_wrapped_token_revoke(self):
+        wrap = self.client.create_token(wrap_ttl='1m')
+
+        # Revoke token before it's unwrapped
+        self.client.revoke_token(wrap['wrap_info']['wrapped_accessor'], accessor=True)
+
+        # Unwrap token anyway
+        result = self.client.unwrap(wrap['wrap_info']['token'])
+        assert result['auth']['client_token']
+
+        # Attempt to validate token
+        with self.assertRaises(exceptions.Forbidden):
+            self.client.lookup_token(result['auth']['client_token'])
+
+    def test_wrapped_client_token_success(self):
+        wrap = self.client.create_token(wrap_ttl='1m')
+        self.client.token = wrap['wrap_info']['token']
+
+        # Unwrap token
+        result = self.client.unwrap()
+        assert result['auth']['client_token']
+
+        # Validate token
+        self.client.token = result['auth']['client_token']
+        lookup = self.client.lookup_token(result['auth']['client_token'])
+        assert result['auth']['client_token'] == lookup['data']['id']
+
+    def test_wrapped_client_token_intercept(self):
+        wrap = self.client.create_token(wrap_ttl='1m')
+        self.client.token = wrap['wrap_info']['token']
+
+        # Intercept wrapped token
+        self.client.unwrap()
+
+        # Attempt to retrieve the token after it's been intercepted
+        with self.assertRaises(exceptions.InvalidRequest):
+            self.client.unwrap()
+
+    def test_wrapped_client_token_cleanup(self):
+        wrap = self.client.create_token(wrap_ttl='1m')
+
+        _token = self.client.token
+        self.client.token = wrap['wrap_info']['token']
+        self.client.unwrap()
+
+        assert self.client.token != wrap
+        assert self.client.token != _token
+
+    def test_wrapped_client_token_revoke(self):
+        wrap = self.client.create_token(wrap_ttl='1m')
+
+        # Revoke token before it's unwrapped
+        self.client.revoke_token(wrap['wrap_info']['wrapped_accessor'], accessor=True)
+
+        # Unwrap token anyway
+        self.client.token = wrap['wrap_info']['token']
+        result = self.client.unwrap()
+        assert result['auth']['client_token']
+
+        # Attempt to validate token
+        with self.assertRaises(exceptions.Forbidden):
+            self.client.lookup_token(result['auth']['client_token'])
+
+    def test_start_generate_root_with_completion(self):
+        test_otp = 'RSMGkAqBH5WnVLrDTbZ+UQ=='
+
+        self.assertFalse(self.client.generate_root_status['started'])
+        response = self.client.start_generate_root(
+            key=test_otp,
+            otp=True,
+        )
+        self.assertTrue(self.client.generate_root_status['started'])
+
+        nonce = response['nonce']
+        for key in self.manager.keys[0:3]:
+            response = self.client.generate_root(
+                key=key,
+                nonce=nonce,
+            )
+        self.assertFalse(self.client.generate_root_status['started'])
+
+        # Decode the token provided in the last response. Root token decoding logic derived from:
+        # https://github.com/hashicorp/vault/blob/284600fbefc32d8ab71b6b9d1d226f2f83b56b1d/command/operator_generate_root.go#L289
+        b64decoded_root_token = b64decode(response['encoded_root_token'])
+        if sys.version_info > (3, 0):
+            # b64decoding + bytes XOR'ing to decode the new root token in python 3.x
+            int_encoded_token = int.from_bytes(b64decoded_root_token, sys.byteorder)
+            int_otp = int.from_bytes(b64decode(test_otp), sys.byteorder)
+            xord_otp_and_token = int_otp ^ int_encoded_token
+            token_hex_string = xord_otp_and_token.to_bytes(len(b64decoded_root_token), sys.byteorder).hex()
+        else:
+            # b64decoding + bytes XOR'ing to decode the new root token in python 2.7
+            otp_and_token = zip(b64decode(test_otp), b64decoded_root_token)
+            xord_otp_and_token = ''.join(chr(ord(y) ^ ord(x)) for (x, y) in otp_and_token)
+            token_hex_string = binascii.hexlify(xord_otp_and_token)
+
+        new_root_token = str(UUID(token_hex_string))
+
+        # Assert our new root token is properly formed and authenticated
+        self.client.token = new_root_token
+        if self.client.is_authenticated():
+            self.manager.root_token = new_root_token
+        else:
+            # If our new token was unable to authenticate, set the test client's token back to the original value
+            self.client.token = self.manager.root_token
+            self.fail('Unable to authenticate with the newly generated root token.')
+
+    def test_start_generate_root_then_cancel(self):
+        test_otp = 'RSMGkAqBH5WnVLrDTbZ+UQ=='
+
+        self.assertFalse(self.client.generate_root_status['started'])
+        self.client.start_generate_root(
+            key=test_otp,
+            otp=True,
+        )
+        self.assertTrue(self.client.generate_root_status['started'])
+
+        self.client.cancel_generate_root()
+        self.assertFalse(self.client.generate_root_status['started'])
+
+    def test_tune_auth_backend(self):
+        test_backend_type = 'approle'
+        test_mount_point = 'tune-approle'
+        test_description = 'this is a test auth backend'
+        test_max_lease_ttl = 12345678
+        if '{0}/'.format(test_mount_point) in self.client.list_auth_backends():
+            self.client.disable_auth_backend(test_mount_point)
+        self.client.enable_auth_backend(
+            backend_type='approle',
+            mount_point=test_mount_point
+        )
+
+        expected_status_code = 204
+        response = self.client.tune_auth_backend(
+            backend_type=test_backend_type,
+            mount_point=test_mount_point,
+            description=test_description,
+            max_lease_ttl=test_max_lease_ttl,
+        )
+        self.assertEqual(
+            first=expected_status_code,
+            second=response.status_code,
+        )
+
+        response = self.client.get_auth_backend_tuning(
+            backend_type=test_backend_type,
+            mount_point=test_mount_point
+        )
+
+        self.assertEqual(
+            first=test_max_lease_ttl,
+            second=response['data']['max_lease_ttl']
+        )
+
+        self.client.disable_auth_backend(mount_point=test_mount_point)
+
+    def test_read_lease(self):
+        # Set up a test pki backend and issue a cert against some role so we.
+        self.configure_test_pki()
+        pki_issue_response = self.client.write(
+            path='pki/issue/my-role',
+            common_name='test.hvac.com',
+        )
+
+        # Read the lease of our test cert that was just issued.
+        read_lease_response = self.client.read_lease(pki_issue_response['lease_id'])
+
+        # Validate we received the expected lease ID back in our response.
+        self.assertEquals(
+            first=pki_issue_response['lease_id'],
+            second=read_lease_response['data']['id'],
+        )
+
+        # Reset integration test state.
+        self.disable_test_pki()

--- a/hvac/tests/integration_tests/v1/test_system_backend.py
+++ b/hvac/tests/integration_tests/v1/test_system_backend.py
@@ -19,13 +19,13 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
 
         result = self.client.unseal_multi(keys[0:2])
 
-        assert result['sealed']
+        self.assertTrue(result['sealed'])
         self.assertEqual(result['progress'], 2)
 
         result = self.client.unseal_reset()
         self.assertEqual(result['progress'], 0)
         result = self.client.unseal_multi(keys[1:3])
-        assert result['sealed']
+        self.assertTrue(result['sealed'])
         self.assertEqual(result['progress'], 2)
         self.client.unseal_multi(keys[0:1])
         result = self.client.unseal_multi(keys[2:3])
@@ -38,7 +38,7 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
 
         self.client.seal()
 
-        assert self.client.is_sealed()
+        self.assertTrue(self.client.is_sealed())
 
         cls.manager.unseal()
 
@@ -148,10 +148,10 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
         self.client.auth_cubbyhole(wrapped_token)
         assert self.client.token != orig_token
         assert self.client.token != wrapped_token
-        assert self.client.is_authenticated()
+        self.assertTrue(self.client.is_authenticated())
 
         self.client.token = orig_token
-        assert self.client.is_authenticated()
+        self.assertTrue(self.client.is_authenticated())
 
     def test_rekey_multi(self):
         cls = type(self)
@@ -159,7 +159,7 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
         assert not self.client.rekey_status['started']
 
         self.client.start_rekey()
-        assert self.client.rekey_status['started']
+        self.assertTrue(self.client.rekey_status['started'])
 
         self.client.cancel_rekey()
         assert not self.client.rekey_status['started']
@@ -169,7 +169,7 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
         keys = cls.manager.keys
 
         result = self.client.rekey_multi(keys, nonce=result['nonce'])
-        assert result['complete']
+        self.assertTrue(result['complete'])
 
         cls.manager.keys = result['keys']
         cls.manager.unseal()
@@ -186,7 +186,7 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
 
         # Unwrap token
         result = self.client.unwrap(wrap['wrap_info']['token'])
-        assert result['auth']['client_token']
+        self.assertTrue(result['auth']['client_token'])
 
         # Validate token
         lookup = self.client.lookup_token(result['auth']['client_token'])
@@ -217,7 +217,7 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
 
         # Unwrap token anyway
         result = self.client.unwrap(wrap['wrap_info']['token'])
-        assert result['auth']['client_token']
+        self.assertTrue(result['auth']['client_token'])
 
         # Attempt to validate token
         with self.assertRaises(exceptions.Forbidden):
@@ -229,7 +229,7 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
 
         # Unwrap token
         result = self.client.unwrap()
-        assert result['auth']['client_token']
+        self.assertTrue(result['auth']['client_token'])
 
         # Validate token
         self.client.token = result['auth']['client_token']
@@ -266,7 +266,7 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
         # Unwrap token anyway
         self.client.token = wrap['wrap_info']['token']
         result = self.client.unwrap()
-        assert result['auth']['client_token']
+        self.assertTrue(result['auth']['client_token'])
 
         # Attempt to validate token
         with self.assertRaises(exceptions.Forbidden):

--- a/hvac/tests/integration_tests/v1/test_system_backend.py
+++ b/hvac/tests/integration_tests/v1/test_system_backend.py
@@ -45,7 +45,7 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
         self.assertFalse(self.client.is_sealed())
 
     def test_ha_status(self):
-        assert 'ha_enabled' in self.client.ha_status
+        self.assertIn('ha_enabled', self.client.ha_status)
 
     def test_wrap_write(self):
         if 'approle/' not in self.client.list_auth_backends():
@@ -53,7 +53,7 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
 
         self.client.write("auth/approle/role/testrole")
         result = self.client.write('auth/approle/role/testrole/secret-id', wrap_ttl="10s")
-        assert 'token' in result['wrap_info']
+        self.assertIn('token', result['wrap_info'])
         self.client.unwrap(result['wrap_info']['token'])
         self.client.disable_auth_backend("approle")
 
@@ -61,7 +61,7 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
         self.assertNotIn('github/', self.client.list_auth_backends())
 
         self.client.enable_auth_backend('github')
-        assert 'github/' in self.client.list_auth_backends()
+        self.assertIn('github/', self.client.list_auth_backends())
 
         self.client.token = self.manager.root_token
         self.client.disable_auth_backend('github')
@@ -71,7 +71,7 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
         self.assertNotIn('test/', self.client.list_secret_backends())
 
         self.client.enable_secret_backend('generic', mount_point='test')
-        assert 'test/' in self.client.list_secret_backends()
+        self.assertIn('test/', self.client.list_secret_backends())
 
         secret_backend_tuning = self.client.get_secret_backend_tuning('generic', mount_point='test')
         self.assertEqual(secret_backend_tuning['max_lease_ttl'], 2764800)
@@ -80,14 +80,14 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
         self.client.tune_secret_backend('generic', mount_point='test', default_lease_ttl='3600s', max_lease_ttl='8600s')
         secret_backend_tuning = self.client.get_secret_backend_tuning('generic', mount_point='test')
 
-        assert 'max_lease_ttl' in secret_backend_tuning
+        self.assertIn('max_lease_ttl', secret_backend_tuning)
         self.assertEqual(secret_backend_tuning['max_lease_ttl'], 8600)
-        assert 'default_lease_ttl' in secret_backend_tuning
+        self.assertIn('default_lease_ttl', secret_backend_tuning)
         self.assertEqual(secret_backend_tuning['default_lease_ttl'], 3600)
 
         self.client.remount_secret_backend('test', 'foobar')
         self.assertNotIn('test/', self.client.list_secret_backends())
-        assert 'foobar/' in self.client.list_secret_backends()
+        self.assertIn('foobar/', self.client.list_secret_backends())
 
         self.client.token = self.manager.root_token
         self.client.disable_secret_backend('foobar')
@@ -101,17 +101,17 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
         }
 
         self.client.enable_audit_backend('file', options=options, name='tmpfile')
-        assert 'tmpfile/' in self.client.list_audit_backends()
+        self.assertIn('tmpfile/', self.client.list_audit_backends())
 
         self.client.token = self.manager.root_token
         self.client.disable_audit_backend('tmpfile')
         self.assertNotIn('tmpfile/', self.client.list_audit_backends())
 
     def test_policy_manipulation(self):
-        assert 'root' in self.client.list_policies()
+        self.assertIn('root', self.client.list_policies())
         assert self.client.get_policy('test') is None
         policy, parsed_policy = self.prep_policy('test')
-        assert 'test' in self.client.list_policies()
+        self.assertIn('test', self.client.list_policies())
         self.assertEqual(policy, self.client.get_policy('test'))
         self.assertEqual(parsed_policy, self.client.get_policy('test', parse=True))
 
@@ -119,7 +119,7 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
         self.assertNotIn('test', self.client.list_policies())
 
     def test_json_policy_manipulation(self):
-        assert 'root' in self.client.list_policies()
+        self.assertIn('root', self.client.list_policies())
 
         policy = {
             "path": {
@@ -133,7 +133,7 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
         }
 
         self.client.set_policy('test', policy)
-        assert 'test' in self.client.list_policies()
+        self.assertIn('test', self.client.list_policies())
 
         self.client.delete_policy('test')
         self.assertNotIn('test', self.client.list_policies())

--- a/hvac/tests/integration_tests/v1/test_system_backend.py
+++ b/hvac/tests/integration_tests/v1/test_system_backend.py
@@ -430,3 +430,10 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
                 container=audit_hash_response['data']['hash'],
             )
         self.client.disable_audit_backend('tmpfile')
+
+    def test_get_secret_backend_tuning(self):
+        secret_backend_tuning = self.client.get_secret_backend_tuning('secret')
+        self.assertIn(
+            member='default_lease_ttl',
+            container=secret_backend_tuning['data'],
+        )

--- a/hvac/tests/integration_tests/v1/test_system_backend.py
+++ b/hvac/tests/integration_tests/v1/test_system_backend.py
@@ -109,7 +109,7 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
 
     def test_policy_manipulation(self):
         self.assertIn('root', self.client.list_policies())
-        assert self.client.get_policy('test') is None
+        self.assertIsNone(self.client.get_policy('test'))
         policy, parsed_policy = self.prep_policy('test')
         self.assertIn('test', self.client.list_policies())
         self.assertEqual(policy, self.client.get_policy('test'))

--- a/hvac/tests/integration_tests/v1/test_system_backend.py
+++ b/hvac/tests/integration_tests/v1/test_system_backend.py
@@ -146,8 +146,8 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
 
         wrapped_token = resp['wrap_info']['token']
         self.client.auth_cubbyhole(wrapped_token)
-        assert self.client.token != orig_token
-        assert self.client.token != wrapped_token
+        self.assertNotEqual(self.client.token, orig_token)
+        self.assertNotEqual(self.client.token, wrapped_token)
         self.assertTrue(self.client.is_authenticated())
 
         self.client.token = orig_token
@@ -254,8 +254,8 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
         self.client.token = wrap['wrap_info']['token']
         self.client.unwrap()
 
-        assert self.client.token != wrap
-        assert self.client.token != _token
+        self.assertNotEqual(self.client.token, wrap)
+        self.assertNotEqual(self.client.token, _token)
 
     def test_wrapped_client_token_revoke(self):
         wrap = self.client.create_token(wrap_ttl='1m')

--- a/hvac/tests/integration_tests/v1/test_system_backend.py
+++ b/hvac/tests/integration_tests/v1/test_system_backend.py
@@ -437,3 +437,11 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
             member='default_lease_ttl',
             container=secret_backend_tuning['data'],
         )
+
+    def test_get_backed_up_keys(self):
+        with self.assertRaises(exceptions.InvalidRequest) as cm:
+            self.client.get_backed_up_keys()
+            self.assertEqual(
+                first='no backed-up keys found',
+                second=str(cm.exception),
+            )

--- a/hvac/tests/integration_tests/v1/test_system_backend.py
+++ b/hvac/tests/integration_tests/v1/test_system_backend.py
@@ -20,13 +20,13 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
         result = self.client.unseal_multi(keys[0:2])
 
         assert result['sealed']
-        assert result['progress'] == 2
+        self.assertEqual(result['progress'], 2)
 
         result = self.client.unseal_reset()
-        assert result['progress'] == 0
+        self.assertEqual(result['progress'], 0)
         result = self.client.unseal_multi(keys[1:3])
         assert result['sealed']
-        assert result['progress'] == 2
+        self.assertEqual(result['progress'], 2)
         self.client.unseal_multi(keys[0:1])
         result = self.client.unseal_multi(keys[2:3])
         assert not result['sealed']
@@ -112,8 +112,8 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
         assert self.client.get_policy('test') is None
         policy, parsed_policy = self.prep_policy('test')
         assert 'test' in self.client.list_policies()
-        assert policy == self.client.get_policy('test')
-        assert parsed_policy == self.client.get_policy('test', parse=True)
+        self.assertEqual(policy, self.client.get_policy('test'))
+        self.assertEqual(parsed_policy, self.client.get_policy('test', parse=True))
 
         self.client.delete_policy('test')
         assert 'test' not in self.client.list_policies()
@@ -142,7 +142,7 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
         orig_token = self.client.token
 
         resp = self.client.create_token(lease='6h', wrap_ttl='1h')
-        assert resp['wrap_info']['ttl'] == 3600
+        self.assertEqual(resp['wrap_info']['ttl'], 3600)
 
         wrapped_token = resp['wrap_info']['token']
         self.client.auth_cubbyhole(wrapped_token)
@@ -190,7 +190,7 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
 
         # Validate token
         lookup = self.client.lookup_token(result['auth']['client_token'])
-        assert result['auth']['client_token'] == lookup['data']['id']
+        self.assertEqual(result['auth']['client_token'], lookup['data']['id'])
 
     def test_wrapped_token_intercept(self):
         wrap = self.client.create_token(wrap_ttl='1m')
@@ -207,7 +207,7 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
 
         _token = self.client.token
         self.client.unwrap(wrap['wrap_info']['token'])
-        assert self.client.token == _token
+        self.assertEqual(self.client.token, _token)
 
     def test_wrapped_token_revoke(self):
         wrap = self.client.create_token(wrap_ttl='1m')
@@ -234,7 +234,7 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
         # Validate token
         self.client.token = result['auth']['client_token']
         lookup = self.client.lookup_token(result['auth']['client_token'])
-        assert result['auth']['client_token'] == lookup['data']['id']
+        self.assertEqual(result['auth']['client_token'], lookup['data']['id'])
 
     def test_wrapped_client_token_intercept(self):
         wrap = self.client.create_token(wrap_ttl='1m')

--- a/hvac/tests/integration_tests/v1/test_system_backend.py
+++ b/hvac/tests/integration_tests/v1/test_system_backend.py
@@ -179,7 +179,7 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
 
         self.client.rotate()
 
-        assert self.client.key_status['term'] > status['term']
+        self.assertGreater(self.client.key_status['term'], status['term'])
 
     def test_wrapped_token_success(self):
         wrap = self.client.create_token(wrap_ttl='1m')

--- a/hvac/tests/integration_tests/v1/test_system_backend.py
+++ b/hvac/tests/integration_tests/v1/test_system_backend.py
@@ -58,17 +58,17 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
         self.client.disable_auth_backend("approle")
 
     def test_auth_backend_manipulation(self):
-        assert 'github/' not in self.client.list_auth_backends()
+        self.assertNotIn('github/', self.client.list_auth_backends())
 
         self.client.enable_auth_backend('github')
         assert 'github/' in self.client.list_auth_backends()
 
         self.client.token = self.manager.root_token
         self.client.disable_auth_backend('github')
-        assert 'github/' not in self.client.list_auth_backends()
+        self.assertNotIn('github/', self.client.list_auth_backends())
 
     def test_secret_backend_manipulation(self):
-        assert 'test/' not in self.client.list_secret_backends()
+        self.assertNotIn('test/', self.client.list_secret_backends())
 
         self.client.enable_secret_backend('generic', mount_point='test')
         assert 'test/' in self.client.list_secret_backends()
@@ -86,15 +86,15 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
         self.assertEqual(secret_backend_tuning['default_lease_ttl'], 3600)
 
         self.client.remount_secret_backend('test', 'foobar')
-        assert 'test/' not in self.client.list_secret_backends()
+        self.assertNotIn('test/', self.client.list_secret_backends())
         assert 'foobar/' in self.client.list_secret_backends()
 
         self.client.token = self.manager.root_token
         self.client.disable_secret_backend('foobar')
-        assert 'foobar/' not in self.client.list_secret_backends()
+        self.assertNotIn('foobar/', self.client.list_secret_backends())
 
     def test_audit_backend_manipulation(self):
-        assert 'tmpfile/' not in self.client.list_audit_backends()
+        self.assertNotIn('tmpfile/', self.client.list_audit_backends())
 
         options = {
             'path': '/tmp/vault.audit.log'
@@ -105,7 +105,7 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
 
         self.client.token = self.manager.root_token
         self.client.disable_audit_backend('tmpfile')
-        assert 'tmpfile/' not in self.client.list_audit_backends()
+        self.assertNotIn('tmpfile/', self.client.list_audit_backends())
 
     def test_policy_manipulation(self):
         assert 'root' in self.client.list_policies()
@@ -116,7 +116,7 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
         self.assertEqual(parsed_policy, self.client.get_policy('test', parse=True))
 
         self.client.delete_policy('test')
-        assert 'test' not in self.client.list_policies()
+        self.assertNotIn('test', self.client.list_policies())
 
     def test_json_policy_manipulation(self):
         assert 'root' in self.client.list_policies()
@@ -136,7 +136,7 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
         assert 'test' in self.client.list_policies()
 
         self.client.delete_policy('test')
-        assert 'test' not in self.client.list_policies()
+        self.assertNotIn('test', self.client.list_policies())
 
     def test_cubbyhole_auth(self):
         orig_token = self.client.token

--- a/hvac/tests/integration_tests/v1/test_system_backend.py
+++ b/hvac/tests/integration_tests/v1/test_system_backend.py
@@ -29,12 +29,12 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
         self.assertEqual(result['progress'], 2)
         self.client.unseal_multi(keys[0:1])
         result = self.client.unseal_multi(keys[2:3])
-        assert not result['sealed']
+        self.assertFalse(result['sealed'])
 
     def test_seal_unseal(self):
         cls = type(self)
 
-        assert not self.client.is_sealed()
+        self.assertFalse(self.client.is_sealed())
 
         self.client.seal()
 
@@ -42,7 +42,7 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
 
         cls.manager.unseal()
 
-        assert not self.client.is_sealed()
+        self.assertFalse(self.client.is_sealed())
 
     def test_ha_status(self):
         assert 'ha_enabled' in self.client.ha_status
@@ -156,13 +156,13 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
     def test_rekey_multi(self):
         cls = type(self)
 
-        assert not self.client.rekey_status['started']
+        self.assertFalse(self.client.rekey_status['started'])
 
         self.client.start_rekey()
         self.assertTrue(self.client.rekey_status['started'])
 
         self.client.cancel_rekey()
-        assert not self.client.rekey_status['started']
+        self.assertFalse(self.client.rekey_status['started'])
 
         result = self.client.start_rekey()
 

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -403,16 +403,21 @@ class Client(object):
                     backup=False):
         """PUT /sys/rekey/init
 
-        :param secret_shares:
-        :type secret_shares:
-        :param secret_threshold:
-        :type secret_threshold:
-        :param pgp_keys:
-        :type pgp_keys:
-        :param backup:
-        :type backup:
-        :return:
-        :rtype:
+        :param secret_shares: Specifies the number of shares to split the master key into.
+        :type secret_shares: int
+        :param secret_threshold: Specifies the number of shares required to reconstruct the master key. This must be
+            less than or equal to secret_shares.
+        :type secret_threshold: int
+        :param pgp_keys: List of PGP public keys used to encrypt the output unseal keys. Ordering is preserved. The keys
+            must be base64-encoded from their original binary representation. The size of this array must be the same as
+            secret_shares.
+        :type pgp_keys: list
+        :param backup: Specifies if using PGP-encrypted keys, whether Vault should also store a plaintext backup of the
+            PGP-encrypted keys at core/unseal-keys-backup in the physical storage backend. These can then be retrieved
+            and removed via the sys/rekey/backup endpoint.
+        :type backup: bool
+        :return: The full response object if an empty body is received, otherwise the JSON dict of the response.
+        :rtype: dict | request.Response
         """
         params = {
             'secret_shares': secret_shares,

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -616,8 +616,8 @@ class Client(object):
             to the backend.
         :type passthrough_request_headers: str
 
-        :return: The JSON response from Vault
-        :rtype: dict.
+        :return: The response from Vault
+        :rtype: request.Response
         """
 
         if not mount_point:


### PR DESCRIPTION
Closes #275

Adding test runs for Vault v0.11.0 in travis-ci (that are marked as "allowed failures) until https://github.com/hvac/hvac/issues/263 is sorted.