### PR TITLE
Revert a few client deprecations

### DIFF
--- a/docs/usage/system_backend/policy.rst
+++ b/docs/usage/system_backend/policy.rst
@@ -81,21 +81,6 @@ Read Policy
 	print('Rules for the hvac policy are: %s' % hvac_policy_rules)
 
 
-Get Policy
-----------
-
-:py:meth:`hvac.api.system_backend.Policy.get_policy`
-
-.. code:: python
-
-	import hvac
-	client = hvac.Client()
-
-	hvac_policy_rules = client.sys.get_policy(name='hvac-policy', parse=True)
-	print('Rules for the hvac policy are: %s' % hvac_policy_rules)
-
-
-
 Create Or Update Policy
 -----------------------
 

--- a/hvac/api/system_backend/key.py
+++ b/hvac/api/system_backend/key.py
@@ -4,23 +4,6 @@ from hvac.exceptions import ParamValidationError
 
 class Key(SystemBackendMixin):
 
-    @property
-    def generate_root_status(self):
-        return self.read_root_generation_progress()
-
-    @property
-    def key_status(self):
-        """GET /sys/key-status
-
-        :return: Information about the current encryption key used by Vault.
-        :rtype: dict
-        """
-        return self.get_encryption_key_status()['data']
-
-    @property
-    def rekey_status(self):
-        return self.read_rekey_progress()
-
     def read_root_generation_progress(self):
         """Read the configuration and process of the current root generation attempt.
 

--- a/hvac/api/system_backend/leader.py
+++ b/hvac/api/system_backend/leader.py
@@ -3,15 +3,6 @@ from hvac.api.system_backend.system_backend_mixin import SystemBackendMixin
 
 class Leader(SystemBackendMixin):
 
-    @property
-    def ha_status(self):
-        """Read the high availability status and current leader instance of Vault.
-
-        :return: The JSON response returned by read_leader_status()
-        :rtype: dict
-        """
-        return self.read_leader_status()
-
     def read_leader_status(self):
         """Read the high availability status and current leader instance of Vault.
 

--- a/hvac/api/system_backend/policy.py
+++ b/hvac/api/system_backend/policy.py
@@ -1,13 +1,6 @@
 import json
 
-from hvac import exceptions
 from hvac.api.system_backend.system_backend_mixin import SystemBackendMixin
-
-try:
-    import hcl
-    has_hcl_parser = True
-except ImportError:
-    has_hcl_parser = False
 
 
 class Policy(SystemBackendMixin):
@@ -43,28 +36,6 @@ class Policy(SystemBackendMixin):
             url=api_path,
         )
         return response.json()
-
-    def get_policy(self, name, parse=False):
-        """Retrieve the policy body for the named policy.
-
-        :param name: The name of the policy to retrieve.
-        :type name: str | unicode
-        :param parse: Specifies whether to parse the policy body using pyhcl or not.
-        :type parse: bool
-        :return: The (optionally parsed) policy body for the specified policy.
-        :rtype: str | dict
-        """
-        try:
-            policy = self.read_policy(name=name)['data']['rules']
-        except exceptions.InvalidPath:
-            return None
-
-        if parse:
-            if not has_hcl_parser:
-                raise ImportError('pyhcl is required for policy parsing')
-            policy = hcl.loads(policy)
-
-        return policy
 
     def create_or_update_policy(self, name, policy):
         """Add a new or update an existing policy.

--- a/hvac/api/system_backend/seal.py
+++ b/hvac/api/system_backend/seal.py
@@ -3,20 +3,6 @@ from hvac.api.system_backend.system_backend_mixin import SystemBackendMixin
 
 class Seal(SystemBackendMixin):
 
-    @property
-    def seal_status(self):
-        """Read the seal status of the Vault.
-
-        This is an unauthenticated endpoint.
-
-        Supported methods:
-            GET: /sys/seal-status. Produces: 200 application/json
-
-        :return: The JSON response of the request.
-        :rtype: dict
-        """
-        return self.read_seal_status()
-
     def is_sealed(self):
         """Determine if  Vault is sealed.
 

--- a/hvac/constants/client.py
+++ b/hvac/constants/client.py
@@ -19,24 +19,4 @@ DEPRECATED_PROPERTIES = {
         to_be_removed_in_version='0.9.0',
         client_property='secrets',
     ),
-    'generate_root_status': dict(
-        to_be_removed_in_version='0.9.0',
-        client_property='sys',
-    ),
-    'key_status': dict(
-        to_be_removed_in_version='0.9.0',
-        client_property='sys',
-    ),
-    'rekey_status': dict(
-        to_be_removed_in_version='0.9.0',
-        client_property='sys',
-    ),
-    'ha_status': dict(
-        to_be_removed_in_version='0.9.0',
-        client_property='sys',
-    ),
-    'seal_status': dict(
-        to_be_removed_in_version='0.9.0',
-        client_property='sys',
-    ),
 }

--- a/hvac/tests/integration_tests/api/system_backend/test_key.py
+++ b/hvac/tests/integration_tests/api/system_backend/test_key.py
@@ -57,25 +57,25 @@ class TestKey(utils.HvacIntegrationTestCase, TestCase):
         self.assertFalse(self.client.sys.read_root_generation_progress()['started'])
 
     def test_rotate(self):
-        status = self.client.sys.key_status
+        status = self.client.key_status
 
         self.client.sys.rotate_encryption_key()
 
         self.assertGreater(
-            self.client.sys.key_status['term'],
+            self.client.key_status['term'],
             status['term'],
         )
 
     def test_rekey_multi(self):
         cls = type(self)
 
-        self.assertFalse(self.client.sys.rekey_status['started'])
+        self.assertFalse(self.client.rekey_status['started'])
 
         self.client.sys.start_rekey()
-        self.assertTrue(self.client.sys.rekey_status['started'])
+        self.assertTrue(self.client.rekey_status['started'])
 
         self.client.sys.cancel_rekey()
-        self.assertFalse(self.client.sys.rekey_status['started'])
+        self.assertFalse(self.client.rekey_status['started'])
 
         result = self.client.sys.start_rekey()
 

--- a/hvac/tests/integration_tests/api/system_backend/test_policy.py
+++ b/hvac/tests/integration_tests/api/system_backend/test_policy.py
@@ -12,14 +12,14 @@ class TestPolicy(utils.HvacIntegrationTestCase, TestCase):
             member='root',
             container=self.client.sys.list_policies()['data']['policies'],
         )
-        self.assertIsNone(self.client.sys.get_policy('test'))
+        self.assertIsNone(self.client.get_policy('test'))
         policy, parsed_policy = self.prep_policy('test')
         self.assertIn(
             member='test',
             container=self.client.sys.list_policies()['data']['policies'],
         )
         self.assertEqual(policy, self.client.sys.read_policy('test')['data']['rules'])
-        self.assertEqual(parsed_policy, self.client.sys.get_policy('test', parse=True))
+        self.assertEqual(parsed_policy, self.client.get_policy('test', parse=True))
 
         self.client.sys.delete_policy(
             name='test',

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -135,6 +135,46 @@ class Client(object):
         """
         return self._sys
 
+    @property
+    def generate_root_status(self):
+        return self.sys.read_root_generation_progress()
+
+    @property
+    def key_status(self):
+        """GET /sys/key-status
+
+        :return: Information about the current encryption key used by Vault.
+        :rtype: dict
+        """
+        return self.sys.get_encryption_key_status()['data']
+
+    @property
+    def rekey_status(self):
+        return self.sys.read_rekey_progress()
+
+    @property
+    def ha_status(self):
+        """Read the high availability status and current leader instance of Vault.
+
+        :return: The JSON response returned by read_leader_status()
+        :rtype: dict
+        """
+        return self.sys.read_leader_status()
+
+    @property
+    def seal_status(self):
+        """Read the seal status of the Vault.
+
+        This is an unauthenticated endpoint.
+
+        Supported methods:
+            GET: /sys/seal-status. Produces: 200 application/json
+
+        :return: The JSON response of the request.
+        :rtype: dict
+        """
+        return self.read_seal_status()
+
     def read(self, path, wrap_ttl=None):
         """GET /<path>
 


### PR DESCRIPTION
Upon reflection, some of the refactoring in creating the new SystemBackend classes went a bit too far. This PR reverts a few of those changes ahead of the 0.7.0 release.