### PR TITLE
New sys backend classes wrap

### DIFF
--- a/docs/usage/system_backend/index.rst
+++ b/docs/usage/system_backend/index.rst
@@ -14,3 +14,4 @@ System Backend
    mount
    policy
    seal
+   wrapping

--- a/docs/usage/system_backend/wrapping.rst
+++ b/docs/usage/system_backend/wrapping.rst
@@ -1,0 +1,15 @@
+Wrapping
+========
+
+
+Unwrap
+------
+
+:py:meth:`hvac.api.system_backend.Wrapping.unwrap`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+

--- a/hvac/api/system_backend/__init__.py
+++ b/hvac/api/system_backend/__init__.py
@@ -11,6 +11,7 @@ from hvac.api.system_backend.lease import Lease
 from hvac.api.system_backend.mount import Mount
 from hvac.api.system_backend.policy import Policy
 from hvac.api.system_backend.seal import Seal
+from hvac.api.system_backend.wrapping import Wrapping
 from hvac.api.system_backend.system_backend_mixin import SystemBackendMixin
 from hvac.api.vault_api_category import VaultApiCategory
 
@@ -27,13 +28,14 @@ __all__ = (
     'Seal',
     'SystemBackend',
     'SystemBackendMixin',
+    'Wrapping',
 )
 
 
 logger = logging.getLogger(__name__)
 
 
-class SystemBackend(VaultApiCategory, Audit, Auth, Health, Init, Key, Leader, Lease, Mount, Policy, Seal):
+class SystemBackend(VaultApiCategory, Audit, Auth, Health, Init, Key, Leader, Lease, Mount, Policy, Seal, Wrapping):
     implemented_classes = [
         Audit,
         Auth,
@@ -45,6 +47,7 @@ class SystemBackend(VaultApiCategory, Audit, Auth, Health, Init, Key, Leader, Le
         Mount,
         Policy,
         Seal,
+        Wrapping,
     ]
     unimplemented_classes = []
 

--- a/hvac/api/system_backend/policy.py
+++ b/hvac/api/system_backend/policy.py
@@ -19,7 +19,7 @@ class Policy(SystemBackendMixin):
             GET: /sys/policy. Produces: 200 application/json
 
         :return: The JSON response of the request.
-        :rtype: list
+        :rtype: dict
         """
         api_path = '/v1/sys/policy'
         response = self._adapter.get(

--- a/hvac/api/system_backend/wrapping.py
+++ b/hvac/api/system_backend/wrapping.py
@@ -1,0 +1,32 @@
+from hvac.api.system_backend.system_backend_mixin import SystemBackendMixin
+
+
+class Wrapping(SystemBackendMixin):
+
+    def unwrap(self, token=None):
+        """Return the original response inside the given wrapping token.
+
+        Unlike simply reading cubbyhole/response (which is deprecated), this endpoint provides additional validation
+        checks on the token, returns the original value on the wire rather than a JSON string representation of it, and
+        ensures that the response is properly audit-logged.
+
+        Supported methods:
+            POST: /sys/wrapping/unwrap. Produces: 200 application/json
+
+        :param token: Specifies the wrapping token ID. This is required if the client token is not the wrapping token.
+            Do not use the wrapping token in both locations.
+        :type token: str | unicode
+        :return: The JSON response of the request.
+        :rtype: dict
+        """
+        params = {}
+        if token is not None:
+            params['token'] = token
+
+        api_path = '/v1/sys/wrapping/unwrap'
+        response = self._adapter.post(
+            url=api_path,
+            json=params,
+        )
+
+        return response.json()

--- a/hvac/tests/integration_tests/api/system_backend/test_auth.py
+++ b/hvac/tests/integration_tests/api/system_backend/test_auth.py
@@ -11,6 +11,7 @@ class TestAuth(utils.HvacIntegrationTestCase, TestCase):
         self.client.sys.disable_auth_method(
             path=self.TEST_AUTH_METHOD_PATH
         )
+        super(TestAuth, self).tearDown()
 
     def test_auth_backend_manipulation(self):
         self.assertNotIn(

--- a/hvac/tests/integration_tests/api/system_backend/test_wrapping.py
+++ b/hvac/tests/integration_tests/api/system_backend/test_wrapping.py
@@ -1,0 +1,39 @@
+import logging
+from unittest import TestCase
+
+from hvac.tests import utils
+
+
+class TestWrapping(utils.HvacIntegrationTestCase, TestCase):
+    TEST_AUTH_METHOD_TYPE = 'approle'
+    TEST_AUTH_METHOD_PATH = 'test-approle'
+
+    def setUp(self):
+        super(TestWrapping, self).setUp()
+        self.client.sys.enable_auth_method(
+            method_type=self.TEST_AUTH_METHOD_TYPE,
+            path=self.TEST_AUTH_METHOD_PATH,
+        )
+
+    def test_unwrap(self):
+        self.client.write(
+            path="auth/{path}/role/testrole".format(path=self.TEST_AUTH_METHOD_PATH),
+        )
+        result = self.client.write(
+            path='auth/{path}/role/testrole/secret-id'.format(
+                path=self.TEST_AUTH_METHOD_PATH
+            ),
+            wrap_ttl="10s",
+        )
+        self.assertIn('token', result['wrap_info'])
+
+        unwrap_response = self.client.sys.unwrap(result['wrap_info']['token'])
+        logging.debug('unwrap_response: %s' % unwrap_response)
+        self.assertIn(
+            member='secret_id_accessor',
+            container=unwrap_response['data']
+        )
+        self.assertIn(
+            member='secret_id',
+            container=unwrap_response['data']
+        )

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -193,16 +193,6 @@ class Client(object):
         """
         self._adapter.delete('/v1/{0}'.format(path))
 
-    def revoke_secret_prefix(self, path_prefix):
-        """PUT /sys/revoke-prefix/<path prefix>
-
-        :param path_prefix:
-        :type path_prefix:
-        :return:
-        :rtype:
-        """
-        self._adapter.put('/v1/sys/revoke-prefix/{0}'.format(path_prefix))
-
     def revoke_self_token(self):
         """PUT /auth/token/revoke-self
 
@@ -2151,6 +2141,15 @@ class Client(object):
     def revoke_secret(self, lease_id):
         return self.sys.revoke_lease(
             lease_id=lease_id,
+        )
+
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.9.0',
+        new_method=api.SystemBackend.revoke_lease,
+    )
+    def revoke_secret_prefix(self, path_prefix):
+        self.sys.revoke_prefix(
+            prefix=path_prefix,
         )
 
     @utils.deprecated_method(

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -193,22 +193,6 @@ class Client(object):
         """
         self._adapter.delete('/v1/{0}'.format(path))
 
-    def unwrap(self, token=None):
-        """POST /sys/wrapping/unwrap
-
-        :param token:
-        :type token:
-        :return:
-        :rtype:
-        """
-        if token:
-            payload = {
-                'token': token
-            }
-            return self._adapter.post('/v1/sys/wrapping/unwrap', json=payload).json()
-        else:
-            return self._adapter.post('/v1/sys/wrapping/unwrap').json()
-
     def revoke_secret_prefix(self, path_prefix):
         """PUT /sys/revoke-prefix/<path prefix>
 
@@ -1966,6 +1950,13 @@ class Client(object):
         params['signature_algorithm'] = signature_algorithm
 
         return self._adapter.post(url, json=params).json()
+
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.9.0',
+        new_method=api.SystemBackend.unwrap,
+    )
+    def unwrap(self, token=None):
+        return self.sys.unwrap(token=token)
 
     @utils.deprecated_method(
         to_be_removed_in_version='0.9.0',


### PR DESCRIPTION
Part 3.0 of 3 in our large refactor series of how we organize auth methods, secrets engines, and system backend classes. This PR fixes up some documentation gaps introduced over the last several PRs.