### PR TITLE
Auth system backend methods

### DIFF
--- a/docs/usage/system_backend/auth.rst
+++ b/docs/usage/system_backend/auth.rst
@@ -1,0 +1,94 @@
+Auth
+====
+
+
+.. code:: python
+
+	methods = client.sys.list_auth_methods()
+
+	client.sys.enable_auth_method('userpass', path='customuserpass')
+	client.sys.disable_auth_method('github')
+
+List Auth Methods
+-----------------
+
+:py:meth:`hvac.api.system_backend.Auth.list_auth_methods`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+	auth_methods = self.client.sys.list_auth_methods()
+	print('The following auth methods are enabled: {auth_methods_list}'.format(
+		auth_methods_list=auth_methods['data'].keys(),
+	)
+
+
+Enable Auth Method
+------------------
+
+:py:meth:`hvac.api.system_backend.Auth.enable_auth_method`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+	self.client.sys.enable_auth_method(
+		method_type='github',
+		path='hvac-github',
+	)
+
+
+Disable Auth Method
+-------------------
+
+:py:meth:`hvac.api.system_backend.Auth.disable_auth_method`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+	self.client.sys.disable_auth_method(
+		path='hvac-github',
+	)
+
+
+Read Auth Method Tuning
+-----------------------
+
+:py:meth:`hvac.api.system_backend.Auth.read_auth_method_tuning`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+	response = self.client.sys.read_auth_method_tuning(
+		path='github-hvac',
+		description='The Github auth method for hvac users',
+	)
+
+	print('The max lease TTL for the auth method under path "github-hvac" is: {max_ttl}'.format(
+		max_ttl=response['data']['max_lease_ttl'],
+	)
+
+
+Tune Auth Method
+----------------
+
+:py:meth:`hvac.api.system_backend.Auth.tune_auth_method`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+	self.client.sys.tune_auth_method(
+		path=self.TEST_AUTH_METHOD_PATH,
+		description='The Github auth method for hvac users',
+	)
+
+
+

--- a/docs/usage/system_backend/index.rst
+++ b/docs/usage/system_backend/index.rst
@@ -5,6 +5,7 @@ System Backend
    :maxdepth: 2
 
    audit
+   auth
 
 .. contents::
 
@@ -40,16 +41,6 @@ Initialize and seal/unseal
     client.seal()
 
     print(client.is_sealed()) # => True
-
-Manipulate auth backends
-------------------------
-
-.. code:: python
-
-    backends = client.list_auth_backends()
-
-    client.enable_auth_backend('userpass', mount_point='customuserpass')
-    client.disable_auth_backend('github')
 
 Manipulate secret backends
 --------------------------

--- a/hvac/api/system_backend/__init__.py
+++ b/hvac/api/system_backend/__init__.py
@@ -2,11 +2,13 @@
 import logging
 
 from hvac.api.system_backend.audit import Audit
+from hvac.api.system_backend.auth import Auth
 from hvac.api.system_backend.system_backend_mixin import SystemBackendMixin
 from hvac.api.vault_api_category import VaultApiCategory
 
 __all__ = (
     'Audit',
+    'Auth',
     'SystemBackend',
     'SystemBackendMixin',
 )
@@ -15,7 +17,7 @@ __all__ = (
 logger = logging.getLogger(__name__)
 
 
-class SystemBackend(VaultApiCategory, Audit):
+class SystemBackend(VaultApiCategory, Audit, Auth):
     implemented_classes = [
         Audit,
     ]

--- a/hvac/api/system_backend/audit.py
+++ b/hvac/api/system_backend/audit.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+"""Support for "Audit"-related System Backend Methods."""
 from hvac.api.system_backend.system_backend_mixin import SystemBackendMixin
 
 

--- a/hvac/api/system_backend/auth.py
+++ b/hvac/api/system_backend/auth.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Support for "Auth"-related System Backend Methods."""
+from hvac.api.system_backend.system_backend_mixin import SystemBackendMixin
+from hvac.utils import validate_list_of_strings_param, list_to_comma_delimited
+from hvac import exceptions
+
+
+class Auth(SystemBackendMixin):
+
+    def list_auth_methods(self):
+        """List all enabled auth methods.
+
+        Supported methods:
+            GET: /sys/auth. Produces: 200 application/json
+
+        :return: The JSON response of the request.
+        :rtype: dict
+        """
+        api_path = '/v1/sys/auth'
+        response = self._adapter.get(
+            url=api_path,
+        )
+        return response.json()
+
+    def enable_auth_method(self, method_type, description=None, config=None, plugin_name=None, local=False, path=None):
+        """Enable a new auth method.
+
+        After enabling, the auth method can be accessed and configured via the auth path specified as part of the URL.
+        This auth path will be nested under the auth prefix.
+
+        Supported methods:
+            POST: /sys/auth/{path}. Produces: 204 (empty body)
+
+        :param method_type: The name of the authentication method type, such as "github" or "token".
+        :type method_type: str | unicode
+        :param description: A human-friendly description of the auth method.
+        :type description: str | unicode
+        :param config: Configuration options for this auth method. These are the possible values:
+
+            * **default_lease_ttl**: The default lease duration, specified as a string duration like "5s" or "30m".
+            * **max_lease_ttl**: The maximum lease duration, specified as a string duration like "5s" or "30m".
+            * **audit_non_hmac_request_keys**: Comma-separated list of keys that will not be HMAC'd by audit devices in
+              the request data object.
+            * **audit_non_hmac_response_keys**: Comma-separated list of keys that will not be HMAC'd by audit devices in
+              the response data object.
+            * **listing_visibility**: Speficies whether to show this mount in the UI-specific listing endpoint.
+            * **passthrough_request_headers**: Comma-separated list of headers to whitelist and pass from the request to
+              the backend.
+        :type config: dict
+        :param plugin_name: The name of the auth plugin to use based from the name in the plugin catalog. Applies only
+            to plugin methods.
+        :type plugin_name: str | unicode
+        :param local: <Vault enterprise only> Specifies if the auth method is a local only. Local auth methods are not
+            replicated nor (if a secondary) removed by replication.
+        :type local: bool
+        :param path: The path to mount the method on. If not provided, defaults to the value of the "method_type"
+            argument.
+        :type path: str | unicode
+        :return: The response of the request.
+        :rtype: requests.Response
+        """
+        if path is None:
+            path = method_type
+
+        params = {
+            'type': method_type,
+            'description': description,
+            'config': config,
+            'plugin_name': plugin_name,
+            'local': local,
+        }
+        api_path = '/v1/sys/auth/{path}'.format(path=path)
+        return self._adapter.post(
+            url=api_path,
+            json=params
+        )
+
+    def disable_auth_method(self, path):
+        """Disable the auth method at the given auth path.
+
+        Supported methods:
+            DELETE: /sys/auth/{path}. Produces: 204 (empty body)
+
+        :param path: The path the method was mounted on. If not provided, defaults to the value of the "method_type"
+            argument.
+        :type path: str | unicode
+        :return: The response of the request.
+        :rtype: requests.Response
+        """
+        api_path = '/v1/sys/auth/{path}'.format(path=path)
+        return self._adapter.delete(
+            url=api_path,
+        )
+
+    def read_auth_method_tuning(self, path):
+        """Read the given auth path's configuration.
+
+        This endpoint requires sudo capability on the final path, but the same functionality can be achieved without
+        sudo via sys/mounts/auth/[auth-path]/tune.
+
+        Supported methods:
+            GET: /sys/auth/{path}/tune. Produces: 200 application/json
+
+        :param path: The path the method was mounted on. If not provided, defaults to the value of the "method_type"
+            argument.
+        :type path: str | unicode
+        :return: The JSON response of the request.
+        :rtype: dict
+        """
+        api_path = '/v1/sys/auth/{path}/tune'.format(
+            path=path,
+        )
+        response = self._adapter.get(
+            url=api_path,
+        )
+        return response.json()
+
+    def tune_auth_method(self, path, default_lease_ttl=None, max_lease_ttl=None, description=None,
+                         audit_non_hmac_request_keys=None, audit_non_hmac_response_keys=None, listing_visibility='',
+                         passthrough_request_headers=None):
+        """Tune configuration parameters for a given auth path.
+
+        This endpoint requires sudo capability on the final path, but the same functionality can be achieved without
+        sudo via sys/mounts/auth/[auth-path]/tune.
+
+        Supported methods:
+            POST: /sys/auth/{path}/tune. Produces: 204 (empty body)
+
+        :param path: The path the method was mounted on. If not provided, defaults to the value of the "method_type"
+            argument.
+        :type path: str | unicode
+        :param default_lease_ttl: Specifies the default time-to-live. If set on a specific auth path, this overrides the
+            global default.
+        :type default_lease_ttl: int
+        :param max_lease_ttl: The maximum time-to-live. If set on a specific auth path, this overrides the global
+            default.
+        :type max_lease_ttl: int
+        :param description: Specifies the description of the mount. This overrides the current stored value, if any.
+        :type description: str | unicode
+        :param audit_non_hmac_request_keys: Specifies the list of keys that will not be HMAC'd by audit devices in the
+            request data object.
+        :type audit_non_hmac_request_keys: array
+        :param audit_non_hmac_response_keys: Specifies the list of keys that will not be HMAC'd by audit devices in the
+            response data object.
+        :type audit_non_hmac_response_keys: list
+        :param listing_visibility: Specifies whether to show this mount in the UI-specific listing endpoint. Valid
+            values are "unauth" or "".
+        :type listing_visibility: list
+        :param passthrough_request_headers: List of headers to whitelist and pass from the request to the backend.
+        :type passthrough_request_headers: list
+        :return: The response of the request.
+        :rtype: requests.Response
+        """
+
+        if listing_visibility not in ['unauth', '']:
+            error_msg = 'invalid listing_visibility argument provided: "{arg}"; valid values: "unauth" or ""'.format(
+                arg=listing_visibility,
+            )
+            raise exceptions.ParamValidationError(error_msg)
+
+        # All parameters are optional for this method. Until/unless we include input validation, we simply loop over the
+        # parameters and add which parameters are set.
+        optional_parameters = {
+            'default_lease_ttl': dict(),
+            'max_lease_ttl': dict(),
+            'description': dict(),
+            'audit_non_hmac_request_keys': dict(comma_delimited_list=True),
+            'audit_non_hmac_response_keys': dict(comma_delimited_list=True),
+            'listing_visibility': dict(),
+            'passthrough_request_headers': dict(comma_delimited_list=True),
+        }
+        params = {}
+        for optional_parameter, parameter_specification in optional_parameters.items():
+            if locals().get(optional_parameter) is not None:
+                if parameter_specification.get('comma_delimited_list'):
+                    argument = locals().get(optional_parameter)
+                    validate_list_of_strings_param(optional_parameter, argument)
+                    params[optional_parameter] = list_to_comma_delimited(argument)
+                else:
+                    params[optional_parameter] = locals().get(optional_parameter)
+
+        api_path = '/v1/sys/auth/{path}/tune'.format(path=path)
+        return self._adapter.post(
+            url=api_path,
+            json=params,
+        )

--- a/hvac/tests/integration_tests/api/system_backend/test_auth.py
+++ b/hvac/tests/integration_tests/api/system_backend/test_auth.py
@@ -1,0 +1,64 @@
+from unittest import TestCase
+
+from hvac.tests import utils
+
+
+class TestAuth(utils.HvacIntegrationTestCase, TestCase):
+    TEST_AUTH_METHOD_TYPE = 'github'
+    TEST_AUTH_METHOD_PATH = 'test-github'
+
+    def tearDown(self):
+        self.client.sys.disable_auth_method(
+            path=self.TEST_AUTH_METHOD_PATH
+        )
+
+    def test_auth_backend_manipulation(self):
+        self.assertNotIn(
+            member='%s/' % self.TEST_AUTH_METHOD_PATH,
+            container=self.client.sys.list_auth_methods()['data'],
+        )
+
+        self.client.sys.enable_auth_method(
+            method_type=self.TEST_AUTH_METHOD_TYPE,
+            path=self.TEST_AUTH_METHOD_PATH,
+        )
+        self.assertIn(
+            member='%s/' % self.TEST_AUTH_METHOD_PATH,
+            container=self.client.sys.list_auth_methods()['data'],
+        )
+
+        self.client.sys.disable_auth_method(
+            path=self.TEST_AUTH_METHOD_PATH,
+        )
+        self.assertNotIn(
+            member='%s/' % self.TEST_AUTH_METHOD_PATH,
+            container=self.client.sys.list_auth_methods()['data'],
+        )
+
+    def test_tune_auth_backend(self):
+        test_description = 'this is a test auth backend'
+        test_max_lease_ttl = 12345678
+        self.client.sys.enable_auth_method(
+            method_type='approle',
+            path=self.TEST_AUTH_METHOD_PATH
+        )
+
+        expected_status_code = 204
+        response = self.client.sys.tune_auth_method(
+            path=self.TEST_AUTH_METHOD_PATH,
+            description=test_description,
+            max_lease_ttl=test_max_lease_ttl,
+        )
+        self.assertEqual(
+            first=expected_status_code,
+            second=response.status_code,
+        )
+
+        response = self.client.sys.read_auth_method_tuning(
+            path=self.TEST_AUTH_METHOD_PATH
+        )
+
+        self.assertEqual(
+            first=test_max_lease_ttl,
+            second=response['data']['max_lease_ttl']
+        )

--- a/hvac/tests/integration_tests/v1/test_integration.py
+++ b/hvac/tests/integration_tests/v1/test_integration.py
@@ -66,7 +66,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
             assert True
 
     def test_userpass_auth(self):
-        if 'userpass/' in self.client.list_auth_backends():
+        if 'userpass/' in self.client.list_auth_backends()['data']:
             self.client.disable_auth_backend('userpass')
 
         self.client.enable_auth_backend('userpass')
@@ -82,7 +82,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
         self.client.disable_auth_backend('userpass')
 
     def test_create_userpass(self):
-        if 'userpass/' not in self.client.list_auth_backends():
+        if 'userpass/' not in self.client.list_auth_backends()['data']:
             self.client.enable_auth_backend('userpass')
 
         self.client.create_userpass('testcreateuser', 'testcreateuserpass', policies='not_root')
@@ -105,7 +105,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
         self.client.disable_auth_backend('userpass')
 
     def test_list_userpass(self):
-        if 'userpass/' not in self.client.list_auth_backends():
+        if 'userpass/' not in self.client.list_auth_backends()['data']:
             self.client.enable_auth_backend('userpass')
 
         # add some users and confirm that they show up in the list
@@ -124,7 +124,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
         assert no_users_list is None
 
     def test_read_userpass(self):
-        if 'userpass/' not in self.client.list_auth_backends():
+        if 'userpass/' not in self.client.list_auth_backends()['data']:
             self.client.enable_auth_backend('userpass')
 
         # create user to read
@@ -138,7 +138,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
         self.client.disable_auth_backend('userpass')
 
     def test_update_userpass_policies(self):
-        if 'userpass/' not in self.client.list_auth_backends():
+        if 'userpass/' not in self.client.list_auth_backends()['data']:
             self.client.enable_auth_backend('userpass')
 
         # create user and then update its policies
@@ -153,7 +153,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
         self.client.disable_auth_backend('userpass')
 
     def test_update_userpass_password(self):
-        if 'userpass/' not in self.client.list_auth_backends():
+        if 'userpass/' not in self.client.list_auth_backends()['data']:
             self.client.enable_auth_backend('userpass')
 
         # create user and then change its password
@@ -170,7 +170,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
         self.client.disable_auth_backend('userpass')
 
     def test_delete_userpass(self):
-        if 'userpass/' not in self.client.list_auth_backends():
+        if 'userpass/' not in self.client.list_auth_backends()['data']:
             self.client.enable_auth_backend('userpass')
 
         self.client.create_userpass('testcreateuser', 'testcreateuserpass', policies='not_root')
@@ -185,7 +185,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
         self.assertRaises(exceptions.InvalidRequest, self.client.auth_userpass, 'testcreateuser', 'testcreateuserpass')
 
     def test_app_id_auth(self):
-        if 'app-id/' in self.client.list_auth_backends():
+        if 'app-id/' in self.client.list_auth_backends()['data']:
             self.client.disable_auth_backend('app-id')
 
         self.client.enable_auth_backend('app-id')
@@ -202,7 +202,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
         self.client.disable_auth_backend('app-id')
 
     def test_create_app_id(self):
-        if 'app-id/' not in self.client.list_auth_backends():
+        if 'app-id/' not in self.client.list_auth_backends()['data']:
             self.client.enable_auth_backend('app-id')
 
         self.client.create_app_id('testappid', policies='not_root', display_name='displayname')
@@ -223,7 +223,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
         self.client.disable_auth_backend('app-id')
 
     def test_create_user_id(self):
-        if 'app-id/' not in self.client.list_auth_backends():
+        if 'app-id/' not in self.client.list_auth_backends()['data']:
             self.client.enable_auth_backend('app-id')
 
         self.client.create_app_id('testappid', policies='not_root', display_name='displayname')
@@ -446,7 +446,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
         assert not self.client.is_authenticated()
 
     def test_revoke_self_token(self):
-        if 'userpass/' in self.client.list_auth_backends():
+        if 'userpass/' in self.client.list_auth_backends()['data']:
             self.client.disable_auth_backend('userpass')
 
         self.client.enable_auth_backend('userpass')
@@ -575,7 +575,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
         self.client.delete_policy('testpolicy')
 
     def test_ec2_role_crud(self):
-        if 'aws-ec2/' in self.client.list_auth_backends():
+        if 'aws-ec2/' in self.client.list_auth_backends()['data']:
             self.client.disable_auth_backend('aws-ec2')
         self.client.enable_auth_backend('aws-ec2')
 
@@ -674,7 +674,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
         self.client.disable_auth_backend('aws-ec2')
 
     def test_ec2_role_token_lifespan(self):
-        if 'aws-ec2/' not in self.client.list_auth_backends():
+        if 'aws-ec2/' not in self.client.list_auth_backends()['data']:
             self.client.enable_auth_backend('aws-ec2')
 
         # create a policy to associate with the role
@@ -728,7 +728,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
     def test_auth_ec2_alternate_mount_point_with_no_client_token_exception(self):
         test_mount_point = 'aws-custom-path'
         # Turn on the aws-ec2 backend with a custom mount_point path specified.
-        if '{0}/'.format(test_mount_point) in self.client.list_auth_backends():
+        if '{0}/'.format(test_mount_point) in self.client.list_auth_backends()['data']:
             self.client.disable_auth_backend(test_mount_point)
         self.client.enable_auth_backend('aws-ec2', mount_point=test_mount_point)
 
@@ -756,7 +756,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
     def test_auth_ec2_alternate_mount_point_with_no_client_token(self):
         test_mount_point = 'aws-custom-path'
         # Turn on the aws-ec2 backend with a custom mount_point path specified.
-        if '{0}/'.format(test_mount_point) in self.client.list_auth_backends():
+        if '{0}/'.format(test_mount_point) in self.client.list_auth_backends()['data']:
             self.client.disable_auth_backend(test_mount_point)
         self.client.enable_auth_backend('aws-ec2', mount_point=test_mount_point)
 
@@ -784,7 +784,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
     def test_auth_gcp_alternate_mount_point_with_no_client_token_exception(self):
         test_mount_point = 'gcp-custom-path'
         # Turn on the gcp backend with a custom mount_point path specified.
-        if '{0}/'.format(test_mount_point) in self.client.list_auth_backends():
+        if '{0}/'.format(test_mount_point) in self.client.list_auth_backends()['data']:
             self.client.disable_auth_backend(test_mount_point)
         self.client.enable_auth_backend('gcp', mount_point=test_mount_point)
 
@@ -827,7 +827,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
         test_mount_point = 'k8s'
 
         # Turn on the kubernetes backend with a custom mount_point path specified.
-        if '{0}/'.format(test_mount_point) in self.client.list_auth_backends():
+        if '{0}/'.format(test_mount_point) in self.client.list_auth_backends()['data']:
             self.client.disable_auth_backend(test_mount_point)
         self.client.enable_auth_backend('kubernetes', mount_point=test_mount_point)
 
@@ -851,7 +851,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
         test_mount_point = 'k8s'
 
         # Turn on the kubernetes backend with a custom mount_point path specified.
-        if '{0}/'.format(test_mount_point) in self.client.list_auth_backends():
+        if '{0}/'.format(test_mount_point) in self.client.list_auth_backends()['data']:
             self.client.disable_auth_backend(test_mount_point)
         self.client.enable_auth_backend('kubernetes', mount_point=test_mount_point)
         with open('test/client-cert.pem') as fp:
@@ -884,7 +884,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
         expected_status_code = 204
 
         # Turn on the kubernetes backend with a custom mount_point path specified.
-        if '{0}/'.format(test_mount_point) in self.client.list_auth_backends():
+        if '{0}/'.format(test_mount_point) in self.client.list_auth_backends()['data']:
             self.client.disable_auth_backend(test_mount_point)
         self.client.enable_auth_backend('kubernetes', mount_point=test_mount_point)
 
@@ -917,7 +917,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
         test_bound_service_account_namespaces = ['vault-test']
 
         # Turn on the kubernetes backend with a custom mount_point path specified.
-        if '{0}/'.format(test_mount_point) in self.client.list_auth_backends():
+        if '{0}/'.format(test_mount_point) in self.client.list_auth_backends()['data']:
             self.client.disable_auth_backend(test_mount_point)
         self.client.enable_auth_backend('kubernetes', mount_point=test_mount_point)
 
@@ -957,7 +957,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
         test_bound_service_account_namespaces = ['vault-test']
 
         # Turn on the kubernetes backend with a custom mount_point path specified.
-        if '{0}/'.format(test_mount_point) in self.client.list_auth_backends():
+        if '{0}/'.format(test_mount_point) in self.client.list_auth_backends()['data']:
             self.client.disable_auth_backend(test_mount_point)
         self.client.enable_auth_backend('kubernetes', mount_point=test_mount_point)
 
@@ -996,7 +996,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
         expected_status_code = 204
 
         # Turn on the kubernetes backend with a custom mount_point path specified.
-        if '{0}/'.format(test_mount_point) in self.client.list_auth_backends():
+        if '{0}/'.format(test_mount_point) in self.client.list_auth_backends()['data']:
             self.client.disable_auth_backend(test_mount_point)
         self.client.enable_auth_backend('kubernetes', mount_point=test_mount_point)
 
@@ -1033,7 +1033,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
         test_mount_point = 'k8s'
 
         # Turn on the kubernetes backend with a custom mount_point path specified.
-        if '{0}/'.format(test_mount_point) in self.client.list_auth_backends():
+        if '{0}/'.format(test_mount_point) in self.client.list_auth_backends()['data']:
             self.client.disable_auth_backend(test_mount_point)
         self.client.enable_auth_backend('kubernetes', mount_point=test_mount_point)
         with open('test/client-cert.pem') as fp:

--- a/hvac/tests/integration_tests/v1/test_system_backend.py
+++ b/hvac/tests/integration_tests/v1/test_system_backend.py
@@ -57,14 +57,14 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
         self.client.disable_auth_backend("approle")
 
     def test_auth_backend_manipulation(self):
-        self.assertNotIn('github/', self.client.list_auth_backends())
+        self.assertNotIn('github/', self.client.list_auth_backends()['data'])
 
         self.client.enable_auth_backend('github')
-        self.assertIn('github/', self.client.list_auth_backends())
+        self.assertIn('github/', self.client.list_auth_backends()['data'])
 
         self.client.token = self.manager.root_token
         self.client.disable_auth_backend('github')
-        self.assertNotIn('github/', self.client.list_auth_backends())
+        self.assertNotIn('github/', self.client.list_auth_backends()['data'])
 
     def test_secret_backend_manipulation(self):
         self.assertNotIn('test/', self.client.list_secret_backends())


### PR DESCRIPTION
Part 2.2 of 3 in our large refactor series of how we organize auth methods, secrets engines, and system backend classes. This PR starts the move with "Auth" related methods to a new "sys" property used to access instances of these SystemBackend mixin classes under the Client class.