### PR TITLE
Fix identity group conditionals

### DIFF
--- a/hvac/api/secrets_engines/identity.py
+++ b/hvac/api/secrets_engines/identity.py
@@ -532,12 +532,19 @@ class Identity(VaultApiBase):
         }
         if group_id is not None:
             params['id'] = group_id
-        if group_type == 'external' and member_entity_ids is not None:
-            # InvalidRequest: member entities can't be set manually for external groups
+
+        if group_type == 'external':
+            if member_entity_ids is not None:
+                logger.warning("InvalidRequest: member entities can't be set manually for external groupsl ignoring member_entity_ids argument.")
+        else:
             params['member_entity_ids'] = member_entity_ids
-        if group_type == 'external' and member_group_ids is not None:
-            # InvalidRequest: member groups can't be set for external groups
+
+        if group_type == 'external':
+            if member_group_ids is not None:
+                logger.warning("InvalidRequest: member groups can't be set for external groups; ignoring member_group_ids argument.")
+        else:
             params['member_group_ids'] = member_group_ids
+
         api_path = '/v1/{mount_point}/group'.format(mount_point=mount_point)
         response = self._adapter.post(
             url=api_path,
@@ -616,12 +623,19 @@ class Identity(VaultApiBase):
             'metadata': metadata,
             'policies': policies,
         }
-        if group_type == 'external' and member_entity_ids is not None:
-            # InvalidRequest: member entities can't be set manually for external groups
+
+        if group_type == 'external':
+            if member_entity_ids is not None:
+                logger.warning("InvalidRequest: member entities can't be set manually for external groupsl ignoring member_entity_ids argument.")
+        else:
             params['member_entity_ids'] = member_entity_ids
-        if group_type == 'external' and member_group_ids is not None:
-            # InvalidRequest: member groups can't be set for external groups
+
+        if group_type == 'external':
+            if member_group_ids is not None:
+                logger.warning("InvalidRequest: member groups can't be set for external groups; ignoring member_group_ids argument.")
+        else:
             params['member_group_ids'] = member_group_ids
+
         api_path = '/v1/{mount_point}/group/id/{id}'.format(
             mount_point=mount_point,
             id=group_id,

--- a/hvac/api/secrets_engines/identity.py
+++ b/hvac/api/secrets_engines/identity.py
@@ -486,18 +486,21 @@ class Identity(VaultApiBase):
 
     @staticmethod
     def validate_member_id_params_for_group_type(group_type, params, member_group_ids, member_entity_ids):
-        """
+        """Determine whether member ID parameters can be sent with a group create / update request.
 
-        :param group_type:
-        :type group_type:
-        :param params:
-        :type params:
-        :param member_group_ids:
-        :type member_group_ids:
-        :param member_entity_ids:
-        :type member_entity_ids:
-        :return:
-        :rtype:
+        These parameters are only allowed for the internal group type. If they're set for an external group type, Vault
+        returns a "error" response.
+
+        :param group_type: Type of the group, internal or external
+        :type group_type: str | unicode
+        :param params: Params dict to conditionally add the member entity/group ID's to.
+        :type params: dict
+        :param member_group_ids:  Group IDs to be assigned as group members.
+        :type member_group_ids: str | unicode
+        :param member_entity_ids: Entity IDs to be assigned as  group members.
+        :type member_entity_ids: str | unicode
+        :return: Params dict with conditionally added member entity/group ID's.
+        :rtype: dict
         """
         if group_type == 'external':
             if member_entity_ids is not None:

--- a/hvac/api/secrets_engines/identity.py
+++ b/hvac/api/secrets_engines/identity.py
@@ -484,6 +484,35 @@ class Identity(VaultApiBase):
             url=api_path,
         )
 
+    @staticmethod
+    def validate_member_id_params_for_group_type(group_type, params, member_group_ids, member_entity_ids):
+        """
+
+        :param group_type:
+        :type group_type:
+        :param params:
+        :type params:
+        :param member_group_ids:
+        :type member_group_ids:
+        :param member_entity_ids:
+        :type member_entity_ids:
+        :return:
+        :rtype:
+        """
+        if group_type == 'external':
+            if member_entity_ids is not None:
+                logger.warning("InvalidRequest: member entities can't be set manually for external groupsl ignoring member_entity_ids argument.")
+        else:
+            params['member_entity_ids'] = member_entity_ids
+
+        if group_type == 'external':
+            if member_group_ids is not None:
+                logger.warning("InvalidRequest: member groups can't be set for external groups; ignoring member_group_ids argument.")
+        else:
+            params['member_group_ids'] = member_group_ids
+
+        return params
+
     def create_or_update_group(self, name, group_id=None, group_type='internal', metadata=None, policies=None,
                                member_group_ids=None, member_entity_ids=None, mount_point=DEFAULT_MOUNT_POINT):
         """Create or update a Group.
@@ -533,17 +562,12 @@ class Identity(VaultApiBase):
         if group_id is not None:
             params['id'] = group_id
 
-        if group_type == 'external':
-            if member_entity_ids is not None:
-                logger.warning("InvalidRequest: member entities can't be set manually for external groupsl ignoring member_entity_ids argument.")
-        else:
-            params['member_entity_ids'] = member_entity_ids
-
-        if group_type == 'external':
-            if member_group_ids is not None:
-                logger.warning("InvalidRequest: member groups can't be set for external groups; ignoring member_group_ids argument.")
-        else:
-            params['member_group_ids'] = member_group_ids
+        Identity.validate_member_id_params_for_group_type(
+            group_type=group_type,
+            params=params,
+            member_group_ids=member_group_ids,
+            member_entity_ids=member_entity_ids,
+        )
 
         api_path = '/v1/{mount_point}/group'.format(mount_point=mount_point)
         response = self._adapter.post(
@@ -624,17 +648,12 @@ class Identity(VaultApiBase):
             'policies': policies,
         }
 
-        if group_type == 'external':
-            if member_entity_ids is not None:
-                logger.warning("InvalidRequest: member entities can't be set manually for external groupsl ignoring member_entity_ids argument.")
-        else:
-            params['member_entity_ids'] = member_entity_ids
-
-        if group_type == 'external':
-            if member_group_ids is not None:
-                logger.warning("InvalidRequest: member groups can't be set for external groups; ignoring member_group_ids argument.")
-        else:
-            params['member_group_ids'] = member_group_ids
+        Identity.validate_member_id_params_for_group_type(
+            group_type=group_type,
+            params=params,
+            member_group_ids=member_group_ids,
+            member_entity_ids=member_entity_ids,
+        )
 
         api_path = '/v1/{mount_point}/group/id/{id}'.format(
             mount_point=mount_point,


### PR DESCRIPTION
Turns out a bug from the first pass on the Identity class caused us to never set the `member_entity_ids` or `member_group_ids`. The original intention was to drop these params from the request sent to Vault for "external" group types as that results in an exception. Regression test cases have been added to catch the bug and a new `validate_member_id_params_for_group_type()` static method with the corrected logic has been added to the Identity class.

General points to note:

* There is some code duplication in the test cases that I am personally totally okay with. However I welcome any suggestions on how to DRY that bit up if y'all would like to see that addressed.
* This is the first time we've added a logger call in one of the API method classes. So it is worth pondering the implications that may entail. For context, the `logger.warning()` call seemed like a good fit between hiding the occurrence (i.e., that params were being dropped to allow the rest of the request to succeed) and continuing to allow some sort of exception to be throw to serve as the notification to the user.