### PR TITLE
Add sys init class

### DIFF
--- a/docs/usage/system_backend/index.rst
+++ b/docs/usage/system_backend/index.rst
@@ -6,6 +6,8 @@ System Backend
 
    audit
    auth
+   health
+   init
 
 .. contents::
 

--- a/docs/usage/system_backend/index.rst
+++ b/docs/usage/system_backend/index.rst
@@ -14,17 +14,17 @@ Initialize and seal/unseal
 
 .. code:: python
 
-    print(client.is_initialized()) # => False
+    print(client.sys.is_initialized()) # => False
 
     shares = 5
     threshold = 3
 
-    result = client.initialize(shares, threshold)
+    result = client.sys.initialize(shares, threshold)
 
     root_token = result['root_token']
     keys = result['keys']
 
-    print(client.is_initialized()) # => True
+    print(client.sys.is_initialized()) # => True
 
     print(client.is_sealed()) # => True
 

--- a/docs/usage/system_backend/init.rst
+++ b/docs/usage/system_backend/init.rst
@@ -1,0 +1,53 @@
+Init
+====
+
+
+.. code:: python
+
+	methods = client.sys.list_auth_methods()
+
+	client.sys.enable_auth_method('userpass', path='customuserpass')
+	client.sys.disable_auth_method('github')
+
+Read Status
+-----------
+
+:py:meth:`hvac.api.system_backend.Auth.list_auth_methods`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+	read_response = client.sys.read_init_status()
+	print('Vault initialize status: %s' % read_response['initialized'])
+
+
+Is Initialized
+--------------
+
+:py:meth:`hvac.api.system_backend.Auth.list_auth_methods`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+	print('Vault initialize status: %s' % client.sys.is_initialized())
+
+
+Initialize
+----------
+
+:py:meth:`hvac.api.system_backend.Auth.list_auth_methods`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+	init_result = client.sys.initialize()
+
+	root_token = init_result['root_token']
+	unseal_keys = init_result['keys']
+

--- a/docs/usage/system_backend/init.rst
+++ b/docs/usage/system_backend/init.rst
@@ -12,7 +12,7 @@ Init
 Read Status
 -----------
 
-:py:meth:`hvac.api.system_backend.Auth.list_auth_methods`
+:py:meth:`hvac.api.system_backend.Init.read_init_status`
 
 .. code:: python
 
@@ -26,7 +26,7 @@ Read Status
 Is Initialized
 --------------
 
-:py:meth:`hvac.api.system_backend.Auth.list_auth_methods`
+:py:meth:`hvac.api.system_backend.Init.is_initialized`
 
 .. code:: python
 
@@ -39,7 +39,7 @@ Is Initialized
 Initialize
 ----------
 
-:py:meth:`hvac.api.system_backend.Auth.list_auth_methods`
+:py:meth:`hvac.api.system_backend.Init.initialize`
 
 .. code:: python
 

--- a/hvac/api/system_backend/__init__.py
+++ b/hvac/api/system_backend/__init__.py
@@ -4,6 +4,7 @@ import logging
 from hvac.api.system_backend.audit import Audit
 from hvac.api.system_backend.auth import Auth
 from hvac.api.system_backend.health import Health
+from hvac.api.system_backend.init import Init
 from hvac.api.system_backend.system_backend_mixin import SystemBackendMixin
 from hvac.api.vault_api_category import VaultApiCategory
 
@@ -19,9 +20,12 @@ __all__ = (
 logger = logging.getLogger(__name__)
 
 
-class SystemBackend(VaultApiCategory, Audit, Auth, Health):
+class SystemBackend(VaultApiCategory, Audit, Auth, Health, Init):
     implemented_classes = [
         Audit,
+        Auth,
+        Health,
+        Init,
     ]
     unimplemented_classes = []
 

--- a/hvac/api/system_backend/init.py
+++ b/hvac/api/system_backend/init.py
@@ -1,0 +1,104 @@
+from hvac.api.system_backend.system_backend_mixin import SystemBackendMixin
+from hvac.exceptions import ParamValidationError
+
+
+class Init(SystemBackendMixin):
+
+    def read_init_status(self):
+        """Read the initialization status of Vault.
+
+        Supported methods:
+            GET: /sys/init. Produces: 200 application/json
+
+        :return: The JSON response of the request.
+        :rtype: dict
+        """
+        api_path = '/v1/sys/init'
+        response = self._adapter.get(
+            url=api_path,
+        )
+        return response.json()
+
+    def is_initialized(self):
+        """Determine is Vault is initialized or not.
+
+        :return: True if Vault is initialized, False otherwise.
+        :rtype: bool
+        """
+        status = self.read_init_status()
+        return status['initialized']
+
+    def initialize(self, secret_shares=5, secret_threshold=3, pgp_keys=None, root_token_pgp_key=None,
+                   stored_shares=None, recovery_shares=None, recovery_threshold=None, recovery_pgp_keys=None):
+        """Initialize a new Vault.
+
+        The Vault must not have been previously initialized. The recovery options, as well as the stored shares option,
+        are only available when using Vault HSM.
+
+        Supported methods:
+            PUT: /sys/init. Produces: 200 application/json
+
+        :param secret_shares: The number of shares to split the master key into.
+        :type secret_shares: int
+        :param secret_threshold: Specifies the number of shares required to reconstruct the master key. This must be
+            less than or equal secret_shares. If using Vault HSM with auto-unsealing, this value must be the same as
+            secret_shares.
+        :type secret_threshold: int
+        :param pgp_keys: List of PGP public keys used to encrypt the output unseal keys.
+            Ordering is preserved. The keys must be base64-encoded from their original binary representation.
+            The size of this array must be the same as secret_shares.
+        :type pgp_keys: list
+        :param root_token_pgp_key: Specifies a PGP public key used to encrypt the initial root token. The
+            key must be base64-encoded from its original binary representation.
+        :type root_token_pgp_key: str | unicode
+        :param stored_shares: <enterprise only> Specifies the number of shares that should be encrypted by the HSM and
+            stored for auto-unsealing. Currently must be the same as secret_shares.
+        :type stored_shares: int
+        :param recovery_shares: <enterprise only> Specifies the number of shares to split the recovery key into.
+        :type recovery_shares: int
+        :param recovery_threshold: <enterprise only> Specifies the number of shares required to reconstruct the recovery
+            key. This must be less than or equal to recovery_shares.
+        :type recovery_threshold: int
+        :param recovery_pgp_keys: <enterprise only> Specifies an array of PGP public keys used to encrypt the output
+            recovery keys. Ordering is preserved. The keys must be base64-encoded from their original binary
+            representation. The size of this array must be the same as recovery_shares.
+        :type recovery_pgp_keys: list
+        :return: The JSON response of the request.
+        :rtype: dict
+        """
+        params = {
+            'secret_shares': secret_shares,
+            'secret_threshold': secret_threshold,
+            'root_token_pgp_key': root_token_pgp_key,
+        }
+
+        if pgp_keys is not None:
+            if len(pgp_keys) != secret_shares:
+                raise ParamValidationError('length of pgp_keys list argument must equal secret_shares value')
+            params['pgp_keys'] = pgp_keys
+
+        if stored_shares is not None:
+            if stored_shares != secret_shares:
+                raise ParamValidationError('value for stored_shares argument must equal secret_shares argument')
+            params['stored_shares'] = stored_shares
+
+        if recovery_shares is not None:
+            params['recovery_shares'] = recovery_shares
+
+        if recovery_threshold is not None:
+            if recovery_threshold <= recovery_shares:
+                error_msg = 'value for recovery_threshold argument be less than or equal to recovery_shares argument'
+                raise ParamValidationError(error_msg)
+            params['recovery_threshold'] = recovery_threshold
+
+        if recovery_pgp_keys is not None:
+            if len(recovery_pgp_keys) != recovery_shares:
+                raise ParamValidationError('length of recovery_pgp_keys list argument must equal recovery_shares value')
+            params['recovery_pgp_keys'] = recovery_pgp_keys
+
+        api_path = '/v1/sys/init'
+        response = self._adapter.put(
+            url=api_path,
+            json=params,
+        )
+        return response.json()

--- a/hvac/tests/integration_tests/api/system_backend/test_init.py
+++ b/hvac/tests/integration_tests/api/system_backend/test_init.py
@@ -1,0 +1,13 @@
+import logging
+from unittest import TestCase
+
+from hvac.tests import utils
+
+
+class TestInit(utils.HvacIntegrationTestCase, TestCase):
+    def test_read_init_status(self):
+        read_response = self.client.sys.read_init_status()
+        logging.debug('read_response: %s' % read_response)
+        self.assertTrue(
+            expr=read_response['initialized']
+        )

--- a/hvac/tests/utils.py
+++ b/hvac/tests/utils.py
@@ -198,7 +198,7 @@ class ServerManager(object):
         last_exception = None
         while attempts_left > 0:
             try:
-                self.client.is_initialized()
+                self.client.sys.is_initialized()
                 return
             except Exception as ex:
                 logger.debug('Waiting for Vault to start')
@@ -220,9 +220,9 @@ class ServerManager(object):
 
     def initialize(self):
         """Perform initialization of the vault server process and record the provided unseal keys and root token."""
-        assert not self.client.is_initialized()
+        assert not self.client.sys.is_initialized()
 
-        result = self.client.initialize()
+        result = self.client.sys.initialize()
 
         self.root_token = result['root_token']
         self.keys = result['keys']

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -215,39 +215,6 @@ class Client(object):
         else:
             return self._adapter.post('/v1/sys/wrapping/unwrap').json()
 
-    def is_initialized(self):
-        """GET /sys/init
-
-        :return:
-        :rtype:
-        """
-        return self._adapter.get('/v1/sys/init').json()['initialized']
-
-    def initialize(self, secret_shares=5, secret_threshold=3, pgp_keys=None):
-        """PUT /sys/init
-
-        :param secret_shares:
-        :type secret_shares:
-        :param secret_threshold:
-        :type secret_threshold:
-        :param pgp_keys:
-        :type pgp_keys:
-        :return:
-        :rtype:
-        """
-        params = {
-            'secret_shares': secret_shares,
-            'secret_threshold': secret_threshold,
-        }
-
-        if pgp_keys:
-            if len(pgp_keys) != secret_shares:
-                raise ValueError('Length of pgp_keys must equal secret shares')
-
-            params['pgp_keys'] = pgp_keys
-
-        return self._adapter.put('/v1/sys/init', json=params).json()
-
     @property
     def seal_status(self):
         """GET /sys/seal-status
@@ -2491,6 +2458,24 @@ class Client(object):
         params['signature_algorithm'] = signature_algorithm
 
         return self._adapter.post(url, json=params).json()
+
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.9.0',
+        new_method=api.SystemBackend.is_initialized,
+    )
+    def is_initialized(self):
+        return self.sys.is_initialized()
+
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.9.0',
+        new_method=api.SystemBackend.initialize,
+    )
+    def initialize(self, secret_shares=5, secret_threshold=3, pgp_keys=None):
+        return self.sys.initialize(
+            secret_shares=secret_shares,
+            secret_threshold=secret_threshold,
+            pgp_keys=pgp_keys,
+        )
 
     @utils.deprecated_method(
         to_be_removed_in_version='0.9.0',


### PR DESCRIPTION
Part 2.2 of 3 in our large refactor series of how we organize auth methods, secrets engines, and system backend classes. This PR starts the move with "Init" related methods to a new "sys" property used to access instances of these SystemBackend mixin classes under the Client class.