### PR TITLE
Add pretty_print arg to create_or_update_policy

### DIFF
--- a/hvac/api/system_backend/policy.py
+++ b/hvac/api/system_backend/policy.py
@@ -37,7 +37,7 @@ class Policy(SystemBackendMixin):
         )
         return response.json()
 
-    def create_or_update_policy(self, name, policy):
+    def create_or_update_policy(self, name, policy, pretty_print=True):
         """Add a new or update an existing policy.
 
         Once a policy is updated, it takes effect immediately to all associated users.
@@ -49,11 +49,17 @@ class Policy(SystemBackendMixin):
         :type name: str | unicode
         :param policy: Specifies the policy document.
         :type policy: str | unicode | dict
+        :param pretty_print: If True, and provided a dict for the policy argument, send the policy JSON to Vault with
+            "pretty" formatting.
+        :type pretty_print: bool
         :return: The response of the request.
         :rtype: requests.Response
         """
         if isinstance(policy, dict):
-            policy = json.dumps(policy)
+            if pretty_print:
+                policy = json.dumps(policy, indent=4, sort_keys=True)
+            else:
+                policy = json.dumps(policy)
         params = {
             'policy': policy,
         }

--- a/tests/integration_tests/api/system_backend/test_policy.py
+++ b/tests/integration_tests/api/system_backend/test_policy.py
@@ -27,6 +27,7 @@ class TestPolicy(HvacIntegrationTestCase, TestCase):
             pretty_print=False,
         ),
     ])
+    @skipIf(utils.skip_if_vault_version_eq('0.11.0'), "Policy parsing broken in Vault version 0.11.0")
     def test_create_or_update_policy(self, label, pretty_print=True):
         test_policy = {
             'path': {

--- a/tests/integration_tests/api/system_backend/test_policy.py
+++ b/tests/integration_tests/api/system_backend/test_policy.py
@@ -1,5 +1,8 @@
-from unittest import TestCase
-from unittest import skipIf
+import json
+import logging
+from unittest import TestCase, skipIf
+
+from parameterized import parameterized, param
 
 from tests import utils
 from tests.utils.hvac_integration_test_case import HvacIntegrationTestCase
@@ -7,6 +10,50 @@ from tests.utils.hvac_integration_test_case import HvacIntegrationTestCase
 
 @skipIf(utils.skip_if_vault_version_lt('0.9.0'), "Policy class uses new parameters added >= Vault 0.9.0")
 class TestPolicy(HvacIntegrationTestCase, TestCase):
+    TEST_POLICY_NAME = 'test-policy-policy'
+
+    def tearDown(self):
+        self.client.sys.delete_policy(
+            name=self.TEST_POLICY_NAME,
+        )
+        super(TestPolicy, self).tearDown()
+
+    @parameterized.expand([
+        param(
+            'success',
+        ),
+        param(
+            'pretty print false',
+            pretty_print=False,
+        ),
+    ])
+    def test_create_or_update_policy(self, label, pretty_print=True):
+        test_policy = {
+            'path': {
+                'test-path': {
+                    'capabilities': ['read'],
+                },
+            },
+        }
+        create_policy_response = self.client.sys.create_or_update_policy(
+            name=self.TEST_POLICY_NAME,
+            policy=test_policy,
+            pretty_print=pretty_print,
+        )
+        logging.debug('create_policy_response: %s' % create_policy_response)
+        self.assertEqual(
+            first=create_policy_response.status_code,
+            second=204,
+        )
+
+        read_policy_response = self.client.sys.read_policy(
+            name=self.TEST_POLICY_NAME,
+        )
+        logging.debug('read_policy_response: %s' % read_policy_response)
+        self.assertDictEqual(
+            d1=json.loads(read_policy_response['data']['rules']),
+            d2=test_policy,
+        )
 
     def test_policy_manipulation(self):
         self.assertIn(

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -43,6 +43,10 @@ def skip_if_vault_version_ge(supported_version):
     return skip_if_vault_version(supported_version, comparison=operator.ge)
 
 
+def skip_if_vault_version_eq(supported_version):
+    return skip_if_vault_version(supported_version, comparison=operator.eq)
+
+
 def create_client(**kwargs):
     """Small helper to instantiate a :py:class:`hvac.v1.Client` class with the appropriate parameters for the test env.
 


### PR DESCRIPTION
When viewing policies (for instance via the Vault UI), it's handy to have a human-readable version of policy documents. This PR updates `create_or_update_policy` to include a pretty print arg.