### PR TITLE
Add new sys Leader class

### DIFF
--- a/docs/usage/system_backend/health.rst
+++ b/docs/usage/system_backend/health.rst
@@ -5,7 +5,7 @@ Health
 Read Status
 -----------
 
-:py:meth:`hvac.api.system_backend.health.read_health_status`
+:py:meth:`hvac.api.system_backend.Health.read_health_status`
 
 .. code:: python
 

--- a/docs/usage/system_backend/index.rst
+++ b/docs/usage/system_backend/index.rst
@@ -9,6 +9,7 @@ System Backend
    health
    init
    key
+   leader
 
 .. contents::
 

--- a/docs/usage/system_backend/leader.rst
+++ b/docs/usage/system_backend/leader.rst
@@ -1,0 +1,16 @@
+Leader
+======
+
+
+Read Leader Status
+------------------
+
+:py:meth:`hvac.api.system_backend.Leader.read_leader_status`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+	status = self.client.sys.read_leader_status()
+	print('HA status is: %s' % status['ha_enabled'])

--- a/hvac/api/system_backend/__init__.py
+++ b/hvac/api/system_backend/__init__.py
@@ -6,6 +6,7 @@ from hvac.api.system_backend.auth import Auth
 from hvac.api.system_backend.health import Health
 from hvac.api.system_backend.init import Init
 from hvac.api.system_backend.key import Key
+from hvac.api.system_backend.leader import Leader
 from hvac.api.system_backend.system_backend_mixin import SystemBackendMixin
 from hvac.api.vault_api_category import VaultApiCategory
 
@@ -23,13 +24,14 @@ __all__ = (
 logger = logging.getLogger(__name__)
 
 
-class SystemBackend(VaultApiCategory, Audit, Auth, Health, Init, Key):
+class SystemBackend(VaultApiCategory, Audit, Auth, Health, Init, Key, Leader):
     implemented_classes = [
         Audit,
         Auth,
         Health,
         Init,
         Key,
+        Leader,
     ]
     unimplemented_classes = []
 

--- a/hvac/api/system_backend/leader.py
+++ b/hvac/api/system_backend/leader.py
@@ -1,0 +1,28 @@
+from hvac.api.system_backend.system_backend_mixin import SystemBackendMixin
+
+
+class Leader(SystemBackendMixin):
+
+    @property
+    def ha_status(self):
+        """Read the high availability status and current leader instance of Vault.
+
+        :return: The JSON response returned by read_leader_status()
+        :rtype: dict
+        """
+        return self.read_leader_status()
+
+    def read_leader_status(self):
+        """Read the high availability status and current leader instance of Vault.
+
+        Supported methods:
+            GET: /sys/leader. Produces: 200 application/json
+
+        :return: The JSON response of the request.
+        :rtype: dict
+        """
+        api_path = '/v1/sys/leader'
+        response = self._adapter.get(
+            url=api_path,
+        )
+        return response.json()

--- a/hvac/constants/client.py
+++ b/hvac/constants/client.py
@@ -31,4 +31,8 @@ DEPRECATED_PROPERTIES = {
         to_be_removed_in_version='0.9.0',
         client_property='sys',
     ),
+    'ha_status': dict(
+        to_be_removed_in_version='0.9.0',
+        client_property='sys',
+    ),
 }

--- a/hvac/tests/integration_tests/api/system_backend/test_leader.py
+++ b/hvac/tests/integration_tests/api/system_backend/test_leader.py
@@ -1,0 +1,12 @@
+from unittest import TestCase
+
+from hvac.tests import utils
+
+
+class TestLeader(utils.HvacIntegrationTestCase, TestCase):
+
+    def test_read_health_status(self):
+        self.assertIn(
+            member='ha_enabled',
+            container=self.client.sys.read_leader_status(),
+        )

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -282,15 +282,6 @@ class Client(object):
 
         return result
 
-    @property
-    def ha_status(self):
-        """GET /sys/leader
-
-        :return:
-        :rtype:
-        """
-        return self._adapter.get('/v1/sys/leader').json()
-
     def read_lease(self, lease_id):
         """PUT /sys/leases/lookup
 


### PR DESCRIPTION
Part 2.4 of 3 in our large refactor series of how we organize auth methods, secrets engines, and system backend classes. This PR starts the move with "Init" related methods to a new "sys" property used to access instances of these SystemBackend mixin classes under the Client class.