### PR TITLE
Bump Vault Versions - Vault v1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,6 @@ sudo: false
 language: python
 matrix:
   include:
-    - name: 'Python v2.7, Vault v0.8.3 - Integration/Unit Tests'
-      python: '2.7'
-      env:
-        - TOXENV=py27
-        - HVAC_VAULT_VERSION=0.8.3
     - name: 'Python v2.7, Vault v0.9.6 - Integration/Unit Tests'
       python: '2.7'
       env:
@@ -23,11 +18,16 @@ matrix:
       env:
         - TOXENV=py27
         - HVAC_VAULT_VERSION=0.11.0
-    - name: 'Python v2.7, Vault v0.11.4 - Integration/Unit Tests'
+    - name: 'Python v2.7, Vault v0.11.5 - Integration/Unit Tests'
       python: '2.7'
       env:
         - TOXENV=py27
-        - HVAC_VAULT_VERSION=0.11.4
+        - HVAC_VAULT_VERSION=0.11.5
+    - name: 'Python v2.7, Vault v1.0.0 - Integration/Unit Tests'
+      python: '2.7'
+      env:
+        - TOXENV=py27
+        - HVAC_VAULT_VERSION=1.0.0
     - name: 'Python v2.7, Vault HEAD ref - Integration/Unit Tests'
       python: '2.7'
       env:
@@ -37,11 +37,6 @@ matrix:
       python: '2.7'
       env:
         - TOXENV=py27-flake8
-    - name: 'Python v3.6, Vault v0.8.3 - Integration/Unit Tests'
-      python: '3.6'
-      env:
-        - TOXENV=py36
-        - HVAC_VAULT_VERSION=0.8.3
     - name: 'Python v3.6, Vault v0.9.6 - Integration/Unit Tests'
       python: '3.6'
       env:
@@ -57,11 +52,16 @@ matrix:
       env:
         - TOXENV=py36
         - HVAC_VAULT_VERSION=0.11.0
-    - name: 'Python v3.6, Vault v0.11.4 - Integration/Unit Tests'
+    - name: 'Python v3.6, Vault v0.11.5 - Integration/Unit Tests'
       python: '3.6'
       env:
         - TOXENV=py36
-        - HVAC_VAULT_VERSION=0.11.4
+        - HVAC_VAULT_VERSION=0.11.5
+    - name: 'Python v3.6, Vault v1.0.0 - Integration/Unit Tests'
+      python: '3.6'
+      env:
+        - TOXENV=py36
+        - HVAC_VAULT_VERSION=1.0.0
     - name: 'Python v3.6, Vault HEAD ref - Integration/Unit Tests'
       python: '3.6'
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,32 +40,32 @@ matrix:
     - name: 'Python v3.6, Vault v0.8.3 - Integration/Unit Tests'
       python: '3.6'
       env:
-        - TOXENV=py27
+        - TOXENV=py36
         - HVAC_VAULT_VERSION=0.8.3
     - name: 'Python v3.6, Vault v0.9.6 - Integration/Unit Tests'
       python: '3.6'
       env:
-        - TOXENV=py27
+        - TOXENV=py36
         - HVAC_VAULT_VERSION=0.9.6
     - name: 'Python v3.6, Vault v0.10.4 - Integration/Unit Tests'
       python: '3.6'
       env:
-        - TOXENV=py27
+        - TOXENV=py36
         - HVAC_VAULT_VERSION=0.10.4
     - name: 'Python v3.6, Vault v0.11.0 - Integration/Unit Tests'
       python: '3.6'
       env:
-        - TOXENV=py27
+        - TOXENV=py36
         - HVAC_VAULT_VERSION=0.11.0
     - name: 'Python v3.6, Vault v0.11.4 - Integration/Unit Tests'
       python: '3.6'
       env:
-        - TOXENV=py27
+        - TOXENV=py36
         - HVAC_VAULT_VERSION=0.11.4
     - name: 'Python v3.6, Vault HEAD ref - Integration/Unit Tests'
       python: '3.6'
       env:
-        - TOXENV=py27
+        - TOXENV=py36
         - HVAC_VAULT_VERSION=HEAD
     - name: 'Python v3.6 - Linting (flake8)'
       python: '3.6'

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Travis CI](https://travis-ci.org/hvac/hvac.svg?branch=master)](https://travis-ci.org/hvac/hvac) [![codecov](https://codecov.io/gh/hvac/hvac/branch/master/graph/badge.svg)](https://codecov.io/gh/hvac/hvac) [![Documentation Status](https://readthedocs.org/projects/hvac/badge/)](https://hvac.readthedocs.io/en/latest/?badge=latest) [![PyPI version](https://badge.fury.io/py/hvac.svg)](https://badge.fury.io/py/hvac)
 
 Tested against the latest release, HEAD ref, and 3 previous major versions (counting back from the latest release) of Vault. 
-Currently supports Vault v0.8.3 or later.
+Currently supports Vault v0.9.6 or later.
 
 ## Documentation
 


### PR DESCRIPTION
Bumping the versions of Vault we test again now that v1.0.0 is available. (Also fixing an oversight where Python 3.6 tests where using the py27 "TOXENV".)