### PR TITLE
Using Various Regions With AWS IAM Auth

### DIFF
--- a/docs/usage/auth_methods/aws.rst
+++ b/docs/usage/auth_methods/aws.rst
@@ -101,6 +101,46 @@ Lambda and/or EC2 Instance
     client = hvac.Client()
     client.auth_aws_iam(access_key_id, secret_access_key)
 
+Caveats For Non-Default AWS Regions
+```````````````````````````````````
+
+I.e., calling :py:meth:`hvac.v1.Client.auth_aws_iam` with a `region` argument other than its default of "**us-east-1**". For additional background / context on this matter, please review the comment at: `vault-ruby#161`_.
+
+The following code snippets are for authenticating hosts in the **us-west-1** region:
+
+.. note::
+    In order to authenticate to various regions, the AWS auth method configuration needs to be set up with an "endpoint URL" corresponding to the region in question. E.g.: "**https://sts.us-west-1.amazonaws.com**" in the case of this example. Vault defaults to an endpoint of "**https://sts.amazonaws.com**" if not configured with a different endpoint URL.
+
+.. code:: python
+
+    import boto3
+    import hvac
+
+    VAULT_ADDR = os.environ["VAULT_ADDR"]
+    VAULT_HEADER_VALUE = os.environ["VAULT_HEADER_VALUE"]
+
+    client = hvac.Client(url=VAULT_ADDR)
+
+    # One-time setup of the credentials / configuration for the Vault server to use.
+    # Note the explicit region subdomain bit included in the endpoint argument.
+    client.create_vault_ec2_client_configuration(
+        access_key='SOME_ACCESS_KEY_FOR_VAULTS_USE',
+        secret_key='SOME_ACCESS_KEY_FOR_VAULTS_USE',
+        endpoint='https://sts.us-west-1.amazonaws.com',
+    )
+
+    session = boto3.Session()
+    creds = session.get_credentials().get_frozen_credentials()
+    client.auth_aws_iam(
+        creds.access_key,
+        creds.secret_key,
+        creds.token,
+        region="us-west-1",
+        header_value=VAULT_HEADER_VALUE,
+        role='some-role,
+        use_token=True,
+    )
+
 
 EC2 Authentication
 ------------------
@@ -259,3 +299,5 @@ Authentication using EC2 instance role credentials and the EC2 metadata service
 
 
     authenticated_vault_client = get_vault_client()
+
+.. _vault-ruby#161: https://github.com/hashicorp/vault-ruby/pull/161#issuecomment-355723269

--- a/docs/usage/auth_methods/aws.rst
+++ b/docs/usage/auth_methods/aws.rst
@@ -104,7 +104,7 @@ Lambda and/or EC2 Instance
 Caveats For Non-Default AWS Regions
 ```````````````````````````````````
 
-I.e., calling :py:meth:`hvac.v1.Client.auth_aws_iam` with a `region` argument other than its default of "**us-east-1**". For additional background / context on this matter, please review the comment at: `vault-ruby#161`_.
+I.e., calling :py:meth:`hvac.v1.Client.auth_aws_iam` with a `region` argument other than its default of "**us-east-1**". For additional background / context on this matter, see the comments at `hvac#251`_ and/or `vault-ruby#161`_.
 
 The following code snippets are for authenticating hosts in the **us-west-1** region:
 
@@ -300,4 +300,5 @@ Authentication using EC2 instance role credentials and the EC2 metadata service
 
     authenticated_vault_client = get_vault_client()
 
+.. _hvac#251: https://github.com/hvac/hvac/issues/251
 .. _vault-ruby#161: https://github.com/hashicorp/vault-ruby/pull/161#issuecomment-355723269

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -1474,16 +1474,31 @@ class Client(object):
     def create_vault_ec2_client_configuration(self, access_key, secret_key, endpoint=None, mount_point='aws-ec2'):
         """POST /auth/<mount_point>/config/client
 
-        :param access_key:
-        :type access_key:
-        :param secret_key:
-        :type secret_key:
-        :param endpoint:
-        :type endpoint:
-        :param mount_point:
-        :type mount_point:
-        :return:
-        :rtype:
+        Configure the credentials required to perform API calls to AWS as well as custom endpoints to talk to AWS APIs.
+        The instance identity document fetched from the PKCS#7 signature will provide the EC2 instance ID. The
+        credentials configured using this endpoint will be used to query the status of the instances via
+        DescribeInstances API. If static credentials are not provided using this endpoint, then the credentials will be
+        retrieved from the environment variables AWS_ACCESS_KEY, AWS_SECRET_KEY and AWS_REGION respectively. If the
+        credentials are still not found and if the method is configured on an EC2 instance with metadata querying
+        capabilities, the credentials are fetched automatically
+
+        :param access_key: AWS Access key with permissions to query AWS APIs. The permissions required depend on the
+            specific configurations. If using the iam auth method without inferencing, then no credentials are
+            necessary. If using the ec2 auth method or using the iam auth method with inferencing, then these
+            credentials need access to ec2:DescribeInstances. If additionally a bound_iam_role is specified, then these
+            credentials also need access to iam:GetInstanceProfile. If, however, an alternate sts configuration is set
+            for the target account, then the credentials must be permissioned to call sts:AssumeRole on the configured
+            role, and that role must have the permissions described here.
+        :type access_key: str|unicode
+        :param secret_key: AWS Secret key with permissions to query AWS APIs.
+        :type secret_key: str|unicode
+        :param endpoint: URL to override the default generated endpoint for making AWS EC2 API calls.
+        :type endpoint: str|unicode
+        :param mount_point: The "path" the AWS auth backend was mounted on. Vault currently defaults to "aws". "aws-ec2"
+            is the default argument for backwards comparability within this module.
+        :type mount_point: str|unicode
+        :return: The response of the request.
+        :rtype: requests.Response
         """
         params = {
             'access_key': access_key,


### PR DESCRIPTION
Closes #251

@joelthompson and/or @paddie: As the folks with the most discussion and input on the [associated issue](https://github.com/hvac/hvac/issues/251) for this PR, I would be most grateful for any feedback on the documentation updates being made here. In particular I'm not 100% positive that I've correctly captured all the nuance of this matter as I haven't had cause to work with Vault deployments in AWS regions other than us-east-1 myself.  