### PR TITLE
Add new sys Policy class

### DIFF
--- a/docs/usage/system_backend/index.rst
+++ b/docs/usage/system_backend/index.rst
@@ -11,6 +11,7 @@ System Backend
    key
    leader
    lease
+   policy
 
 .. contents::
 

--- a/docs/usage/system_backend/policy.rst
+++ b/docs/usage/system_backend/policy.rst
@@ -1,0 +1,86 @@
+Policy
+======
+
+
+List Policies
+-------------
+
+:py:meth:`hvac.api.system_backend.policy.list_policies`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+	list_policies_resp = client.sys.list_policies()['data']['policies']
+	print('List of currently configured policies: %s' % list_policies_resp)
+
+
+Read Policy
+-----------
+
+:py:meth:`hvac.api.system_backend.policy.read_policy`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+	hvac_policy_rules = client.sys.read_policy(name='hvac-policy')['data']['rules']
+	print('Rules for the hvac policy are: %s' % hvac_policy_rules)
+
+
+Get Policy
+----------
+
+:py:meth:`hvac.api.system_backend.policy.create_or_update_policy`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+	hvac_policy_rules = client.sys.get_policy(name='hvac-policy', parse=True)
+	print('Rules for the hvac policy are: %s' % hvac_policy_rules)
+
+
+
+Create Or Update Policy
+-----------------------
+
+:py:meth:`hvac.api.system_backend.policy.read_status`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+	policy = '''
+		path "sys" {
+			policy = "deny"
+		}
+		path "secret" {
+			policy = "write"
+		}
+	'''
+	client.sys.create_or_update_policy(
+		name='secret-writer',
+		policy=policy,
+	)
+
+
+Delete Policy
+-------------
+
+:py:meth:`hvac.api.system_backend.policy.delete_policy`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+	client.sys.delete_policy(
+		name='secret-writer',
+	)
+
+

--- a/hvac/api/system_backend/__init__.py
+++ b/hvac/api/system_backend/__init__.py
@@ -9,6 +9,7 @@ from hvac.api.system_backend.key import Key
 from hvac.api.system_backend.leader import Leader
 from hvac.api.system_backend.lease import Lease
 from hvac.api.system_backend.mount import Mount
+from hvac.api.system_backend.policy import Policy
 from hvac.api.system_backend.system_backend_mixin import SystemBackendMixin
 from hvac.api.vault_api_category import VaultApiCategory
 
@@ -21,6 +22,7 @@ __all__ = (
     'Leader',
     'Lease',
     'Mount',
+    'Policy',
     'SystemBackend',
     'SystemBackendMixin',
 )
@@ -29,7 +31,7 @@ __all__ = (
 logger = logging.getLogger(__name__)
 
 
-class SystemBackend(VaultApiCategory, Audit, Auth, Health, Init, Key, Leader, Lease, Mount):
+class SystemBackend(VaultApiCategory, Audit, Auth, Health, Init, Key, Leader, Lease, Mount, Policy):
     implemented_classes = [
         Audit,
         Auth,
@@ -39,6 +41,7 @@ class SystemBackend(VaultApiCategory, Audit, Auth, Health, Init, Key, Leader, Le
         Leader,
         Lease,
         Mount,
+        Policy,
     ]
     unimplemented_classes = []
 

--- a/hvac/api/system_backend/policy.py
+++ b/hvac/api/system_backend/policy.py
@@ -1,0 +1,111 @@
+import json
+
+from hvac import exceptions
+from hvac.api.system_backend.system_backend_mixin import SystemBackendMixin
+
+try:
+    import hcl
+    has_hcl_parser = True
+except ImportError:
+    has_hcl_parser = False
+
+
+class Policy(SystemBackendMixin):
+
+    def list_policies(self):
+        """List all configured policies.
+
+        Supported methods:
+            GET: /sys/policy. Produces: 200 application/json
+
+        :return: The JSON response of the request.
+        :rtype: list
+        """
+        api_path = '/v1/sys/policy'
+        response = self._adapter.get(
+            url=api_path,
+        )
+        return response.json()
+
+    def read_policy(self, name):
+        """Retrieve the policy body for the named policy.
+
+        Supported methods:
+            GET: /sys/policy/{name}. Produces: 200 application/json
+
+        :param name: The name of the policy to retrieve.
+        :type name: str | unicode
+        :return: The response of the request
+        :rtype: dict
+        """
+        api_path = '/v1/sys/policy/{name}'.format(name=name)
+        response = self._adapter.get(
+            url=api_path,
+        )
+        return response.json()
+
+    def get_policy(self, name, parse=False):
+        """Retrieve the policy body for the named policy.
+
+        :param name: The name of the policy to retrieve.
+        :type name: str | unicode
+        :param parse: Specifies whether to parse the policy body using pyhcl or not.
+        :type parse: bool
+        :return: The (optionally parsed) policy body for the specified policy.
+        :rtype: str | dict
+        """
+        try:
+            policy = self.read_policy(name=name)['data']['rules']
+        except exceptions.InvalidPath:
+            return None
+
+        if parse:
+            if not has_hcl_parser:
+                raise ImportError('pyhcl is required for policy parsing')
+            policy = hcl.loads(policy)
+
+        return policy
+
+    def create_or_update_policy(self, name, policy):
+        """Add a new or update an existing policy.
+
+        Once a policy is updated, it takes effect immediately to all associated users.
+
+        Supported methods:
+            PUT: /sys/policy/{name}. Produces: 204 (empty body)
+
+        :param name: Specifies the name of the policy to create.
+        :type name: str | unicode
+        :param policy: Specifies the policy document.
+        :type policy: str | unicode | dict
+        :return: The response of the request.
+        :rtype: requests.Response
+        """
+        if isinstance(policy, dict):
+            policy = json.dumps(policy)
+        params = {
+            'policy': policy,
+        }
+        api_path = '/v1/sys/policy/{name}'.format(name=name)
+        return self._adapter.put(
+            url=api_path,
+            json=params,
+        )
+
+    def delete_policy(self, name):
+        """Delete the policy with the given name.
+
+        This will immediately affect all users associated with this policy.
+
+        Supported methods:
+            DELETE: /sys/policy/{name}. Produces: 204 (empty body)
+
+        :param name: Specifies the name of the policy to delete.
+        :type name: str | unicode
+        :return: The response of the request.
+        :rtype: requests.Response
+        """
+        api_path = '/v1/sys/policy/{name}'.format(name=name)
+        return self._adapter.delete(
+            url=api_path,
+        )

--- a/hvac/tests/integration_tests/api/system_backend/test_policy.py
+++ b/hvac/tests/integration_tests/api/system_backend/test_policy.py
@@ -1,8 +1,10 @@
 from unittest import TestCase
+from unittest import skipIf
 
 from hvac.tests import utils
 
 
+@skipIf(utils.skip_if_vault_version_lt('0.9.0'), "Policy class uses new parameters added >= Vault 0.9.0")
 class TestPolicy(utils.HvacIntegrationTestCase, TestCase):
 
     def test_policy_manipulation(self):

--- a/hvac/tests/integration_tests/api/system_backend/test_policy.py
+++ b/hvac/tests/integration_tests/api/system_backend/test_policy.py
@@ -1,0 +1,57 @@
+from unittest import TestCase
+
+from hvac.tests import utils
+
+
+class TestPolicy(utils.HvacIntegrationTestCase, TestCase):
+
+    def test_policy_manipulation(self):
+        self.assertIn(
+            member='root',
+            container=self.client.sys.list_policies()['data']['policies'],
+        )
+        self.assertIsNone(self.client.sys.get_policy('test'))
+        policy, parsed_policy = self.prep_policy('test')
+        self.assertIn(
+            member='test',
+            container=self.client.sys.list_policies()['data']['policies'],
+        )
+        self.assertEqual(policy, self.client.sys.read_policy('test')['data']['rules'])
+        self.assertEqual(parsed_policy, self.client.sys.get_policy('test', parse=True))
+
+        self.client.sys.delete_policy(
+            name='test',
+        )
+        self.assertNotIn(
+            member='test',
+            container=self.client.sys.list_policies()['data']['policies'],
+        )
+
+    def test_json_policy_manipulation(self):
+        self.assertIn(
+            member='root',
+            container=self.client.sys.list_policies()['data']['policies'],
+        )
+
+        policy = '''
+            path "sys" {
+                policy = "deny"
+            }
+            path "secret" {
+                policy = "write"
+            }
+        '''
+        self.client.sys.create_or_update_policy(
+            name='test',
+            policy=policy,
+        )
+        self.assertIn(
+            member='test',
+            container=self.client.sys.list_policies()['data']['policies'],
+        )
+
+        self.client.delete_policy('test')
+        self.assertNotIn(
+            member='test',
+            container=self.client.sys.list_policies()['data']['policies'],
+        )

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -2057,10 +2057,27 @@ class Client(object):
         new_method=api.SystemBackend.create_or_update_policy,
     )
     def set_policy(self, name, rules):
-        self.sys.create_or_update_policy(
+        """Add a new or update an existing policy.
+
+        Once a policy is updated, it takes effect immediately to all associated users.
+
+        Supported methods:
+            PUT: /sys/policy/{name}. Produces: 204 (empty body)
+
+        :param name: Specifies the name of the policy to create.
+        :type name: str | unicode
+        :param policy: Specifies the policy document.
+        :type policy: str | unicode | dict
+        """
+        if isinstance(rules, dict):
+            rules = json.dumps(rules)
+        params = {
+            'rules': rules,
+        }
+        api_path = '/v1/sys/policy/{name}'.format(
             name=name,
-            policy=rules,
         )
+        self._adapter.put(api_path, json=params)
 
     @utils.deprecated_method(
         to_be_removed_in_version='0.9.0',


### PR DESCRIPTION
Part 2.6 of 3 in our large refactor series of how we organize auth methods, secrets engines, and system backend classes. This PR starts the move with "Policy" related methods to a new "sys" property used to access instances of these SystemBackend mixin classes under the Client class.