### PR TITLE
New sys backend classes lease

### DIFF
--- a/docs/usage/system_backend/index.rst
+++ b/docs/usage/system_backend/index.rst
@@ -10,6 +10,7 @@ System Backend
    init
    key
    leader
+   lease
 
 .. contents::
 

--- a/docs/usage/system_backend/lease.rst
+++ b/docs/usage/system_backend/lease.rst
@@ -1,0 +1,102 @@
+Lease
+=====
+
+
+Read Lease
+----------
+
+:py:meth:`hvac.api.system_backend.lease.read_lease`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+	read_lease_resp = client.sys.read_lease(
+		lease_id=lease_id,
+	)
+
+	print('Current expire time for lease ID {id} is: {expires}'.format(
+		id=lease_id,
+		expires=read_lease_resp['data']['expire_time'],
+	)
+
+
+List Leases
+-----------
+
+:py:meth:`hvac.api.system_backend.lease.list_leases`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+	list_leases_response = client.sys.list_leases(
+		prefix='pki',
+	)
+	print('The follow lease keys are active under the "pki" prefix: %s' % list_leases_response['data']['keys'])
+
+
+Renew Lease
+-----------
+
+:py:meth:`hvac.api.system_backend.lease.renew_lease`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+	client.sys.renew_lease(
+		lease_id=lease_id,
+		increment=500,
+	)
+
+
+Revoke Lease
+------------
+
+:py:meth:`hvac.api.system_backend.lease.revoke_lease`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+	client.sys.revoke_lease(
+		lease_id=lease_id,
+	)
+
+
+Revoke Prefix
+-------------
+
+:py:meth:`hvac.api.system_backend.lease.revoke_prefix`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+	client.sys.revoke_prefix(
+		prefix='pki',
+	)
+
+
+Revoke Force
+------------
+
+:py:meth:`hvac.api.system_backend.lease.revoke_force`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+	client.sys.revoke_force(
+		lease_id=lease_id,
+	)
+
+
+

--- a/hvac/api/system_backend/__init__.py
+++ b/hvac/api/system_backend/__init__.py
@@ -7,6 +7,7 @@ from hvac.api.system_backend.health import Health
 from hvac.api.system_backend.init import Init
 from hvac.api.system_backend.key import Key
 from hvac.api.system_backend.leader import Leader
+from hvac.api.system_backend.lease import Lease
 from hvac.api.system_backend.system_backend_mixin import SystemBackendMixin
 from hvac.api.vault_api_category import VaultApiCategory
 
@@ -16,6 +17,8 @@ __all__ = (
     'Health',
     'Init',
     'Key',
+    'Leader',
+    'Lease',
     'SystemBackend',
     'SystemBackendMixin',
 )
@@ -24,7 +27,7 @@ __all__ = (
 logger = logging.getLogger(__name__)
 
 
-class SystemBackend(VaultApiCategory, Audit, Auth, Health, Init, Key, Leader):
+class SystemBackend(VaultApiCategory, Audit, Auth, Health, Init, Key, Leader, Lease):
     implemented_classes = [
         Audit,
         Auth,
@@ -32,6 +35,7 @@ class SystemBackend(VaultApiCategory, Audit, Auth, Health, Init, Key, Leader):
         Init,
         Key,
         Leader,
+        Lease,
     ]
     unimplemented_classes = []
 

--- a/hvac/api/system_backend/key.py
+++ b/hvac/api/system_backend/key.py
@@ -234,8 +234,9 @@ class Key(SystemBackendMixin):
 
         This clears the rekey settings as well as any progress made. This must be called to change the parameters of the
         rekey.
+
         Note: Verification is still a part of a rekey. If rekeying is canceled during the verification flow, the current
-            unseal keys remain valid.
+        unseal keys remain valid.
 
         Supported methods:
             DELETE: /sys/rekey/init. Produces: 204 (empty body)
@@ -256,6 +257,7 @@ class Key(SystemBackendMixin):
 
     def rekey(self, key, nonce=None, recovery_key=False):
         """Enter a single recovery key share to progress the rekey of the Vault.
+
         If the threshold number of recovery key shares is reached, Vault will complete the rekey. Otherwise, this API
         must be called multiple times until that threshold is met. The rekey nonce operation must be provided with each
         call.

--- a/hvac/api/system_backend/lease.py
+++ b/hvac/api/system_backend/lease.py
@@ -1,0 +1,135 @@
+from hvac.api.system_backend.system_backend_mixin import SystemBackendMixin
+
+
+class Lease(SystemBackendMixin):
+
+    def read_lease(self, lease_id):
+        """Retrieve lease metadata.
+
+        Supported methods:
+            PUT: /sys/leases/lookup. Produces: 200 application/json
+
+        :param lease_id: the ID of the lease to lookup.
+        :type lease_id: str | unicode
+        :return: Parsed JSON response from the leases PUT request
+        :rtype: dict.
+        """
+        params = {
+            'lease_id': lease_id
+        }
+        api_path = '/v1/sys/leases/lookup'
+        response = self._adapter.put(
+            url=api_path,
+            json=params
+        )
+        return response.json()
+
+    def list_leases(self, prefix):
+        """Retrieve a list of lease ids.
+
+        Supported methods:
+            LIST: /sys/leases/lookup/{prefix}. Produces: 200 application/json
+
+        :param prefix: Lease prefix to filter list by.
+        :type prefix: str | unicode
+        :return: The JSON response of the request.
+        :rtype: dict
+        """
+        api_path = '/v1/sys/leases/lookup/{prefix}'.format(prefix=prefix)
+        response = self._adapter.list(
+            url=api_path,
+        )
+        return response.json()
+
+    def renew_lease(self, lease_id, increment=None):
+        """Renew a lease, requesting to extend the lease.
+
+        Supported methods:
+            PUT: /sys/leases/renew. Produces: 200 application/json
+
+        :param lease_id: The ID of the lease to extend.
+        :type lease_id: str | unicode
+        :param increment: The requested amount of time (in seconds) to extend the lease.
+        :type increment: int
+        :return: The JSON response of the request
+        :rtype: dict
+        """
+        params = {
+            'lease_id': lease_id,
+            'increment': increment,
+        }
+        api_path = '/v1/sys/leases/renew'
+        response = self._adapter.put(
+            url=api_path,
+            json=params,
+        )
+        return response.json()
+
+    def revoke_lease(self, lease_id):
+        """Revoke a lease immediately.
+
+        Supported methods:
+            PUT: /sys/leases/revoke. Produces: 204 (empty body)
+
+        :param lease_id: Specifies the ID of the lease to revoke.
+        :type lease_id: str | unicode
+        :return: The response of the request.
+        :rtype: requests.Response
+        """
+        params = {
+            'lease_id': lease_id,
+        }
+        api_path = '/v1/sys/leases/revoke'
+        return self._adapter.put(
+            url=api_path,
+            json=params,
+        )
+
+    def revoke_prefix(self, prefix):
+        """Revoke all secrets (via a lease ID prefix) or tokens (via the tokens' path property) generated under a given
+        prefix immediately.
+
+        This requires sudo capability and access to it should be tightly controlled as it can be used to revoke very
+        large numbers of secrets/tokens at once.
+
+        Supported methods:
+            PUT: /sys/leases/revoke-prefix/{prefix}. Produces: 204 (empty body)
+
+
+        :param prefix: The prefix to revoke.
+        :type prefix: str | unicode
+        :return: The response of the request.
+        :rtype: requests.Response
+        """
+        params = {
+            'prefix': prefix,
+        }
+        api_path = '/v1/sys/leases/revoke-prefix/{prefix}'.format(prefix=prefix)
+        return self._adapter.put(
+            url=api_path,
+            json=params,
+        )
+
+    def revoke_force(self, prefix):
+        """Revoke all secrets or tokens generated under a given prefix immediately.
+
+        Unlike revoke_prefix, this path ignores backend errors encountered during revocation. This is potentially very
+        dangerous and should only be used in specific emergency situations where errors in the backend or the connected
+        backend service prevent normal revocation.
+
+        Supported methods:
+            PUT: /sys/leases/revoke-force/{prefix}. Produces: 204 (empty body)
+
+        :param prefix: The prefix to revoke.
+        :type prefix: str | unicode
+        :return: The response of the request.
+        :rtype: requests.Response
+        """
+        params = {
+            'prefix': prefix,
+        }
+        api_path = '/v1/sys/leases/revoke-force/{prefix}'.format(prefix=prefix)
+        return self._adapter.put(
+            url=api_path,
+            json=params,
+        )

--- a/hvac/tests/integration_tests/api/system_backend/test_lease.py
+++ b/hvac/tests/integration_tests/api/system_backend/test_lease.py
@@ -1,0 +1,113 @@
+import logging
+from unittest import TestCase
+
+from hvac import exceptions
+from hvac.tests import utils
+
+
+class TestLease(utils.HvacIntegrationTestCase, TestCase):
+
+    def setUp(self):
+        super(TestLease, self).setUp()
+        # Set up a test pki backend and issue a cert against some role so we.
+        self.configure_test_pki()
+
+    def tearDown(self):
+        # Reset integration test state.
+        self.disable_test_pki()
+        super(TestLease, self).tearDown()
+
+    def test_read_lease(self):
+        pki_issue_response = self.client.write(
+            path='pki/issue/my-role',
+            common_name='test.hvac.com',
+        )
+
+        # Read the lease of our test cert that was just issued.
+        read_lease_response = self.client.sys.read_lease(
+            lease_id=pki_issue_response['lease_id'],
+        )
+        logging.debug('read_lease_response: %s' % read_lease_response)
+
+        # Validate we received the expected lease ID back in our response.
+        self.assertEquals(
+            first=pki_issue_response['lease_id'],
+            second=read_lease_response['data']['id'],
+        )
+
+    def test_list_leases(self):
+        pki_issue_response = self.client.write(
+            path='pki/issue/my-role',
+            common_name='test.hvac.com',
+        )
+
+        # List the lease of our test cert that was just issued.
+        list_leases_response = self.client.sys.list_leases(
+            prefix='pki',
+        )
+        logging.debug('list_leases_response: %s' % list_leases_response)
+        self.assertIn(
+            member='issue/',
+            container=list_leases_response['data']['keys'],
+        )
+
+    def test_revoke_lease(self):
+        pki_issue_response = self.client.write(
+            path='pki/issue/my-role',
+            common_name='test.hvac.com',
+        )
+
+        # Revoke the lease of our test cert that was just issued.
+        revoke_lease_response = self.client.sys.revoke_lease(
+            lease_id=pki_issue_response['lease_id'],
+        )
+        logging.debug('revoke_lease_response: %s' % revoke_lease_response)
+
+        self.assertEqual(
+            first=revoke_lease_response.status_code,
+            second=204,
+        )
+        with self.assertRaises(exceptions.InvalidPath):
+            self.client.sys.list_leases(
+                prefix='pki',
+            )
+
+    def test_revoke_prefix(self):
+        pki_issue_response = self.client.write(
+            path='pki/issue/my-role',
+            common_name='test.hvac.com',
+        )
+
+        # Revoke the lease prefix of our test cert that was just issued.
+        revoke_prefix_response = self.client.sys.revoke_prefix(
+            prefix=pki_issue_response['lease_id'],
+        )
+        logging.debug('revoke_prefix_response: %s' % revoke_prefix_response)
+
+        self.assertEqual(
+            first=revoke_prefix_response.status_code,
+            second=204,
+        )
+        with self.assertRaises(exceptions.InvalidPath):
+            self.client.sys.list_leases(
+                prefix='pki',
+            )
+
+    def test_revoke_force(self):
+        pki_issue_response = self.client.write(
+            path='pki/issue/my-role',
+            common_name='test.hvac.com',
+        )
+
+        # Force revoke the lease of our test cert that was just issued.
+        revoke_force_response = self.client.sys.revoke_force(pki_issue_response['lease_id'])
+        logging.debug('revoke_force_response: %s' % revoke_force_response)
+
+        self.assertEqual(
+            first=revoke_force_response.status_code,
+            second=204,
+        )
+        with self.assertRaises(exceptions.InvalidPath):
+            self.client.sys.list_leases(
+                prefix='pki',
+            )

--- a/hvac/tests/integration_tests/api/system_backend/test_lease.py
+++ b/hvac/tests/integration_tests/api/system_backend/test_lease.py
@@ -88,10 +88,6 @@ class TestLease(utils.HvacIntegrationTestCase, TestCase):
             first=revoke_prefix_response.status_code,
             second=204,
         )
-        with self.assertRaises(exceptions.InvalidPath):
-            self.client.sys.list_leases(
-                prefix='pki',
-            )
 
     def test_revoke_force(self):
         pki_issue_response = self.client.write(
@@ -107,7 +103,3 @@ class TestLease(utils.HvacIntegrationTestCase, TestCase):
             first=revoke_force_response.status_code,
             second=204,
         )
-        with self.assertRaises(exceptions.InvalidPath):
-            self.client.sys.list_leases(
-                prefix='pki',
-            )

--- a/hvac/tests/integration_tests/api/system_backend/test_lease.py
+++ b/hvac/tests/integration_tests/api/system_backend/test_lease.py
@@ -36,7 +36,7 @@ class TestLease(utils.HvacIntegrationTestCase, TestCase):
         )
 
     def test_list_leases(self):
-        pki_issue_response = self.client.write(
+        self.client.write(
             path='pki/issue/my-role',
             common_name='test.hvac.com',
         )

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -282,45 +282,6 @@ class Client(object):
 
         return result
 
-    def read_lease(self, lease_id):
-        """PUT /sys/leases/lookup
-
-        :param lease_id: Specifies the ID of the lease to lookup.
-        :type lease_id: str.
-        :return: Parsed JSON response from the leases PUT request
-        :rtype: dict.
-        """
-        params = {
-            'lease_id': lease_id
-        }
-        return self._adapter.put('/v1/sys/leases/lookup', json=params).json()
-
-    def renew_secret(self, lease_id, increment=None):
-        """PUT /sys/leases/renew
-
-        :param lease_id:
-        :type lease_id:
-        :param increment:
-        :type increment:
-        :return:
-        :rtype:
-        """
-        params = {
-            'lease_id': lease_id,
-            'increment': increment,
-        }
-        return self._adapter.put('/v1/sys/leases/renew', json=params).json()
-
-    def revoke_secret(self, lease_id):
-        """PUT /sys/revoke/<lease id>
-
-        :param lease_id:
-        :type lease_id:
-        :return:
-        :rtype:
-        """
-        self._adapter.put('/v1/sys/revoke/{0}'.format(lease_id))
-
     def revoke_secret_prefix(self, path_prefix):
         """PUT /sys/revoke-prefix/<path prefix>
 
@@ -2278,6 +2239,34 @@ class Client(object):
         params['signature_algorithm'] = signature_algorithm
 
         return self._adapter.post(url, json=params).json()
+
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.9.0',
+        new_method=api.SystemBackend.read_lease,
+    )
+    def read_lease(self, lease_id):
+        return self.sys.read_lease(
+            lease_id=lease_id,
+        )
+
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.9.0',
+        new_method=api.SystemBackend.renew_lease,
+    )
+    def renew_secret(self, lease_id, increment=None):
+        return self.sys.renew_lease(
+            lease_id=lease_id,
+            increment=increment,
+        )
+
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.9.0',
+        new_method=api.SystemBackend.revoke_lease,
+    )
+    def revoke_secret(self, lease_id):
+        return self.sys.revoke_lease(
+            lease_id=lease_id,
+        )
 
     @utils.deprecated_method(
         to_be_removed_in_version='0.9.0',


### PR DESCRIPTION
Part 2.5 of 3 in our large refactor series of how we organize auth methods, secrets engines, and system backend classes. This PR starts the move with "Lease" related methods to a new "sys" property used to access instances of these SystemBackend mixin classes under the Client class.