### PR TITLE
New sys backend classes key

### DIFF
--- a/docs/usage/system_backend/health.rst
+++ b/docs/usage/system_backend/health.rst
@@ -5,7 +5,7 @@ Health
 Read Status
 -----------
 
-:py:meth:`hvac.api.system_backend.health.read_status`
+:py:meth:`hvac.api.system_backend.health.read_health_status`
 
 .. code:: python
 

--- a/docs/usage/system_backend/index.rst
+++ b/docs/usage/system_backend/index.rst
@@ -8,6 +8,7 @@ System Backend
    auth
    health
    init
+   key
 
 .. contents::
 

--- a/docs/usage/system_backend/key.rst
+++ b/docs/usage/system_backend/key.rst
@@ -42,6 +42,8 @@ Cancel Root Generation
 	import hvac
 	client = hvac.Client()
 
+	client.sys.cancel_root_generation()
+
 
 Generate Root
 -------------
@@ -53,7 +55,10 @@ Generate Root
 	import hvac
 	client = hvac.Client()
 
-	client.sys.cancel_root_generation()
+	client.sys.generate_root(
+		key=key,
+		nonce=nonce,
+	)
 
 
 Get Encryption Key Status
@@ -66,6 +71,8 @@ Get Encryption Key Status
 	import hvac
 	client = hvac.Client()
 
+	print('Encryption key term is: %s' % client.sys.key_status['term'])
+
 
 Rotate Encryption Key
 ---------------------
@@ -76,6 +83,8 @@ Rotate Encryption Key
 
 	import hvac
 	client = hvac.Client()
+
+	client.sys.rotate_encryption_key()
 
 
 Read Rekey Progress
@@ -88,6 +97,8 @@ Read Rekey Progress
 	import hvac
 	client = hvac.Client()
 
+	print('Rekey "started" status is: %s' % client.sys.read_rekey_progress()['started'])
+
 
 Start Rekey
 -----------
@@ -98,6 +109,8 @@ Start Rekey
 
 	import hvac
 	client = hvac.Client()
+
+	client.sys.start_rekey()
 
 
 Cancel Rekey
@@ -110,6 +123,8 @@ Cancel Rekey
 	import hvac
 	client = hvac.Client()
 
+	client.sys.cancel_rekey()
+
 
 Rekey
 -----
@@ -120,6 +135,12 @@ Rekey
 
 	import hvac
 	client = hvac.Client()
+
+	client.sys.rekey(
+		key=key,
+		nonce=nonce,
+		recovery_key=recovery_key,
+	)
 
 
 Rekey Multi
@@ -132,15 +153,18 @@ Rekey Multi
 	import hvac
 	client = hvac.Client()
 
+	client.sys.rekey_multi(keys, nonce=nonce)
 
-Read Backup Key
----------------
 
-:py:meth:`hvac.api.system_backend.key.read_backup_key`
+Read Backup Keys
+----------------
+
+:py:meth:`hvac.api.system_backend.key.read_backup_keys`
 
 .. code:: python
 
 	import hvac
 	client = hvac.Client()
 
+	print('Backup keys are: %s' % client.sys.read_backup_keys()['keys'])
 

--- a/docs/usage/system_backend/key.rst
+++ b/docs/usage/system_backend/key.rst
@@ -1,0 +1,146 @@
+Key
+===
+
+Read Root Generation Progress
+-----------------------------
+
+:py:meth:`hvac.api.system_backend.key.read_root_generation_progress`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+	root_gen_progress = client.sys.read_root_generation_progress()
+	print('Root generation "started" status: %s' % root_gen_progress['started'])
+
+
+Start Root Token Generation
+---------------------------
+
+:py:meth:`hvac.api.system_backend.key.start_root_token_generation`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+	new_otp = 'RSMGkAqBH5WnVLrDTbZ+UQ=='
+	start_generate_root_response = client.sys.start_root_token_generation(
+        otp=new_otp,
+    )
+	print('Nonce for root generation is: %s' % start_generate_root_response['nonce'])
+
+
+Cancel Root Generation
+----------------------
+
+:py:meth:`hvac.api.system_backend.key.cancel_root_generation`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+
+Generate Root
+-------------
+
+:py:meth:`hvac.api.system_backend.key.generate_root`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+	client.sys.cancel_root_generation()
+
+
+Get Encryption Key Status
+-------------------------
+
+:py:meth:`hvac.api.system_backend.key.get_encryption_key_status`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+
+Rotate Encryption Key
+---------------------
+
+:py:meth:`hvac.api.system_backend.key.rotate_encryption_key`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+
+Read Rekey Progress
+-------------------
+
+:py:meth:`hvac.api.system_backend.key.read_rekey_progress`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+
+Start Rekey
+-----------
+
+:py:meth:`hvac.api.system_backend.key.start_rekey`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+
+Cancel Rekey
+------------
+
+:py:meth:`hvac.api.system_backend.key.cancel_rekey`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+
+Rekey
+-----
+
+:py:meth:`hvac.api.system_backend.key.rekey`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+
+Rekey Multi
+-----------
+
+:py:meth:`hvac.api.system_backend.key.rekey_multi`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+
+Read Backup Key
+---------------
+
+:py:meth:`hvac.api.system_backend.key.read_backup_key`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+

--- a/hvac/api/system_backend/__init__.py
+++ b/hvac/api/system_backend/__init__.py
@@ -5,6 +5,7 @@ from hvac.api.system_backend.audit import Audit
 from hvac.api.system_backend.auth import Auth
 from hvac.api.system_backend.health import Health
 from hvac.api.system_backend.init import Init
+from hvac.api.system_backend.key import Key
 from hvac.api.system_backend.system_backend_mixin import SystemBackendMixin
 from hvac.api.vault_api_category import VaultApiCategory
 
@@ -12,6 +13,8 @@ __all__ = (
     'Audit',
     'Auth',
     'Health',
+    'Init',
+    'Key',
     'SystemBackend',
     'SystemBackendMixin',
 )
@@ -20,12 +23,13 @@ __all__ = (
 logger = logging.getLogger(__name__)
 
 
-class SystemBackend(VaultApiCategory, Audit, Auth, Health, Init):
+class SystemBackend(VaultApiCategory, Audit, Auth, Health, Init, Key):
     implemented_classes = [
         Audit,
         Auth,
         Health,
         Init,
+        Key,
     ]
     unimplemented_classes = []
 

--- a/hvac/api/system_backend/key.py
+++ b/hvac/api/system_backend/key.py
@@ -1,0 +1,296 @@
+from hvac.api.system_backend.system_backend_mixin import SystemBackendMixin
+from hvac.exceptions import ParamValidationError
+
+
+class Key(SystemBackendMixin):
+
+    @property
+    def generate_root_status(self):
+        return self.read_root_generation_progress()
+
+    def read_root_generation_progress(self):
+        """Read the configuration and process of the current root generation attempt.
+
+        Supported methods:
+            GET: /sys/generate-root/attempt. Produces: 200 application/json
+
+        :return: The JSON response of the request.
+        :rtype: dict
+        """
+        api_path = '/v1/sys/generate-root/attempt'
+        response = self._adapter.get(
+            url=api_path,
+        )
+        return response.json()
+
+    def start_root_token_generation(self, otp=None, pgp_key=None):
+        """Initialize a new root generation attempt.
+
+        Only a single root generation attempt can take place at a time. One (and only one) of otp or pgp_key are
+        required.
+
+        Supported methods:
+            PUT: /sys/generate-root/attempt. Produces: 200 application/json
+
+        :param otp: Specifies a base64-encoded 16-byte value. The raw bytes of the token will be XOR'd with this value
+            before being returned to the final unseal key provider.
+        :type otp: str | unicode
+        :param pgp_key: Specifies a base64-encoded PGP public key. The raw bytes of the token will be encrypted with
+            this value before being returned to the final unseal key provider.
+        :type pgp_key: str | unicode
+        :return: The JSON response of the request.
+        :rtype: dict
+        """
+        params = {}
+        if otp is not None and pgp_key is not None:
+            raise ParamValidationError('one (and only one) of otp or pgp_key arguments are required')
+        if otp is not None:
+            params['otp'] = otp
+        if pgp_key is not None:
+            params['pgp_key'] = pgp_key
+
+        api_path = '/v1/sys/generate-root/attempt'
+        response = self._adapter.put(
+            url=api_path,
+            json=params
+        )
+        return response.json()
+
+    def generate_root(self, key, nonce):
+        """Enter a single master key share to progress the root generation attempt.
+
+        If the threshold number of master key shares is reached, Vault will complete the root generation and issue the
+        new token. Otherwise, this API must be called multiple times until that threshold is met. The attempt nonce must
+        be provided with each call.
+
+        Supported methods:
+            PUT: /sys/generate-root/update. Produces: 200 application/json
+
+        :param key: Specifies a single master key share.
+        :type key: str | unicode
+        :param nonce: The nonce of the attempt.
+        :type nonce: str | unicode
+        :return: The JSON response of the request.
+        :rtype: dict
+        """
+        params = {
+            'key': key,
+            'nonce': nonce,
+        }
+        api_path = '/v1/sys/generate-root/update'
+        response = self._adapter.put(
+            url=api_path,
+            json=params,
+        )
+        return response.json()
+
+    def cancel_root_generation(self):
+        """Cancel any in-progress root generation attempt.
+
+        This clears any progress made. This must be called to change the OTP or PGP key being used.
+
+        Supported methods:
+            DELETE: /sys/generate-root/attempt. Produces: 204 (empty body)
+
+        :return: The response of the request.
+        :rtype: request.Response
+        """
+        api_path = '/v1/sys/generate-root/attempt'
+        response = self._adapter.delete(
+            url=api_path,
+        )
+        return response
+
+    def get_encryption_key_status(self):
+        """Read information about the current encryption key used by Vault.
+
+        Supported methods:
+            GET: /sys/key-status. Produces: 200 application/json
+
+        :return: Information about the current encryption key used by Vault.
+        :rtype: dict
+        """
+        api_path = '/v1/sys/key-status'
+        response = self._adapter.get(
+            url=api_path,
+        )
+        return response.json().get('data')
+
+    def rotate_encryption_key(self):
+        """Trigger a rotation of the backend encryption key.
+
+        This is the key that is used to encrypt data written to the storage backend, and is not provided to operators.
+        This operation is done online. Future values are encrypted with the new key, while old values are decrypted with
+        previous encryption keys.
+
+        This path requires sudo capability in addition to update.
+
+        Supported methods:
+            PUT: /sys/rorate. Produces: 204 (empty body)
+
+        :return: The response of the request.
+        :rtype: requests.Response
+        """
+        api_path = '/v1/sys/rotate'
+        response = self._adapter.put(
+            url=api_path,
+        )
+        return response
+
+    def read_rekey_progress(self):
+        """Read the configuration and progress of the current rekey attempt.
+
+        Supported methods:
+            GET: /sys/rekey-recovery-key/init. Produces: 200 application/json
+
+        :return: The JSON response of the request.
+        :rtype: requests.Response
+        """
+        api_path = '/v1/sys/rekey-recovery-key/init'
+        response = self._adapter.get(
+            url=api_path,
+        )
+        return response.json()
+
+    def start_rekey(self, secret_shares=5, secret_threshold=3, pgp_keys=None, backup=False, require_verification=False):
+        """Initializes a new rekey attempt.
+
+        Only a single recovery key rekeyattempt can take place at a time, and changing the parameters of a rekey
+        requires canceling and starting a new rekey, which will also provide a new nonce.
+
+        Supported methods:
+            PUT: /sys/rekey-recovery-key/init. Produces: 204 (empty body)
+
+        :param secret_shares: Specifies the number of shares to split the master key into.
+        :type secret_shares: int
+        :param secret_threshold: Specifies the number of shares required to reconstruct the master key. This must be
+            less than or equal to secret_shares.
+        :type secret_threshold: int
+        :param pgp_keys: Specifies an array of PGP public keys used to encrypt the output unseal keys. Ordering is
+            preserved. The keys must be base64-encoded from their original binary representation. The size of this array
+            must be the same as secret_shares.
+        :type pgp_keys: list
+        :param backup: Specifies if using PGP-encrypted keys, whether Vault should also store a plaintext backup of the
+            PGP-encrypted keys at core/unseal-keys-backup in the physical storage backend. These can then be retrieved
+            and removed via the sys/rekey/backup endpoint.
+        :type backup: bool
+        :param require_verification: This turns on verification functionality. When verification is turned on, after
+            successful authorization with the current unseal keys, the new unseal keys are returned but the master key
+            is not actually rotated. The new keys must be provided to authorize the actual rotation of the master key.
+            This ensures that the new keys have been successfully saved and protects against a risk of the keys being
+            lost after rotation but before they can be persisted. This can be used with without pgp_keys, and when used
+            with it, it allows ensuring that the returned keys can be successfully decrypted before committing to the
+            new shares, which the backup functionality does not provide.
+        :type require_verification: bool
+        :return: The JSON dict of the response.
+        :rtype: dict | request.Response
+        """
+        params = {
+            'secret_shares': secret_shares,
+            'secret_threshold': secret_threshold,
+            'require_verification': require_verification,
+        }
+
+        if pgp_keys:
+            if len(pgp_keys) != secret_shares:
+                raise ParamValidationError('length of pgp_keys argument must equal secret shares value')
+
+            params['pgp_keys'] = pgp_keys
+            params['backup'] = backup
+
+        api_path = '/v1/sys/rekey/init'
+        response = self._adapter.put(
+            url=api_path,
+            json=params,
+        )
+
+        return response.json()
+
+    def cancel_rekey(self):
+        """Cancel any in-progress rekey.
+
+        This clears the rekey settings as well as any progress made. This must be called to change the parameters of the
+        rekey.
+        Note: Verification is still a part of a rekey. If rekeying is canceled during the verification flow, the current
+            unseal keys remain valid.
+
+        Supported methods:
+            DELETE: /sys/rekey-recovery-key/init. Produces: 204 (empty body)
+
+        :return: The response of the request.
+        :rtype: requests.Response
+        """
+        api_path = '/v1/sys/rekey/init'
+        response = self._adapter.delete(
+            url=api_path,
+        )
+        return response
+
+    def rekey(self, key, nonce=None):
+        """Enter a single recovery key share to progress the rekey of the Vault.
+        If the threshold number of recovery key shares is reached, Vault will complete the rekey. Otherwise, this API
+        must be called multiple times until that threshold is met. The rekey nonce operation must be provided with each
+        call.
+
+        Supported methods:
+            PUT: /sys/rekey-recovery-key/update. Produces: 200 application/json
+
+        :param key: Specifies a single recovery share key.
+        :type key: str | unicode
+        :param nonce: Specifies the nonce of the rekey operation.
+        :type nonce: str | unicode
+        :return: The JSON response of the request.
+        :rtype: dict
+        """
+        params = {
+            'key': key,
+        }
+
+        if nonce is not None:
+            params['nonce'] = nonce
+
+        api_path = '/v1/sys/rekey/update'
+        response = self._adapter.put(
+            url=api_path,
+            json=params,
+        )
+        return response.json()
+
+    def rekey_multi(self, keys, nonce=None):
+        """Enter multiple recovery key shares to progress the rekey of the Vault.
+
+        If the threshold number of recovery key shares is reached, Vault will complete the rekey.
+
+        :param keys: Specifies multiple recovery share keys.
+        :type keys: list
+        :param nonce: Specifies the nonce of the rekey operation.
+        :type nonce: str | unicode
+        :return: The last response of the rekey request.
+        :rtype: response.Request
+        """
+        result = None
+
+        for key in keys:
+            result = self.rekey(key, nonce=nonce)
+            if result.get('complete'):
+                break
+
+        return result
+
+    def read_backup_key(self):
+        """Retrieve the backup copy of PGP-encrypted unseal keys.
+
+        The returned value is the nonce of the rekey operation and a map of PGP key fingerprint to hex-encoded
+        PGP-encrypted key.
+
+        Supported methods:
+            PUT: /sys/rekey/backup. Produces: 200 application/json
+
+        :return: The JSON response of the request.
+        :rtype: dict
+        """
+        api_path = '/v1/sys/rekey/backup'
+        response = self._adapter.get(
+            url=api_path,
+        )
+        return response.json()

--- a/hvac/constants/client.py
+++ b/hvac/constants/client.py
@@ -19,4 +19,9 @@ DEPRECATED_PROPERTIES = {
         to_be_removed_in_version='0.9.0',
         client_property='secrets',
     ),
+    'generate_root_status': dict(
+        to_be_removed_in_version='0.9.0',
+        client_property='sys',
+        new_name='read_root_generation_progress',
+    ),
 }

--- a/hvac/constants/client.py
+++ b/hvac/constants/client.py
@@ -22,6 +22,13 @@ DEPRECATED_PROPERTIES = {
     'generate_root_status': dict(
         to_be_removed_in_version='0.9.0',
         client_property='sys',
-        new_name='read_root_generation_progress',
+    ),
+    'key_status': dict(
+        to_be_removed_in_version='0.9.0',
+        client_property='sys',
+    ),
+    'rekey_status': dict(
+        to_be_removed_in_version='0.9.0',
+        client_property='sys',
     ),
 }

--- a/hvac/tests/integration_tests/api/system_backend/test_health.py
+++ b/hvac/tests/integration_tests/api/system_backend/test_health.py
@@ -6,7 +6,7 @@ from parameterized import parameterized, param
 from hvac.tests import utils
 
 
-class TestAuth(utils.HvacIntegrationTestCase, TestCase):
+class TestHealth(utils.HvacIntegrationTestCase, TestCase):
 
     @parameterized.expand([
         param(

--- a/hvac/tests/integration_tests/api/system_backend/test_key.py
+++ b/hvac/tests/integration_tests/api/system_backend/test_key.py
@@ -1,0 +1,57 @@
+import logging
+from unittest import TestCase
+
+from hvac.tests import utils
+
+
+class TestKey(utils.HvacIntegrationTestCase, TestCase):
+
+    def test_start_generate_root_with_completion(self):
+        test_otp = 'RSMGkAqBH5WnVLrDTbZ+UQ=='
+
+        self.assertFalse(self.client.sys.read_root_generation_progress()['started'])
+        start_generate_root_response = self.client.sys.start_root_token_generation(
+            otp=test_otp,
+        )
+        logging.debug('generate_root_response: %s' % start_generate_root_response)
+        self.assertTrue(self.client.sys.read_root_generation_progress()['started'])
+
+        nonce = start_generate_root_response['nonce']
+
+        last_generate_root_response = {}
+        for key in self.manager.keys[0:3]:
+            last_generate_root_response = self.client.sys.generate_root(
+                key=key,
+                nonce=nonce,
+            )
+        logging.debug('last_generate_root_response: %s' % last_generate_root_response)
+        self.assertFalse(self.client.sys.read_root_generation_progress()['started'])
+
+        new_root_token = utils.decode_generated_root_token(
+            encoded_token=last_generate_root_response['encoded_root_token'],
+            otp=test_otp,
+        )
+        logging.debug('new_root_token: %s' % new_root_token)
+        token_lookup_resp = self.client.lookup_token(token=new_root_token)
+        logging.debug('token_lookup_resp: %s' % token_lookup_resp)
+
+        # Assert our new root token is properly formed and authenticated
+        self.client.token = new_root_token
+        if self.client.is_authenticated():
+            self.manager.root_token = new_root_token
+        else:
+            # If our new token was unable to authenticate, set the test client's token back to the original value
+            self.client.token = self.manager.root_token
+            self.fail('Unable to authenticate with the newly generated root token.')
+
+    def test_start_generate_root_then_cancel(self):
+        test_otp = 'RSMGkAqBH5WnVLrDTbZ+UQ=='
+
+        self.assertFalse(self.client.sys.read_root_generation_progress()['started'])
+        self.client.sys.start_root_token_generation(
+            otp=test_otp,
+        )
+        self.assertTrue(self.client.sys.read_root_generation_progress()['started'])
+
+        self.client.sys.cancel_root_generation()
+        self.assertFalse(self.client.sys.read_root_generation_progress()['started'])

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -283,59 +283,6 @@ class Client(object):
         return result
 
     @property
-    def generate_root_status(self):
-        """GET /sys/generate-root/attempt
-
-        :return:
-        :rtype:
-        """
-        return self._adapter.get('/v1/sys/generate-root/attempt').json()
-
-    def start_generate_root(self, key, otp=False):
-        """PUT /sys/generate-root/attempt
-
-        :param key:
-        :type key:
-        :param otp:
-        :type otp:
-        :return:
-        :rtype:
-        """
-        params = {}
-        if otp:
-            params['otp'] = key
-        else:
-            params['pgp_key'] = key
-
-        return self._adapter.put('/v1/sys/generate-root/attempt', json=params).json()
-
-    def generate_root(self, key, nonce):
-        """PUT /sys/generate-root/update
-
-        :param key:
-        :type key:
-        :param nonce:
-        :type nonce:
-        :return:
-        :rtype:
-        """
-        params = {
-            'key': key,
-            'nonce': nonce,
-        }
-
-        return self._adapter.put('/v1/sys/generate-root/update', json=params).json()
-
-    def cancel_generate_root(self):
-        """DELETE /sys/generate-root/attempt
-
-        :return:
-        :rtype:
-        """
-
-        return self._adapter.delete('/v1/sys/generate-root/attempt').status_code == 204
-
-    @property
     def key_status(self):
         """GET /sys/key-status
 
@@ -2476,6 +2423,35 @@ class Client(object):
             secret_threshold=secret_threshold,
             pgp_keys=pgp_keys,
         )
+
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.9.0',
+        new_method=api.SystemBackend.start_root_token_generation,
+    )
+    def start_generate_root(self, key, otp=False):
+        params = {}
+        if otp:
+            params['otp'] = key
+        else:
+            params['pgp_key'] = key
+        return self.sys.start_root_token_generation(**params)
+
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.9.0',
+        new_method=api.SystemBackend.generate_root,
+    )
+    def generate_root(self, key, nonce):
+        return self.sys.generate_root(
+            key=key,
+            nonce=nonce,
+        )
+
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.9.0',
+        new_method=api.SystemBackend.cancel_root_generation,
+    )
+    def cancel_generate_root(self):
+        return self.sys.cancel_root_generation().status_code == 204
 
     @utils.deprecated_method(
         to_be_removed_in_version='0.9.0',

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -283,124 +283,6 @@ class Client(object):
         return result
 
     @property
-    def key_status(self):
-        """GET /sys/key-status
-
-        :return: Information about the current encryption key used by Vault.
-        :rtype: dict
-        """
-        key_status_response = self._adapter.get('/v1/sys/key-status').json()
-        key_status = key_status_response['data']
-        return key_status
-
-    def rotate(self):
-        """PUT /sys/rotate
-
-        :return:
-        :rtype:
-        """
-        self._adapter.put('/v1/sys/rotate')
-
-    @property
-    def rekey_status(self):
-        """GET /sys/rekey/init
-
-        :return:
-        :rtype:
-        """
-        return self._adapter.get('/v1/sys/rekey/init').json()
-
-    def start_rekey(self, secret_shares=5, secret_threshold=3, pgp_keys=None,
-                    backup=False):
-        """PUT /sys/rekey/init
-
-        :param secret_shares: Specifies the number of shares to split the master key into.
-        :type secret_shares: int
-        :param secret_threshold: Specifies the number of shares required to reconstruct the master key. This must be
-            less than or equal to secret_shares.
-        :type secret_threshold: int
-        :param pgp_keys: List of PGP public keys used to encrypt the output unseal keys. Ordering is preserved. The keys
-            must be base64-encoded from their original binary representation. The size of this array must be the same as
-            secret_shares.
-        :type pgp_keys: list
-        :param backup: Specifies if using PGP-encrypted keys, whether Vault should also store a plaintext backup of the
-            PGP-encrypted keys at core/unseal-keys-backup in the physical storage backend. These can then be retrieved
-            and removed via the sys/rekey/backup endpoint.
-        :type backup: bool
-        :return: The full response object if an empty body is received, otherwise the JSON dict of the response.
-        :rtype: dict | request.Response
-        """
-        params = {
-            'secret_shares': secret_shares,
-            'secret_threshold': secret_threshold,
-        }
-
-        if pgp_keys:
-            if len(pgp_keys) != secret_shares:
-                raise ValueError('Length of pgp_keys must equal secret shares')
-
-            params['pgp_keys'] = pgp_keys
-            params['backup'] = backup
-
-        resp = self._adapter.put('/v1/sys/rekey/init', json=params)
-        if resp.text:
-            return resp.json()
-
-    def cancel_rekey(self):
-        """DELETE /sys/rekey/init
-
-        :return:
-        :rtype:
-        """
-        self._adapter.delete('/v1/sys/rekey/init')
-
-    def rekey(self, key, nonce=None):
-        """PUT /sys/rekey/update
-
-        :param key:
-        :type key:
-        :param nonce:
-        :type nonce:
-        :return:
-        :rtype:
-        """
-        params = {
-            'key': key,
-        }
-
-        if nonce:
-            params['nonce'] = nonce
-
-        return self._adapter.put('/v1/sys/rekey/update', json=params).json()
-
-    def rekey_multi(self, keys, nonce=None):
-        """
-
-        :param keys:
-        :type keys:
-        :param nonce:
-        :type nonce:
-        :return:
-        :rtype:
-        """
-        result = None
-
-        for key in keys:
-            result = self.rekey(key, nonce=nonce)
-            if result.get('complete'):
-                break
-
-        return result
-
-    def get_backed_up_keys(self):
-        """GET /sys/rekey/backup
-
-        :return:
-        :rtype:
-        """
-        return self._adapter.get('/v1/sys/rekey/backup').json()
-
-    @property
     def ha_status(self):
         """GET /sys/leader
 
@@ -2405,6 +2287,59 @@ class Client(object):
         params['signature_algorithm'] = signature_algorithm
 
         return self._adapter.post(url, json=params).json()
+
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.9.0',
+        new_method=api.SystemBackend.rotate_encryption_key,
+    )
+    def rotate(self):
+        self.sys.rotate_encryption_key()
+
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.9.0',
+        new_method=api.SystemBackend.start_rekey,
+    )
+    def start_rekey(self, secret_shares=5, secret_threshold=3, pgp_keys=None, backup=False):
+        return self.sys.start_rekey(
+            secret_shares=secret_shares,
+            secret_threshold=secret_threshold,
+            pgp_keys=pgp_keys,
+            backup=backup,
+        )
+
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.9.0',
+        new_method=api.SystemBackend.cancel_rekey,
+    )
+    def cancel_rekey(self):
+        return self.sys.cancel_rekey()
+
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.9.0',
+        new_method=api.SystemBackend.rekey,
+    )
+    def rekey(self, key, nonce=None):
+        self.sys.rekey(
+            key=key,
+            nonce=nonce,
+        )
+
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.9.0',
+        new_method=api.SystemBackend.rekey_multi,
+    )
+    def rekey_multi(self, keys, nonce=None):
+        return self.sys.rekey_multi(
+            keys=keys,
+            nonce=nonce,
+        )
+
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.9.0',
+        new_method=api.SystemBackend.read_backup_keys,
+    )
+    def get_backed_up_keys(self):
+        return self.sys.read_backup_keys()
 
     @utils.deprecated_method(
         to_be_removed_in_version='0.9.0',


### PR DESCRIPTION
Part 2.3 of 3 in our large refactor series of how we organize auth methods, secrets engines, and system backend classes. This PR starts the move with "Init" related methods to a new "sys" property used to access instances of these SystemBackend mixin classes under the Client class.