### PR TITLE
Fix Request Redirection Handling

### DIFF
--- a/hvac/adapters.py
+++ b/hvac/adapters.py
@@ -247,14 +247,13 @@ class Request(Adapter):
         _kwargs = self._kwargs.copy()
         _kwargs.update(kwargs)
 
-        response = self.session.request(method, url, headers=headers,
-                                        allow_redirects=False, **_kwargs)
-
-        # NOTE(ianunruh): workaround for https://github.com/hvac/hvac/issues/51
-        while response.is_redirect and self.allow_redirects:
-            url = self.urljoin(self.base_uri, response.headers['Location'])
-            response = self.session.request(method, url, headers=headers,
-                                            allow_redirects=False, **_kwargs)
+        response = self.session.request(
+            method=method,
+            url=url,
+            headers=headers,
+            allow_redirects=self.allow_redirects,
+            **_kwargs,
+        )
 
         if 400 <= response.status_code < 600:
             text = errors = None

--- a/hvac/adapters.py
+++ b/hvac/adapters.py
@@ -255,7 +255,7 @@ class Request(Adapter):
             url=url,
             headers=headers,
             allow_redirects=self.allow_redirects,
-            **_kwargs,
+            **_kwargs
         )
 
         if 400 <= response.status_code < 600:

--- a/hvac/adapters.py
+++ b/hvac/adapters.py
@@ -229,6 +229,9 @@ class Request(Adapter):
         :return: The response of the request.
         :rtype: requests.Response
         """
+        # Vault CLI treats a double forward slash ('//') as a single forward slash for a given path.
+        # To avoid issues with the requests module's redirection logic, we perform the same translation here.
+        url = url.replace('//', '/')
         url = self.urljoin(self.base_uri, url)
 
         if not headers:

--- a/hvac/adapters.py
+++ b/hvac/adapters.py
@@ -256,7 +256,7 @@ class Request(Adapter):
             response = self.session.request(method, url, headers=headers,
                                             allow_redirects=False, **_kwargs)
 
-        if response.status_code >= 400 and response.status_code < 600:
+        if 400 <= response.status_code < 600:
             text = errors = None
             if response.headers.get('Content-Type') == 'application/json':
                 errors = response.json().get('errors')

--- a/hvac/adapters.py
+++ b/hvac/adapters.py
@@ -235,9 +235,12 @@ class Request(Adapter):
         :return: The response of the request.
         :rtype: requests.Response
         """
-        # Vault CLI treats a double forward slash ('//') as a single forward slash for a given path.
-        # To avoid issues with the requests module's redirection logic, we perform the same translation here.
-        url = url.replace('//', '/')
+        if '//' in url:
+            # Vault CLI treats a double forward slash ('//') as a single forward slash for a given path.
+            # To avoid issues with the requests module's redirection logic, we perform the same translation here.
+            logger.warning('Replacing double-slashes ("//") in path with single slash ("/") to avoid Vault redirect response.')
+            url = url.replace('//', '/')
+
         url = self.urljoin(self.base_uri, url)
 
         if not headers:

--- a/tests/unit_tests/test_adapters.py
+++ b/tests/unit_tests/test_adapters.py
@@ -35,6 +35,7 @@ class TestRequest(TestCase):
         ),
     ])
     def test_get(self, label, url, path='v1/sys/health', redirect_url=None):
+        path = path.replace('//', '/')
         expected_status_code = 200
         mock_url = '{0}/{1}'.format(url, path)
         adapter = adapters.Request(base_uri=url)

--- a/tests/unit_tests/test_adapters.py
+++ b/tests/unit_tests/test_adapters.py
@@ -1,7 +1,10 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import logging
 from unittest import TestCase
 
 import requests_mock
-from parameterized import parameterized
+from parameterized import parameterized, param
 
 from hvac import adapters
 
@@ -10,22 +13,54 @@ class TestRequest(TestCase):
     """Unit tests providing coverage for requests-related methods in the hvac Client class."""
 
     @parameterized.expand([
-        ("standard Vault address", 'https://localhost:8200'),
-        ("Vault address with route", 'https://example.com/vault'),
+        param(
+            "standard Vault address",
+            url='https://localhost:8200',
+        ),
+        param(
+            "Vault address with route",
+            url='https://example.com/vault',
+        ),
+        param(
+            "regression test for hvac issue #51",
+            url='https://localhost:8200',
+            path='keyring/http://some.url/sub/entry',
+        ),
+        param(
+            "redirect with location header for issue #343",
+            url='https://localhost:8200',
+            path='secret/some-secret',
+            redirect_url='https://some-other-place.com/secret/some-secret',
+
+        ),
     ])
-    @requests_mock.Mocker()
-    def test_get(self, test_label, test_url, requests_mocker):
-        test_path = 'v1/sys/health'
+    def test_get(self, label, url, path='v1/sys/health', redirect_url=None):
         expected_status_code = 200
-        mock_url = '{0}/{1}'.format(test_url, test_path)
-        requests_mocker.register_uri(
-            method='GET',
-            url=mock_url,
-        )
-        adapter = adapters.Request(base_uri=test_url)
-        response = adapter.get(
-            url='v1/sys/health',
-        )
+        mock_url = '{0}/{1}'.format(url, path)
+        adapter = adapters.Request(base_uri=url)
+        response_headers = {}
+        response_status_code = 200
+        if redirect_url is not None:
+            response_headers['Location'] = redirect_url
+            response_status_code = 301
+        with requests_mock.mock() as requests_mocker:
+            logging.debug('Registering "mock_url": %s' % mock_url)
+            requests_mocker.register_uri(
+                method='GET',
+                url=mock_url,
+                headers=response_headers,
+                status_code=response_status_code,
+            )
+            if redirect_url is not None:
+                logging.debug('Registering "redirect_url": %s' % redirect_url)
+                requests_mocker.register_uri(
+                    method='GET',
+                    url=redirect_url,
+                )
+
+            response = adapter.get(
+                url=path,
+            )
         self.assertEqual(
             first=expected_status_code,
             second=response.status_code,

--- a/tests/unit_tests/test_adapters.py
+++ b/tests/unit_tests/test_adapters.py
@@ -38,6 +38,7 @@ class TestRequest(TestCase):
         path = path.replace('//', '/')
         expected_status_code = 200
         mock_url = '{0}/{1}'.format(url, path)
+        expected_request_urls = [mock_url]
         adapter = adapters.Request(base_uri=url)
         response_headers = {}
         response_status_code = 200
@@ -53,6 +54,7 @@ class TestRequest(TestCase):
                 status_code=response_status_code,
             )
             if redirect_url is not None:
+                expected_request_urls.append(redirect_url)
                 logging.debug('Registering "redirect_url": %s' % redirect_url)
                 requests_mocker.register_uri(
                     method='GET',
@@ -61,6 +63,13 @@ class TestRequest(TestCase):
 
             response = adapter.get(
                 url=path,
+            )
+
+        # Assert all our expected uri(s) were requested
+        for request_num, expected_request_url in enumerate(expected_request_urls):
+            self.assertEqual(
+                first=expected_request_url,
+                second=requests_mocker.request_history[request_num].url
             )
         self.assertEqual(
             first=expected_status_code,


### PR DESCRIPTION
Closes #343. (cc: @stvdilln)
We've had three general issues with URL parsing and/or redirects in the past:

* https://github.com/hvac/hvac/issues/51 - Vault redirect / 301 response when a path contains `//` to a version of the path with a single `/`
* https://github.com/hvac/hvac/issues/205 - urllib's `urljoin()` method dropping paths from the base URL
* https://github.com/hvac/hvac/issues/343 - custom redirect logic and urljoin methods from the above two issues is causing Location headers in the response from Vault being incorrectly handled.

This PR ensures that all three issues are captured in test cases and reverts back to using the requests module's built-in redirect handling logic. The latter bit is accomplished by converting occurrences of `//` in a given path to `/` ourselves so that we don't end up with a 301 response back from Vault when it makes that change.