### PR TITLE
New sys backend classes mount

### DIFF
--- a/docs/usage/system_backend/mount.rst
+++ b/docs/usage/system_backend/mount.rst
@@ -1,0 +1,68 @@
+Mount
+=====
+
+
+List Mounted Secrets Engines
+----------------------------
+
+:py:meth:`hvac.api.system_backend.mount.read_status`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+
+Enable Secrets Engine
+---------------------
+
+:py:meth:`hvac.api.system_backend.mount.read_status`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+
+Disable Secrets Engine
+----------------------
+
+:py:meth:`hvac.api.system_backend.mount.read_status`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+
+Read Mount Configuration
+------------------------
+
+:py:meth:`hvac.api.system_backend.mount.read_status`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+
+Tune Mount Configuration
+------------------------
+
+:py:meth:`hvac.api.system_backend.mount.read_status`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+
+Move Backend
+------------
+
+:py:meth:`hvac.api.system_backend.mount.read_status`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()

--- a/hvac/api/system_backend/__init__.py
+++ b/hvac/api/system_backend/__init__.py
@@ -8,6 +8,7 @@ from hvac.api.system_backend.init import Init
 from hvac.api.system_backend.key import Key
 from hvac.api.system_backend.leader import Leader
 from hvac.api.system_backend.lease import Lease
+from hvac.api.system_backend.mount import Mount
 from hvac.api.system_backend.system_backend_mixin import SystemBackendMixin
 from hvac.api.vault_api_category import VaultApiCategory
 
@@ -19,6 +20,7 @@ __all__ = (
     'Key',
     'Leader',
     'Lease',
+    'Mount',
     'SystemBackend',
     'SystemBackendMixin',
 )
@@ -27,7 +29,7 @@ __all__ = (
 logger = logging.getLogger(__name__)
 
 
-class SystemBackend(VaultApiCategory, Audit, Auth, Health, Init, Key, Leader, Lease):
+class SystemBackend(VaultApiCategory, Audit, Auth, Health, Init, Key, Leader, Lease, Mount):
     implemented_classes = [
         Audit,
         Auth,
@@ -36,6 +38,7 @@ class SystemBackend(VaultApiCategory, Audit, Auth, Health, Init, Key, Leader, Le
         Key,
         Leader,
         Lease,
+        Mount,
     ]
     unimplemented_classes = []
 

--- a/hvac/api/system_backend/mount.py
+++ b/hvac/api/system_backend/mount.py
@@ -1,0 +1,193 @@
+from hvac.api.system_backend.system_backend_mixin import SystemBackendMixin
+
+
+class Mount(SystemBackendMixin):
+
+    def list_mounted_secrets_engines(self):
+        """Lists all the mounted secrets engines.
+
+        Supported methods:
+            POST: /sys/mounts. Produces: 200 application/json
+
+        :return: JSON response of the request.
+        :rtype: dict
+        """
+        response = self._adapter.get('/v1/sys/mounts')
+        return response.json()
+
+    def enable_secrets_engine(self, backend_type, path=None, description=None, config=None, plugin_name=None,
+                              options=None, local=False, seal_wrap=False):
+        """Enable a new secrets engine at the given path.
+
+        Supported methods:
+            POST: /sys/mounts/{path}. Produces: 204 (empty body)
+
+        :param backend_type: The name of the backend type, such as "github" or "token".
+        :type backend_type: str | unicode
+        :param path: The path to mount the method on. If not provided, defaults to the value of the "method_type"
+            argument.
+        :type path: str | unicode
+        :param description: A human-friendly description of the mount.
+        :type description: str | unicode
+        :param config: Configuration options for this mount. These are the possible values:
+
+            * **default_lease_ttl**: The default lease duration, specified as a string duration like "5s" or "30m".
+            * **max_lease_ttl**: The maximum lease duration, specified as a string duration like "5s" or "30m".
+            * **force_no_cache**: Disable caching.
+            * **plugin_name**: The name of the plugin in the plugin catalog to use.
+            * **audit_non_hmac_request_keys**: Comma-separated list of keys that will not be HMAC'd by audit devices in
+              the request data object.
+            * **audit_non_hmac_response_keys**: Comma-separated list of keys that will not be HMAC'd by audit devices in
+              the response data object.
+            * **listing_visibility**: Specifies whether to show this mount in the UI-specific listing endpoint. ("unauth" or "hidden")
+            * **passthrough_request_headers**: Comma-separated list of headers to whitelist and pass from the request to
+              the backend.
+        :type config: dict
+        :param options: Specifies mount type specific options that are passed to the backend.
+
+            * **version**: <KV> The version of the KV to mount. Set to "2" for mount KV v2.
+        :type options: dict
+        :param plugin_name: Specifies the name of the plugin to use based from the name in the plugin catalog. Applies only to plugin backends.
+        :type plugin_name: str | unicode
+        :param local: <Vault enterprise only> Specifies if the auth method is a local only. Local auth methods are not
+            replicated nor (if a secondary) removed by replication.
+        :type local: bool
+        :param seal_wrap: <Vault enterprise only> Enable seal wrapping for the mount.
+        :type seal_wrap: bool
+        :return: The response of the request.
+        :rtype: requests.Response
+        """
+        if path is None:
+            path = backend_type
+
+        params = {
+            'type': backend_type,
+            'description': description,
+            'config': config,
+            'options': options,
+            'plugin_name': plugin_name,
+            'local': local,
+            'seal_wrap': seal_wrap,
+        }
+
+        api_path = '/v1/sys/mounts/{path}'.format(path=path)
+        return self._adapter.post(
+            url=api_path,
+            json=params,
+        )
+
+    def disable_secrets_engine(self, path):
+        """Disable the mount point specified by the provided path.
+
+        Supported methods:
+            DELETE: /sys/mounts/{path}. Produces: 204 (empty body)
+
+        :param path: Specifies the path where the secrets engine will be mounted. This is specified as part of the URL.
+        :type path: str | unicode
+        :return: The response of the request.
+        :rtype: requests.Response
+        """
+        api_path = '/v1/sys/mounts/{path}'.format(path=path)
+        return self._adapter.delete(
+            url=api_path,
+        )
+
+    def read_mount_configuration(self, path):
+        """Read the given mount's configuration.
+
+        Unlike the mounts endpoint, this will return the current time in seconds for each TTL, which may be the system
+        default or a mount-specific value.
+
+        Supported methods:
+            GET: /sys/mounts/{path}/tune. Produces: 200 application/json
+
+        :param path: Specifies the path where the secrets engine will be mounted. This is specified as part of the URL.
+        :type path: str | unicode
+        :return: The JSON response of the request.
+        :rtype: requests.Response
+        """
+        api_path = '/v1/sys/mounts/{path}/tune'.format(path=path)
+        response = self._adapter.get(
+            url=api_path,
+        )
+        return response.json()
+
+    def tune_mount_configuration(self, path, default_lease_ttl=None, max_lease_ttl=None, description=None,
+                                 audit_non_hmac_request_keys=None, audit_non_hmac_response_keys=None,
+                                 listing_visibility=None, passthrough_request_headers=None):
+        """Tune configuration parameters for a given mount point.
+
+        Supported methods:
+            POST: /sys/mounts/{path}/tune. Produces: 204 (empty body)
+
+        :param path: Specifies the path where the secrets engine will be mounted. This is specified as part of the URL.
+        :type path: str | unicode
+        :param mount_point: The path the associated secret backend is mounted
+        :type mount_point: str
+        :param description: Specifies the description of the mount. This overrides the current stored value, if any.
+        :type description: str
+        :param default_lease_ttl: Default time-to-live. This overrides the global default. A value of 0 is equivalent to
+            the system default TTL
+        :type default_lease_ttl: int
+        :param max_lease_ttl: Maximum time-to-live. This overrides the global default. A value of 0 are equivalent and
+            set to the system max TTL.
+        :type max_lease_ttl: int
+        :param audit_non_hmac_request_keys: Specifies the comma-separated list of keys that will not be HMAC'd by audit
+            devices in the request data object.
+        :type audit_non_hmac_request_keys: list
+        :param audit_non_hmac_response_keys: Specifies the comma-separated list of keys that will not be HMAC'd by audit
+            devices in the response data object.
+        :type audit_non_hmac_response_keys: list
+        :param listing_visibility: Speficies whether to show this mount in the UI-specific listing endpoint. Valid
+            values are "unauth" or "".
+        :type listing_visibility: str
+        :param passthrough_request_headers: Comma-separated list of headers to whitelist and pass from the request
+            to the backend.
+        :type passthrough_request_headers: str
+        :return: The response from the request.
+        :rtype: request.Response
+        """
+        # All parameters are optional for this method. Until/unless we include input validation, we simply loop over the
+        # parameters and add which parameters are set.
+        optional_parameters = [
+            'default_lease_ttl',
+            'max_lease_ttl',
+            'description',
+            'audit_non_hmac_request_keys',
+            'audit_non_hmac_response_keys',
+            'listing_visibility',
+            'passthrough_request_headers',
+        ]
+        params = {}
+        for optional_parameter in optional_parameters:
+            if locals().get(optional_parameter) is not None:
+                params[optional_parameter] = locals().get(optional_parameter)
+
+        api_path = '/v1/sys/mounts/{path}/tune'.format(path=path)
+        return self._adapter.post(
+            url=api_path,
+            json=params,
+        )
+
+    def move_backend(self, from_path, to_path):
+        """Move an already-mounted backend to a new mount point.
+
+        Supported methods:
+            POST: /sys/remount. Produces: 204 (empty body)
+
+        :param from_path: Specifies the previous mount point.
+        :type from_path: str | unicode
+        :param to_path: Specifies the new destination mount point.
+        :type to_path: str | unicode
+        :return: The response of the request.
+        :rtype: requests.Response
+        """
+        params = {
+            'from': from_path,
+            'to': to_path,
+        }
+        api_path = '/v1/sys/remount'
+        return self._adapter.post(
+            url=api_path,
+            json=params,
+        )

--- a/hvac/tests/integration_tests/api/system_backend/test_lease.py
+++ b/hvac/tests/integration_tests/api/system_backend/test_lease.py
@@ -10,11 +10,11 @@ class TestLease(utils.HvacIntegrationTestCase, TestCase):
     def setUp(self):
         super(TestLease, self).setUp()
         # Set up a test pki backend and issue a cert against some role so we.
-        self.configure_test_pki()
+        self.configure_pki()
 
     def tearDown(self):
         # Reset integration test state.
-        self.disable_test_pki()
+        self.disable_pki()
         super(TestLease, self).tearDown()
 
     def test_read_lease(self):

--- a/hvac/tests/integration_tests/api/system_backend/test_mount.py
+++ b/hvac/tests/integration_tests/api/system_backend/test_mount.py
@@ -1,0 +1,66 @@
+from unittest import TestCase
+
+from hvac.tests import utils
+
+
+class TestMount(utils.HvacIntegrationTestCase, TestCase):
+
+    def test_secret_backend_manipulation(self):
+        self.assertNotIn(
+            member='test/',
+            container=self.client.sys.list_mounted_secrets_engines()['data'],
+        )
+
+        self.client.sys.enable_secrets_engine(
+            backend_type='generic',
+            path='test',
+        )
+        self.assertIn(
+            member='test/',
+            container=self.client.sys.list_mounted_secrets_engines()['data'],
+        )
+
+        secret_backend_tuning = self.client.sys.read_mount_configuration(path='test')
+        self.assertEqual(secret_backend_tuning['data']['max_lease_ttl'], 2764800)
+        self.assertEqual(secret_backend_tuning['data']['default_lease_ttl'], 2764800)
+
+        self.client.sys.tune_mount_configuration(
+            path='test',
+            default_lease_ttl='3600s',
+            max_lease_ttl='8600s',
+        )
+        secret_backend_tuning = self.client.sys.read_mount_configuration(path='test')
+
+        self.assertIn('max_lease_ttl', secret_backend_tuning['data'])
+        self.assertEqual(secret_backend_tuning['data']['max_lease_ttl'], 8600)
+        self.assertIn('default_lease_ttl', secret_backend_tuning['data'])
+        self.assertEqual(secret_backend_tuning['data']['default_lease_ttl'], 3600)
+
+        self.client.sys.move_backend(
+            from_path='test',
+            to_path='foobar',
+        )
+        self.assertNotIn(
+            member='test/',
+            container=self.client.sys.list_mounted_secrets_engines()['data'],
+        )
+        self.assertIn(
+            member='foobar/',
+            container=self.client.sys.list_mounted_secrets_engines()['data'],
+        )
+
+        self.client.token = self.manager.root_token
+        self.client.sys.disable_secrets_engine(
+            path='foobar'
+        )
+        self.assertNotIn(
+            member='foobar/',
+            container=self.client.sys.list_mounted_secrets_engines()['data'],
+        )
+
+    def test_get_secret_backend_tuning(self):
+        secret_backend_tuning = self.client.sys.read_mount_configuration(path='secret')
+        self.assertIn(
+            member='default_lease_ttl',
+            container=secret_backend_tuning['data'],
+        )

--- a/hvac/tests/integration_tests/v1/test_integration.py
+++ b/hvac/tests/integration_tests/v1/test_integration.py
@@ -26,7 +26,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
         self.client.delete('secret/test-list/foo')
 
     def test_write_with_response(self):
-        if 'transit/' in self.client.list_secret_backends():
+        if 'transit/' in self.client.list_secret_backends()['data']:
             self.client.disable_secret_backend('transit')
         self.client.enable_secret_backend('transit')
 
@@ -250,7 +250,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
         self.client.disable_auth_backend('app-id')
 
     def test_transit_read_write(self):
-        if 'transit/' in self.client.list_secret_backends():
+        if 'transit/' in self.client.list_secret_backends()['data']:
             self.client.disable_secret_backend('transit')
         self.client.enable_secret_backend('transit')
 
@@ -269,7 +269,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
         assert not result['data']['exportable']
 
     def test_transit_list_keys(self):
-        if 'transit/' in self.client.list_secret_backends():
+        if 'transit/' in self.client.list_secret_backends()['data']:
             self.client.disable_secret_backend('transit')
         self.client.enable_secret_backend('transit')
 
@@ -281,7 +281,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
         assert result['data']['keys'] == ["foo1", "foo2", "foo3"]
 
     def test_transit_update_delete_keys(self):
-        if 'transit/' in self.client.list_secret_backends():
+        if 'transit/' in self.client.list_secret_backends()['data']:
             self.client.disable_secret_backend('transit')
         self.client.enable_secret_backend('transit')
 
@@ -300,7 +300,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
             assert False
 
     def test_transit_rotate_key(self):
-        if 'transit/' in self.client.list_secret_backends():
+        if 'transit/' in self.client.list_secret_backends()['data']:
             self.client.disable_secret_backend('transit')
         self.client.enable_secret_backend('transit')
 
@@ -315,7 +315,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
         assert '3' in response['data']['keys']
 
     def test_transit_export_key(self):
-        if 'transit/' in self.client.list_secret_backends():
+        if 'transit/' in self.client.list_secret_backends()['data']:
             self.client.disable_secret_backend('transit')
         self.client.enable_secret_backend('transit')
 
@@ -324,7 +324,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
         assert response is not None
 
     def test_transit_encrypt_data(self):
-        if 'transit/' in self.client.list_secret_backends():
+        if 'transit/' in self.client.list_secret_backends()['data']:
             self.client.disable_secret_backend('transit')
         self.client.enable_secret_backend('transit')
 
@@ -334,7 +334,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
         assert plaintext_resp == 'abbaabba'
 
     def test_transit_rewrap_data(self):
-        if 'transit/' in self.client.list_secret_backends():
+        if 'transit/' in self.client.list_secret_backends()['data']:
             self.client.disable_secret_backend('transit')
         self.client.enable_secret_backend('transit')
 
@@ -347,7 +347,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
         assert plaintext_resp == 'abbaabba'
 
     def test_transit_generate_data_key(self):
-        if 'transit/' in self.client.list_secret_backends():
+        if 'transit/' in self.client.list_secret_backends()['data']:
             self.client.disable_secret_backend('transit')
         self.client.enable_secret_backend('transit')
 
@@ -361,7 +361,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
         assert 'plaintext' not in response_ciphertext
 
     def test_transit_generate_rand_bytes(self):
-        if 'transit/' in self.client.list_secret_backends():
+        if 'transit/' in self.client.list_secret_backends()['data']:
             self.client.disable_secret_backend('transit')
         self.client.enable_secret_backend('transit')
 
@@ -369,7 +369,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
         assert response_data
 
     def test_transit_hash_data(self):
-        if 'transit/' in self.client.list_secret_backends():
+        if 'transit/' in self.client.list_secret_backends()['data']:
             self.client.disable_secret_backend('transit')
         self.client.enable_secret_backend('transit')
 
@@ -380,7 +380,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
         assert len(response_hash) == 128
 
     def test_transit_generate_verify_hmac(self):
-        if 'transit/' in self.client.list_secret_backends():
+        if 'transit/' in self.client.list_secret_backends()['data']:
             self.client.disable_secret_backend('transit')
         self.client.enable_secret_backend('transit')
 
@@ -398,7 +398,7 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
         assert verify_resp
 
     def test_transit_sign_verify_signature_data(self):
-        if 'transit/' in self.client.list_secret_backends():
+        if 'transit/' in self.client.list_secret_backends()['data']:
             self.client.disable_secret_backend('transit')
         self.client.enable_secret_backend('transit')
 
@@ -811,11 +811,11 @@ class IntegrationTest(utils.HvacIntegrationTestCase, TestCase):
 
     @skipIf(utils.skip_if_vault_version('0.10.0'), "KV version 2 secret engine not available before Vault version 0.10.0")
     def test_kv2_secret_backend(self):
-        if 'test/' in self.client.list_secret_backends():
+        if 'test/' in self.client.list_secret_backends()['data']:
             self.client.disable_secret_backend('test')
         self.client.enable_secret_backend('kv', mount_point='test', options={'version': '2'})
 
-        secret_backends = self.client.list_secret_backends()
+        secret_backends = self.client.list_secret_backends()['data']
 
         assert 'test/' in secret_backends
         self.assertDictEqual(secret_backends['test/']['options'], {'version': '2'})

--- a/hvac/tests/integration_tests/v1/test_system_backend.py
+++ b/hvac/tests/integration_tests/v1/test_system_backend.py
@@ -67,30 +67,30 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
         self.assertNotIn('github/', self.client.list_auth_backends()['data'])
 
     def test_secret_backend_manipulation(self):
-        self.assertNotIn('test/', self.client.list_secret_backends())
+        self.assertNotIn('test/', self.client.list_secret_backends()['data'])
 
         self.client.enable_secret_backend('generic', mount_point='test')
-        self.assertIn('test/', self.client.list_secret_backends())
+        self.assertIn('test/', self.client.list_secret_backends()['data'])
 
         secret_backend_tuning = self.client.get_secret_backend_tuning('generic', mount_point='test')
-        self.assertEqual(secret_backend_tuning['max_lease_ttl'], 2764800)
-        self.assertEqual(secret_backend_tuning['default_lease_ttl'], 2764800)
+        self.assertEqual(secret_backend_tuning['data']['max_lease_ttl'], 2764800)
+        self.assertEqual(secret_backend_tuning['data']['default_lease_ttl'], 2764800)
 
         self.client.tune_secret_backend('generic', mount_point='test', default_lease_ttl='3600s', max_lease_ttl='8600s')
         secret_backend_tuning = self.client.get_secret_backend_tuning('generic', mount_point='test')
 
-        self.assertIn('max_lease_ttl', secret_backend_tuning)
-        self.assertEqual(secret_backend_tuning['max_lease_ttl'], 8600)
-        self.assertIn('default_lease_ttl', secret_backend_tuning)
-        self.assertEqual(secret_backend_tuning['default_lease_ttl'], 3600)
+        self.assertIn('max_lease_ttl', secret_backend_tuning['data'])
+        self.assertEqual(secret_backend_tuning['data']['max_lease_ttl'], 8600)
+        self.assertIn('default_lease_ttl', secret_backend_tuning['data'])
+        self.assertEqual(secret_backend_tuning['data']['default_lease_ttl'], 3600)
 
         self.client.remount_secret_backend('test', 'foobar')
-        self.assertNotIn('test/', self.client.list_secret_backends())
-        self.assertIn('foobar/', self.client.list_secret_backends())
+        self.assertNotIn('test/', self.client.list_secret_backends()['data'])
+        self.assertIn('foobar/', self.client.list_secret_backends()['data'])
 
         self.client.token = self.manager.root_token
         self.client.disable_secret_backend('foobar')
-        self.assertNotIn('foobar/', self.client.list_secret_backends())
+        self.assertNotIn('foobar/', self.client.list_secret_backends()['data'])
 
     def test_audit_backend_manipulation(self):
         self.assertNotIn('tmpfile/', self.client.list_audit_backends())
@@ -358,7 +358,7 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
 
     def test_read_lease(self):
         # Set up a test pki backend and issue a cert against some role so we.
-        self.configure_test_pki()
+        self.configure_pki()
         pki_issue_response = self.client.write(
             path='pki/issue/my-role',
             common_name='test.hvac.com',
@@ -374,7 +374,7 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
         )
 
         # Reset integration test state.
-        self.disable_test_pki()
+        self.disable_pki()
 
     @parameterized.expand([
         param(
@@ -423,7 +423,7 @@ class TestSystemBackend(utils.HvacIntegrationTestCase, TestCase):
         secret_backend_tuning = self.client.get_secret_backend_tuning('secret')
         self.assertIn(
             member='default_lease_ttl',
-            container=secret_backend_tuning,
+            container=secret_backend_tuning['data'],
         )
 
     def test_get_backed_up_keys(self):

--- a/hvac/tests/utils.py
+++ b/hvac/tests/utils.py
@@ -322,7 +322,7 @@ class HvacIntegrationTestCase(object):
         self.client.set_policy(name, text)
         return text, obj
 
-    def configure_test_pki(self, common_name='hvac.com', role_name='my-role', mount_point='pki'):
+    def configure_pki(self, common_name='hvac.com', role_name='my-role', mount_point='pki'):
         """Helper function to configure a pki backend for integration tests that need to work with lease IDs.
 
         :param common_name: Common name to configure in the pki backend
@@ -357,7 +357,7 @@ class HvacIntegrationTestCase(object):
             max_ttl='72h',
         )
 
-    def disable_test_pki(self, mount_point='pki'):
+    def disable_pki(self, mount_point='pki'):
         """Disable a previously configured pki backend.
 
         :param mount_point: The path the pki backend is mounted under.

--- a/hvac/utils.py
+++ b/hvac/utils.py
@@ -131,7 +131,10 @@ def getattr_with_deprecated_properties(obj, item, deprecated_properties):
         client_property = getattr(obj, deprecated_properties[item]['client_property'])
         return getattr(client_property, deprecated_properties[item].get('new_property', item))
 
-    raise AttributeError
+    raise AttributeError("'{class_name}' has no attribute '{item}'".format(
+        class_name=obj.__class__.__name__,
+        item=item,
+    ))
 
 
 def deprecated_method(to_be_removed_in_version, new_method=None):

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -300,140 +300,6 @@ class Client(object):
         """
         self._adapter.put('/v1/auth/token/revoke-self')
 
-    def list_secret_backends(self):
-        """GET /sys/mounts
-
-        :return: List of all the mounted secrets engines.
-        :rtype: dict
-        """
-        list_secret_backends_response = self._adapter.get('/v1/sys/mounts').json()
-        secret_backends = list_secret_backends_response['data']
-        return secret_backends
-
-    def enable_secret_backend(self, backend_type, description=None, mount_point=None, config=None, options=None):
-        """POST /sys/mounts/<mount point>
-
-        :param backend_type:
-        :type backend_type:
-        :param description:
-        :type description:
-        :param mount_point:
-        :type mount_point:
-        :param config:
-        :type config:
-        :param options:
-        :type options:
-        :return:
-        :rtype:
-        """
-        if not mount_point:
-            mount_point = backend_type
-
-        params = {
-            'type': backend_type,
-            'description': description,
-            'config': config,
-            'options': options,
-        }
-
-        self._adapter.post('/v1/sys/mounts/{0}'.format(mount_point), json=params)
-
-    def tune_secret_backend(self, backend_type, mount_point=None, default_lease_ttl=None, max_lease_ttl=None, description=None,
-                            audit_non_hmac_request_keys=None, audit_non_hmac_response_keys=None, listing_visibility=None,
-                            passthrough_request_headers=None):
-        """POST /sys/mounts/<mount point>/tune
-
-        :param backend_type: Type of the secret backend to modify
-        :type backend_type: str
-        :param mount_point: The path the associated secret backend is mounted
-        :type mount_point: str
-        :param description: Specifies the description of the mount. This overrides the current stored value, if any.
-        :type description: str
-        :param default_lease_ttl: Default time-to-live. This overrides the global default. A value of 0 is equivalent to
-            the system default TTL
-        :type default_lease_ttl: int
-        :param max_lease_ttl: Maximum time-to-live. This overrides the global default. A value of 0 are equivalent and
-            set to the system max TTL.
-        :type max_lease_ttl: int
-        :param audit_non_hmac_request_keys: Specifies the comma-separated list of keys that will not be HMAC'd by audit
-            devices in the request data object.
-        :type audit_non_hmac_request_keys: list
-        :param audit_non_hmac_response_keys: Specifies the comma-separated list of keys that will not be HMAC'd by audit
-            devices in the response data object.
-        :type audit_non_hmac_response_keys: list
-        :param listing_visibility: Specifies whether to show this mount in the UI-specific listing endpoint. Valid
-            values are "unauth" or "".
-        :type listing_visibility: str
-        :param passthrough_request_headers: Comma-separated list of headers to whitelist and pass from the request
-            to the backend.
-        :type passthrough_request_headers: str
-
-        :return: The response from Vault
-        :rtype: request.Response
-        """
-
-        if not mount_point:
-            mount_point = backend_type
-        # All parameters are optional for this method. Until/unless we include input validation, we simply loop over the
-        # parameters and add which parameters are set.
-        optional_parameters = [
-            'default_lease_ttl',
-            'max_lease_ttl',
-            'description',
-            'audit_non_hmac_request_keys',
-            'audit_non_hmac_response_keys',
-            'listing_visibility',
-            'passthrough_request_headers',
-        ]
-        params = {}
-        for optional_parameter in optional_parameters:
-            if locals().get(optional_parameter) is not None:
-                params[optional_parameter] = locals().get(optional_parameter)
-        return self._adapter.post('/v1/sys/mounts/{0}/tune'.format(mount_point), json=params)
-
-    def get_secret_backend_tuning(self, backend_type, mount_point=None):
-        """GET /sys/mounts/<mount point>/tune
-
-        :param backend_type: Name of the secret engine. E.g. "aws".
-        :type backend_type: str | unicode
-        :param mount_point: Alternate argument for backend_type.
-        :type mount_point: str | unicode
-        :return: The specified mount's configuration.
-        :rtype: dict
-        """
-        if not mount_point:
-            mount_point = backend_type
-
-        read_config_response = self._adapter.get('/v1/sys/mounts/{0}/tune'.format(mount_point)).json()
-        return read_config_response['data']
-
-    def disable_secret_backend(self, mount_point):
-        """DELETE /sys/mounts/<mount point>
-
-        :param mount_point:
-        :type mount_point:
-        :return:
-        :rtype:
-        """
-        self._adapter.delete('/v1/sys/mounts/{0}'.format(mount_point))
-
-    def remount_secret_backend(self, from_mount_point, to_mount_point):
-        """POST /sys/remount
-
-        :param from_mount_point:
-        :type from_mount_point:
-        :param to_mount_point:
-        :type to_mount_point:
-        :return:
-        :rtype:
-        """
-        params = {
-            'from': from_mount_point,
-            'to': to_mount_point,
-        }
-
-        self._adapter.post('/v1/sys/remount', json=params)
-
     def list_policies(self):
         """GET /sys/policy
 
@@ -2242,6 +2108,86 @@ class Client(object):
 
     @utils.deprecated_method(
         to_be_removed_in_version='0.9.0',
+        new_method=api.SystemBackend.list_mounted_secrets_engines,
+    )
+    def list_secret_backends(self):
+        return self.sys.list_mounted_secrets_engines()
+
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.9.0',
+        new_method=api.SystemBackend.enable_secrets_engine,
+    )
+    def enable_secret_backend(self, backend_type, description=None, mount_point=None, config=None, options=None):
+        return self.sys.enable_secrets_engine(
+            backend_type=backend_type,
+            path=mount_point,
+            description=description,
+            config=config,
+            options=options,
+        )
+
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.9.0',
+        new_method=api.SystemBackend.tune_mount_configuration,
+    )
+    def tune_secret_backend(self, backend_type, mount_point=None, default_lease_ttl=None, max_lease_ttl=None, description=None,
+                            audit_non_hmac_request_keys=None, audit_non_hmac_response_keys=None, listing_visibility=None,
+                            passthrough_request_headers=None):
+        if not mount_point:
+            mount_point = backend_type
+
+        return self.sys.tune_mount_configuration(
+            path=mount_point,
+            default_lease_ttl=default_lease_ttl,
+            max_lease_ttl=max_lease_ttl,
+            description=description,
+            audit_non_hmac_request_keys=audit_non_hmac_request_keys,
+            audit_non_hmac_response_keys=audit_non_hmac_response_keys,
+            listing_visibility=listing_visibility,
+            passthrough_request_headers=passthrough_request_headers,
+        )
+
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.9.0',
+        new_method=api.SystemBackend.read_mount_configuration,
+    )
+    def get_secret_backend_tuning(self, backend_type, mount_point=None):
+        """GET /sys/mounts/<mount point>/tune
+
+        :param backend_type: Name of the secret engine. E.g. "aws".
+        :type backend_type: str | unicode
+        :param mount_point: Alternate argument for backend_type.
+        :type mount_point: str | unicode
+        :return: The specified mount's configuration.
+        :rtype: dict
+        """
+        if not mount_point:
+            mount_point = backend_type
+        return self.sys.read_mount_configuration(
+            path=mount_point,
+        )
+
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.9.0',
+        new_method=api.SystemBackend.disable_secrets_engine,
+    )
+    def disable_secret_backend(self, mount_point):
+        return self.sys.disable_secrets_engine(
+            path=mount_point,
+        )
+
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.9.0',
+        new_method=api.SystemBackend.move_backend,
+    )
+    def remount_secret_backend(self, from_mount_point, to_mount_point):
+        return self.sys.move_backend(
+            from_path=from_mount_point,
+            to_path=to_mount_point,
+        )
+
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.9.0',
         new_method=api.SystemBackend.read_lease,
     )
     def read_lease(self, lease_id):
@@ -2385,6 +2331,7 @@ class Client(object):
             description=description,
             config=config,
             path=mount_point,
+            plugin_name=plugin_name,
         )
 
     @utils.deprecated_method(
@@ -2412,15 +2359,6 @@ class Client(object):
         new_method=api.SystemBackend.read_auth_method_tuning,
     )
     def get_auth_backend_tuning(self, backend_type, mount_point=None):
-        """GET /sys/auth/<mount point>/tune
-
-        :param backend_type: Name of the auth backend to modify (e.g., token, approle, etc.)
-        :type backend_type: str.
-        :param mount_point: The path the associated auth backend is mounted under.
-        :type mount_point: str.
-        :return: The JSON response from Vault
-        :rtype: dict.
-        """
         if not mount_point:
             mount_point = backend_type
         return self.sys.read_auth_method_tuning(


### PR DESCRIPTION
Part 2.6 of 3 in our large refactor series of how we organize auth methods, secrets engines, and system backend classes. This PR starts the move with "Lease" related methods to a new "sys" property used to access instances of these SystemBackend mixin classes under the Client class.