### PR TITLE
Add new sys Seal class

### DIFF
--- a/docs/usage/system_backend/index.rst
+++ b/docs/usage/system_backend/index.rst
@@ -12,6 +12,7 @@ System Backend
    leader
    lease
    policy
+   seal
 
 .. contents::
 

--- a/docs/usage/system_backend/seal.rst
+++ b/docs/usage/system_backend/seal.rst
@@ -1,0 +1,71 @@
+Seal
+====
+
+
+Seal Status
+-----------
+
+:py:meth:`hvac.api.system_backend.seal.read_status`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+
+Is Sealed
+---------
+
+:py:meth:`hvac.api.system_backend.seal.read_status`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+
+Read Seal Status
+----------------
+
+:py:meth:`hvac.api.system_backend.seal.read_status`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+
+Seal
+----
+
+:py:meth:`hvac.api.system_backend.seal.read_status`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+
+Submit Unseal Key
+-----------------
+
+:py:meth:`hvac.api.system_backend.seal.read_status`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+
+Submit Unseal Keys
+------------------
+
+:py:meth:`hvac.api.system_backend.seal.read_status`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+
+

--- a/hvac/api/system_backend/__init__.py
+++ b/hvac/api/system_backend/__init__.py
@@ -10,6 +10,7 @@ from hvac.api.system_backend.leader import Leader
 from hvac.api.system_backend.lease import Lease
 from hvac.api.system_backend.mount import Mount
 from hvac.api.system_backend.policy import Policy
+from hvac.api.system_backend.seal import Seal
 from hvac.api.system_backend.system_backend_mixin import SystemBackendMixin
 from hvac.api.vault_api_category import VaultApiCategory
 
@@ -23,6 +24,7 @@ __all__ = (
     'Lease',
     'Mount',
     'Policy',
+    'Seal',
     'SystemBackend',
     'SystemBackendMixin',
 )
@@ -31,7 +33,7 @@ __all__ = (
 logger = logging.getLogger(__name__)
 
 
-class SystemBackend(VaultApiCategory, Audit, Auth, Health, Init, Key, Leader, Lease, Mount, Policy):
+class SystemBackend(VaultApiCategory, Audit, Auth, Health, Init, Key, Leader, Lease, Mount, Policy, Seal):
     implemented_classes = [
         Audit,
         Auth,
@@ -42,6 +44,7 @@ class SystemBackend(VaultApiCategory, Audit, Auth, Health, Init, Key, Leader, Le
         Lease,
         Mount,
         Policy,
+        Seal,
     ]
     unimplemented_classes = []
 

--- a/hvac/api/system_backend/seal.py
+++ b/hvac/api/system_backend/seal.py
@@ -1,0 +1,121 @@
+from hvac.api.system_backend.system_backend_mixin import SystemBackendMixin
+
+
+class Seal(SystemBackendMixin):
+
+    @property
+    def seal_status(self):
+        """Read the seal status of the Vault.
+
+        This is an unauthenticated endpoint.
+
+        Supported methods:
+            GET: /sys/seal-status. Produces: 200 application/json
+
+        :return: The JSON response of the request.
+        :rtype: dict
+        """
+        return self.read_seal_status()
+
+    def is_sealed(self):
+        """Determine if  Vault is sealed.
+
+        :return: True if Vault is seal, False otherwise.
+        :rtype: bool
+        """
+        seal_status = self.read_seal_status()
+        return seal_status['sealed']
+
+    def read_seal_status(self):
+        """Read the seal status of the Vault.
+
+        This is an unauthenticated endpoint.
+
+        Supported methods:
+            GET: /sys/seal-status. Produces: 200 application/json
+
+        :return: The JSON response of the request.
+        :rtype: dict
+        """
+        api_path = '/v1/sys/seal-status'
+        response = self._adapter.get(
+            url=api_path,
+        )
+        return response.json()
+
+    def seal(self):
+        """Seal the Vault.
+
+        In HA mode, only an active node can be sealed. Standby nodes should be restarted to get the same effect.
+        Requires a token with root policy or sudo capability on the path.
+
+        Supported methods:
+            PUT: /sys/seal. Produces: 204 (empty body)
+
+        :return: The response of the request.
+        :rtype: requests.Response
+        """
+        api_path = '/v1/sys/seal'
+        return self._adapter.put(
+            url=api_path,
+        )
+
+    def submit_unseal_key(self, key=None, reset=False, migrate=False):
+        """Enter a single master key share to progress the unsealing of the Vault.
+
+        If the threshold number of master key shares is reached, Vault will attempt to unseal the Vault. Otherwise, this
+        API must be called multiple times until that threshold is met.
+
+        Either the key or reset parameter must be provided; if both are provided, reset takes precedence.
+
+        Supported methods:
+            PUT: /sys/unseal. Produces: 200 application/json
+
+        :param key: Specifies a single master key share. This is required unless reset is true.
+        :type key: str | unicode
+        :param reset: Specifies if previously-provided unseal keys are discarded and the unseal process is reset.
+        :type reset: bool
+        :param migrate: Available in 1.0 Beta - Used to migrate the seal from shamir to autoseal or autoseal to shamir.
+            Must be provided on all unseal key calls.
+        :type: migrate: bool
+        :return: The JSON response of the request.
+        :rtype: dict
+        """
+
+        params = {
+            'migrate': migrate,
+        }
+        if not reset and key is not None:
+            params['key'] = key
+        elif reset:
+            params['reset'] = reset
+
+        api_path = '/v1/sys/unseal'
+        response = self._adapter.put(
+            url=api_path,
+            json=params,
+        )
+        return response.json()
+
+    def submit_unseal_keys(self, keys, migrate=False):
+        """Enter multiple master key share to progress the unsealing of the Vault.
+
+        :param key: List of master key shares.
+        :type key: List[str]
+        :param migrate: Available in 1.0 Beta - Used to migrate the seal from shamir to autoseal or autoseal to shamir.
+            Must be provided on all unseal key calls.
+        :type: migrate: bool
+        :return: The JSON response of the last unseal request.
+        :rtype: dict
+        """
+        result = None
+
+        for key in keys:
+            result = self.submit_unseal_key(
+                key=key,
+                migrate=migrate,
+            )
+            if not result['sealed']:
+                break
+
+        return result

--- a/hvac/constants/client.py
+++ b/hvac/constants/client.py
@@ -35,4 +35,8 @@ DEPRECATED_PROPERTIES = {
         to_be_removed_in_version='0.9.0',
         client_property='sys',
     ),
+    'seal_status': dict(
+        to_be_removed_in_version='0.9.0',
+        client_property='sys',
+    ),
 }

--- a/hvac/tests/integration_tests/api/system_backend/test_seal.py
+++ b/hvac/tests/integration_tests/api/system_backend/test_seal.py
@@ -1,0 +1,40 @@
+from unittest import TestCase
+
+from hvac.tests import utils
+
+
+class TestSeal(utils.HvacIntegrationTestCase, TestCase):
+
+    def test_unseal_multi(self):
+        cls = type(self)
+
+        self.client.sys.seal()
+
+        keys = cls.manager.keys
+
+        result = self.client.sys.submit_unseal_keys(keys[0:2])
+
+        self.assertTrue(result['sealed'])
+        self.assertEqual(result['progress'], 2)
+
+        result = self.client.sys.submit_unseal_key(reset=True)
+        self.assertEqual(result['progress'], 0)
+        result = self.client.sys.submit_unseal_keys(keys[1:3])
+        self.assertTrue(result['sealed'])
+        self.assertEqual(result['progress'], 2)
+        self.client.sys.submit_unseal_keys(keys[0:1])
+        result = self.client.sys.submit_unseal_keys(keys[2:3])
+        self.assertFalse(result['sealed'])
+
+    def test_seal_unseal(self):
+        cls = type(self)
+
+        self.assertFalse(self.client.sys.is_sealed())
+
+        self.client.sys.seal()
+
+        self.assertTrue(self.client.sys.is_sealed())
+
+        cls.manager.unseal()
+
+        self.assertFalse(self.client.sys.is_sealed())

--- a/hvac/tests/utils.py
+++ b/hvac/tests/utils.py
@@ -229,7 +229,7 @@ class ServerManager(object):
 
     def unseal(self):
         """Unseal the vault server process."""
-        self.client.unseal_multi(self.keys)
+        self.client.sys.submit_unseal_keys(self.keys)
 
 
 class HvacIntegrationTestCase(object):

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -209,73 +209,6 @@ class Client(object):
         else:
             return self._adapter.post('/v1/sys/wrapping/unwrap').json()
 
-    @property
-    def seal_status(self):
-        """GET /sys/seal-status
-
-        :return:
-        :rtype:
-        """
-        return self._adapter.get('/v1/sys/seal-status').json()
-
-    def is_sealed(self):
-        """
-
-        :return:
-        :rtype:
-        """
-        return self.seal_status['sealed']
-
-    def seal(self):
-        """PUT /sys/seal
-
-        :return:
-        :rtype:
-        """
-        self._adapter.put('/v1/sys/seal')
-
-    def unseal_reset(self):
-        """PUT /sys/unseal
-
-        :return:
-        :rtype:
-        """
-        params = {
-            'reset': True,
-        }
-        return self._adapter.put('/v1/sys/unseal', json=params).json()
-
-    def unseal(self, key):
-        """PUT /sys/unseal
-
-        :param key:
-        :type key:
-        :return:
-        :rtype:
-        """
-        params = {
-            'key': key,
-        }
-
-        return self._adapter.put('/v1/sys/unseal', json=params).json()
-
-    def unseal_multi(self, keys):
-        """
-
-        :param keys:
-        :type keys:
-        :return:
-        :rtype:
-        """
-        result = None
-
-        for key in keys:
-            result = self.unseal(key)
-            if not result['sealed']:
-                break
-
-        return result
-
     def revoke_secret_prefix(self, path_prefix):
         """PUT /sys/revoke-prefix/<path prefix>
 
@@ -2085,6 +2018,41 @@ class Client(object):
     )
     def delete_policy(self, name):
         self.sys.delete_policy(name=name)
+
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.9.0',
+        new_method=api.SystemBackend.is_sealed,
+    )
+    def is_sealed(self):
+        return self.sys.is_sealed()
+
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.9.0',
+        new_method=api.SystemBackend.seal,
+    )
+    def seal(self):
+        self.sys.seal()
+
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.9.0',
+        new_method=api.SystemBackend.submit_unseal_key,
+    )
+    def unseal_reset(self):
+        return self.sys.submit_unseal_key(reset=True)
+
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.9.0',
+        new_method=api.SystemBackend.submit_unseal_key,
+    )
+    def unseal(self, key):
+        return self.sys.submit_unseal_key(key=key)
+
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.9.0',
+        new_method=api.SystemBackend.submit_unseal_keys,
+    )
+    def unseal_multi(self, keys):
+        return self.sys.submit_unseal_keys(keys=keys)
 
     @utils.deprecated_method(
         to_be_removed_in_version='0.9.0',


### PR DESCRIPTION
Part 2.9 of 3 in our large refactor series of how we organize auth methods, secrets engines, and system backend classes. This PR starts the move with "Policy" related methods to a new "sys" property used to access instances of these SystemBackend mixin classes under the Client class.