### PR TITLE
fix identity engine double slash

### DIFF
--- a/hvac/api/secrets_engines/identity.py
+++ b/hvac/api/secrets_engines/identity.py
@@ -123,7 +123,7 @@ class Identity(VaultApiBase):
         :return: The JSON response of the request.
         :rtype: dict
         """
-        api_path = '/v1/{mount_point}//entity/id/{id}'.format(
+        api_path = '/v1/{mount_point}/entity/id/{id}'.format(
             mount_point=mount_point,
             id=entity_id,
         )


### PR DESCRIPTION
When called, double slash results in 301 HTTP code and the redirect which is necessary.
Closes  #351