### PR TITLE
Rename auth method

### DIFF
--- a/hvac/adapters.py
+++ b/hvac/adapters.py
@@ -144,8 +144,10 @@ class Adapter(object):
         """
         return self.request('list', url, **kwargs)
 
-    def auth(self, url, use_token=True, **kwargs):
-        """Performs a request (typically to a path prefixed with "/v1/auth") and optionaly stores the client token sent
+    def login(self, url, use_token=True, **kwargs):
+        """Perform a login request.
+
+        Associated request is typically to a path prefixed with "/v1/auth") and optionally stores the client token sent
             in the resulting Vault response for use by the :py:meth:`hvac.adapters.Adapter` instance under the _adapater
             Client attribute.
 
@@ -165,6 +167,17 @@ class Adapter(object):
             self.token = response['auth']['client_token']
 
         return response
+
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.9.0',
+        new_method=login,
+    )
+    def auth(self, url, use_token=True, **kwargs):
+        return self.login(
+            url=url,
+            use_token=use_token,
+            **kwargs
+        )
 
     @abstractmethod
     def request(self, method, url, headers=None, **kwargs):

--- a/hvac/api/auth/azure.py
+++ b/hvac/api/auth/azure.py
@@ -276,7 +276,7 @@ class Azure(VaultApiBase):
         if vmss_name is not None:
             params['vmss_name'] = vmss_name
         api_path = '/v1/auth/{mount_point}/login'.format(mount_point=mount_point)
-        response = self._adapter.auth(
+        response = self._adapter.login(
             url=api_path,
             use_token=use_token,
             json=params,

--- a/hvac/api/auth/gcp.py
+++ b/hvac/api/auth/gcp.py
@@ -390,7 +390,7 @@ class Gcp(VaultApiBase):
             'jwt': jwt,
         }
         api_path = '/v1/auth/{mount_point}/login'.format(mount_point=mount_point)
-        response = self._adapter.auth(
+        response = self._adapter.login(
             url=api_path,
             use_token=use_token,
             json=params,

--- a/hvac/api/auth/github.py
+++ b/hvac/api/auth/github.py
@@ -209,7 +209,7 @@ class Github(VaultApiBase):
             'token': token,
         }
         api_path = '/v1/auth/{mount_point}/login'.format(mount_point=mount_point)
-        return self._adapter.auth(
+        return self._adapter.login(
             url=api_path,
             use_token=use_token,
             json=params,

--- a/hvac/api/auth/ldap.py
+++ b/hvac/api/auth/ldap.py
@@ -379,7 +379,7 @@ class Ldap(VaultApiBase):
             mount_point=mount_point,
             username=username,
         )
-        return self._adapter.auth(
+        return self._adapter.login(
             url=api_path,
             use_token=use_token,
             json=params,

--- a/hvac/tests/unit_tests/v1/test_aws_iam_methods.py
+++ b/hvac/tests/unit_tests/v1/test_aws_iam_methods.py
@@ -12,7 +12,7 @@ class TestAwsIamMethods(TestCase):
     """Unit tests providing coverage for AWS (EC2) auth backend-related methods/routes."""
 
     @mock.patch('hvac.aws_utils.datetime')
-    @mock.patch('hvac.v1.Client.auth')
+    @mock.patch('hvac.v1.Client.login')
     def test_auth_aws_iam(self, auth_mock, datetime_mock):
         datetime_mock.utcnow.return_value = datetime(2015, 8, 30, 12, 36, 0)
         client = Client()

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -1739,8 +1739,10 @@ class Client(object):
         self.token = token
         return self.auth('/v1/sys/wrapping/unwrap')
 
-    def auth(self, url, use_token=True, **kwargs):
-        """Performs a request (typically to a path prefixed with "/v1/auth") and optionaly stores the client token sent
+    def login(self, url, use_token=True, **kwargs):
+        """Perform a login request.
+
+        Associated request is typically to a path prefixed with "/v1/auth") and optionally stores the client token sent
             in the resulting Vault response for use by the :py:meth:`hvac.adapters.Adapter` instance under the _adapater
             Client attribute.
 
@@ -1754,7 +1756,7 @@ class Client(object):
         :return: The response of the auth request.
         :rtype: requests.Response
         """
-        return self._adapter.auth(
+        return self._adapter.login(
             url=url,
             use_token=use_token,
             **kwargs
@@ -2687,6 +2689,17 @@ class Client(object):
         params['signature_algorithm'] = signature_algorithm
 
         return self._adapter.post(url, json=params).json()
+
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.9.0',
+        new_method=login,
+    )
+    def auth(self, url, use_token=True, **kwargs):
+        return self.login(
+            url=url,
+            use_token=use_token,
+            **kwargs
+        )
 
     @utils.deprecated_method(
         to_be_removed_in_version='0.8.0',

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -1125,7 +1125,7 @@ class Client(object):
             'user_id': user_id,
         }
 
-        return self.auth('/v1/auth/{0}/login'.format(mount_point), json=params, use_token=use_token)
+        return self.login('/v1/auth/{0}/login'.format(mount_point), json=params, use_token=use_token)
 
     def auth_tls(self, mount_point='cert', use_token=True):
         """POST /auth/<mount point>/login
@@ -1137,7 +1137,7 @@ class Client(object):
         :return:
         :rtype:
         """
-        return self.auth('/v1/auth/{0}/login'.format(mount_point), use_token=use_token)
+        return self.login('/v1/auth/{0}/login'.format(mount_point), use_token=use_token)
 
     def auth_userpass(self, username, password, mount_point='userpass', use_token=True, **kwargs):
         """POST /auth/<mount point>/login/<username>
@@ -1161,7 +1161,7 @@ class Client(object):
 
         params.update(kwargs)
 
-        return self.auth('/v1/auth/{0}/login/{1}'.format(mount_point, username), json=params, use_token=use_token)
+        return self.login('/v1/auth/{0}/login/{1}'.format(mount_point, username), json=params, use_token=use_token)
 
     def auth_aws_iam(self, access_key, secret_key, session_token=None, header_value=None, mount_point='aws', role='', use_token=True, region='us-east-1'):
         """POST /auth/<mount point>/login
@@ -1206,7 +1206,7 @@ class Client(object):
             'role': role,
         }
 
-        return self.auth('/v1/auth/{0}/login'.format(mount_point), json=params, use_token=use_token)
+        return self.login('/v1/auth/{0}/login'.format(mount_point), json=params, use_token=use_token)
 
     def auth_ec2(self, pkcs7, nonce=None, role=None, use_token=True, mount_point='aws-ec2'):
         """POST /auth/<mount point>/login
@@ -1234,7 +1234,7 @@ class Client(object):
         if role:
             params['role'] = role
 
-        return self.auth('/v1/auth/{0}/login'.format(mount_point), json=params, use_token=use_token)
+        return self.login('/v1/auth/{0}/login'.format(mount_point), json=params, use_token=use_token)
 
     def create_userpass(self, username, password, policies, mount_point='userpass', **kwargs):
         """POST /auth/<mount point>/users/<username>
@@ -1737,7 +1737,7 @@ class Client(object):
         :rtype:
         """
         self.token = token
-        return self.auth('/v1/sys/wrapping/unwrap')
+        return self.login('/v1/sys/wrapping/unwrap')
 
     def login(self, url, use_token=True, **kwargs):
         """Perform a login request.
@@ -2106,7 +2106,7 @@ class Client(object):
         if secret_id is not None:
             params['secret_id'] = secret_id
 
-        return self.auth('/v1/auth/{0}/login'.format(mount_point), json=params, use_token=use_token)
+        return self.login('/v1/auth/{0}/login'.format(mount_point), json=params, use_token=use_token)
 
     def create_kubernetes_configuration(self, kubernetes_host, kubernetes_ca_cert=None, token_reviewer_jwt=None, pem_keys=None, mount_point='kubernetes'):
         """POST /auth/<mount_point>/config
@@ -2254,7 +2254,7 @@ class Client(object):
             'jwt': jwt
         }
         url = 'v1/auth/{0}/login'.format(mount_point)
-        return self.auth(url, json=params, use_token=use_token)
+        return self.login(url, json=params, use_token=use_token)
 
     def transit_create_key(self, name, convergent_encryption=None, derived=None, exportable=None,
                            key_type=None, mount_point='transit'):


### PR DESCRIPTION
Renaming the Client / Adapter `auth()` method to `login()` so we can begin using an `auth` attribute on the Client class down the line for organization of the various auth method classes (e.g., Ldap, Github, etc.).