### PR TITLE
Fix version regex / Bump Latest Vault Version for Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,11 @@ matrix:
       env:
         - TOXENV=py27
         - HVAC_VAULT_VERSION=0.11.0
-    - name: 'Python v2.7, Vault v0.11.2 - Integration/Unit Tests'
+    - name: 'Python v2.7, Vault v0.11.4 - Integration/Unit Tests'
       python: '2.7'
       env:
         - TOXENV=py27
-        - HVAC_VAULT_VERSION=0.11.2
+        - HVAC_VAULT_VERSION=0.11.4
     - name: 'Python v2.7, Vault HEAD ref - Integration/Unit Tests'
       python: '2.7'
       env:
@@ -57,11 +57,11 @@ matrix:
       env:
         - TOXENV=py27
         - HVAC_VAULT_VERSION=0.11.0
-    - name: 'Python v3.6, Vault v0.11.2 - Integration/Unit Tests'
+    - name: 'Python v3.6, Vault v0.11.4 - Integration/Unit Tests'
       python: '3.6'
       env:
         - TOXENV=py27
-        - HVAC_VAULT_VERSION=0.11.2
+        - HVAC_VAULT_VERSION=0.11.4
     - name: 'Python v3.6, Vault HEAD ref - Integration/Unit Tests'
       python: '3.6'
       env:

--- a/hvac/tests/utils.py
+++ b/hvac/tests/utils.py
@@ -20,7 +20,7 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
-VERSION_REGEX = re.compile('Vault v([\d\.]+)')
+VERSION_REGEX = re.compile(r'Vault v([0-9.]+)')
 LATEST_VAULT_VERSION = '0.11.2'
 
 

--- a/hvac/tests/utils.py
+++ b/hvac/tests/utils.py
@@ -21,7 +21,7 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 VERSION_REGEX = re.compile(r'Vault v([0-9.]+)')
-LATEST_VAULT_VERSION = '0.11.2'
+LATEST_VAULT_VERSION = '0.11.4'
 
 
 def get_installed_vault_version():

--- a/scripts/install-vault.sh
+++ b/scripts/install-vault.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eux
 
-DEFAULT_VAULT_VERSION=0.11.2
+DEFAULT_VAULT_VERSION=0.11.4
 HVAC_VAULT_VERSION=${1:-$DEFAULT_VAULT_VERSION}
 
 function build_and_install_vault_head_ref() {


### PR DESCRIPTION
Saw some odd linting failures in https://github.com/hvac/hvac/pull/299/. This PR ideally patches that up. Also bumping the latest version of Vault for testing to 0.11.4.