### PR TITLE
Tweak Travis CI Configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
   - HVAC_VAULT_VERSION=HEAD
 matrix:
   include:
+    # Explicitly include our flake8 tox jobs so they're only run once per Python version and have independent results.
     - name: 'Python v2.7 - Linting (flake8)'
       python: '2.7'
       env: TOXENV=flake8-py27

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,91 +1,37 @@
 language: python
+python:
+  - '2.7'
+  - '3.6'
+env:
+  - HVAC_VAULT_VERSION=0.9.6
+  - HVAC_VAULT_VERSION=0.10.4
+  # Leaving Vault v0.11.0 since it has some backwards-incompatible changes that were reverted in later versions.
+  - HVAC_VAULT_VERSION=0.11.0
+  - HVAC_VAULT_VERSION=0.11.5
+  - HVAC_VAULT_VERSION=1.0.0
+  - HVAC_VAULT_VERSION=HEAD
 matrix:
   include:
-    - name: 'Python v2.7, Vault v0.9.6 - Integration/Unit Tests'
-      python: '2.7'
-      env:
-        - TOXENV=py27
-        - HVAC_VAULT_VERSION=0.9.6
-    - name: 'Python v2.7, Vault v0.10.4 - Integration/Unit Tests'
-      python: '2.7'
-      env:
-        - TOXENV=py27
-        - HVAC_VAULT_VERSION=0.10.4
-    # Leaving Vault v0.11.0 since it has some backwards-incompatible changes that were reverted in later versions.
-    - name: 'Python v2.7, Vault v0.11.0 - Integration/Unit Tests'
-      python: '2.7'
-      env:
-        - TOXENV=py27
-        - HVAC_VAULT_VERSION=0.11.0
-    - name: 'Python v2.7, Vault v0.11.5 - Integration/Unit Tests'
-      python: '2.7'
-      env:
-        - TOXENV=py27
-        - HVAC_VAULT_VERSION=0.11.5
-    - name: 'Python v2.7, Vault v1.0.0 - Integration/Unit Tests'
-      python: '2.7'
-      env:
-        - TOXENV=py27
-        - HVAC_VAULT_VERSION=1.0.0
-    - name: 'Python v2.7, Vault HEAD ref - Integration/Unit Tests'
-      python: '2.7'
-      env:
-        - TOXENV=py27
-        - HVAC_VAULT_VERSION=HEAD
     - name: 'Python v2.7 - Linting (flake8)'
       python: '2.7'
       env:
         - TOXENV=py27-flake8
-    - name: 'Python v3.6, Vault v0.9.6 - Integration/Unit Tests'
-      python: '3.6'
-      env:
-        - TOXENV=py36
-        - HVAC_VAULT_VERSION=0.9.6
-    - name: 'Python v3.6, Vault v0.10.4 - Integration/Unit Tests'
-      python: '3.6'
-      env:
-        - TOXENV=py36
-        - HVAC_VAULT_VERSION=0.10.4
-    # Leaving Vault v0.11.0 since it has some backwards-incompatible changes that were reverted in later versions.
-    - name: 'Python v3.6, Vault v0.11.0 - Integration/Unit Tests'
-      python: '3.6'
-      env:
-        - TOXENV=py36
-        - HVAC_VAULT_VERSION=0.11.0
-    - name: 'Python v3.6, Vault v0.11.5 - Integration/Unit Tests'
-      python: '3.6'
-      env:
-        - TOXENV=py36
-        - HVAC_VAULT_VERSION=0.11.5
-    - name: 'Python v3.6, Vault v1.0.0 - Integration/Unit Tests'
-      python: '3.6'
-      env:
-        - TOXENV=py36
-        - HVAC_VAULT_VERSION=1.0.0
-    - name: 'Python v3.6, Vault HEAD ref - Integration/Unit Tests'
-      python: '3.6'
-      env:
-        - TOXENV=py36
-        - HVAC_VAULT_VERSION=HEAD
     - name: 'Python v3.6 - Linting (flake8)'
       python: '3.6'
       env:
-        - TOXENV=py27-flake8
+        - TOXENV=py36-flake8
   allow_failures:
-    - name: 'Python v2.7, Vault HEAD ref - Integration/Unit Tests'
-      python: '2.7'
+    - python: '2.7'
       env:
-        - TOXENV=py27
         - HVAC_VAULT_VERSION=HEAD
-    - name: 'Python v3.6, Vault HEAD ref - Integration/Unit Tests'
-      python: '3.6'
+    - python: '3.6'
       env:
         - TOXENV=py36
         - HVAC_VAULT_VERSION=HEAD
 install:
   - tests/scripts/install-consul.sh
   - tests/scripts/install-vault.sh ${HVAC_VAULT_VERSION}
-  - pip install tox
+  - pip install tox-travis
 script:
   - export PATH=$HOME/bin:$PATH
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,8 @@ matrix:
       python: '3.6'
       env: TOXENV=flake8-py36
   allow_failures:
-    - python: '2.7'
-      env:
-        - HVAC_VAULT_VERSION=HEAD
-    - python: '3.6'
-      env:
-        - HVAC_VAULT_VERSION=HEAD
+    # Ignore failed tests run against Vault builds using the HEAD ref at: https://github.com/hashicorp/vault.
+    - env: HVAC_VAULT_VERSION=HEAD
 install:
   - tests/scripts/install-consul.sh
   - tests/scripts/install-vault.sh ${HVAC_VAULT_VERSION}

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,18 +15,17 @@ matrix:
     - name: 'Python v2.7 - Linting (flake8)'
       python: '2.7'
       env:
-        - TOXENV=py27-flake8
+        - TOXENV=flake8-py27
     - name: 'Python v3.6 - Linting (flake8)'
       python: '3.6'
       env:
-        - TOXENV=py36-flake8
+        - TOXENV=flake8-py36
   allow_failures:
     - python: '2.7'
       env:
         - HVAC_VAULT_VERSION=HEAD
     - python: '3.6'
       env:
-        - TOXENV=py36
         - HVAC_VAULT_VERSION=HEAD
 install:
   - tests/scripts/install-consul.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 python:
   - '2.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 env:
   - HVAC_VAULT_VERSION=0.9.6
   - HVAC_VAULT_VERSION=0.10.4
-  - HVAC_VAULT_VERSION=0.11.0  # Leaving Vault v0.11.0 since it has some backwards-incompatible changes that were reverted in later versions.
+  - HVAC_VAULT_VERSION=0.11.0  # This ver kept explicitly; it has subsequently reverted backwards-incompatible changes.
   - HVAC_VAULT_VERSION=0.11.6
   - HVAC_VAULT_VERSION=1.0.1
   - HVAC_VAULT_VERSION=HEAD

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ python:
 env:
   - HVAC_VAULT_VERSION=0.9.6
   - HVAC_VAULT_VERSION=0.10.4
-  # Leaving Vault v0.11.0 since it has some backwards-incompatible changes that were reverted in later versions.
-  - HVAC_VAULT_VERSION=0.11.0
+  - HVAC_VAULT_VERSION=0.11.0  # Leaving Vault v0.11.0 since it has some backwards-incompatible changes that were reverted in later versions.
   - HVAC_VAULT_VERSION=0.11.5
   - HVAC_VAULT_VERSION=1.0.0
   - HVAC_VAULT_VERSION=HEAD

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: xenial
 language: python
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,13 @@ env:
 matrix:
   include:
     # Explicitly include our flake8 tox jobs so they're only run once per Python version and have independent results.
-    - name: 'Python v2.7 - Linting (flake8)'
+    - name: 'Linting (flake8) - Python v2.7'
       python: '2.7'
       env: TOXENV=flake8-py27
-    - name: 'Python v3.6 - Linting (flake8)'
+    - name: 'Linting (flake8) - Python v3.6'
       python: '3.6'
       env: TOXENV=flake8-py36
-    - name: 'Python v3.7 - Linting (flake8)'
+    - name: 'Linting (flake8) - Python v3.7'
       python: '3.7'
       env: TOXENV=flake8-py37
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ matrix:
     - name: 'Python v3.6 - Linting (flake8)'
       python: '3.6'
       env: TOXENV=flake8-py36
+    - name: 'Python v3.7 - Linting (flake8)'
+      python: '3.7'
+      env: TOXENV=flake8-py37
   allow_failures:
     # Ignore failed tests run against Vault builds using the HEAD ref at: https://github.com/hashicorp/vault.
     - env: HVAC_VAULT_VERSION=HEAD

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - '2.7'
   - '3.6'
+  - '3.7'
 env:
   - HVAC_VAULT_VERSION=0.9.6
   - HVAC_VAULT_VERSION=0.10.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 dist: xenial
-sudo: false
 language: python
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ matrix:
   allow_failures:
     # Ignore failed tests run against Vault builds using the HEAD ref at: https://github.com/hashicorp/vault.
     - env: HVAC_VAULT_VERSION=HEAD
+  # Don't wait on the "allow_failures" build jobs before reporting on the overall success/failure of the current build.
+  fast_finish: true
 install:
   - tests/scripts/install-consul.sh
   - tests/scripts/install-vault.sh ${HVAC_VAULT_VERSION}

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,10 @@ matrix:
   include:
     - name: 'Python v2.7 - Linting (flake8)'
       python: '2.7'
-      env:
-        - TOXENV=flake8-py27
+      env: TOXENV=flake8-py27
     - name: 'Python v3.6 - Linting (flake8)'
       python: '3.6'
-      env:
-        - TOXENV=flake8-py36
+      env: TOXENV=flake8-py36
   allow_failures:
     - python: '2.7'
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ env:
   - HVAC_VAULT_VERSION=0.9.6
   - HVAC_VAULT_VERSION=0.10.4
   - HVAC_VAULT_VERSION=0.11.0  # Leaving Vault v0.11.0 since it has some backwards-incompatible changes that were reverted in later versions.
-  - HVAC_VAULT_VERSION=0.11.5
-  - HVAC_VAULT_VERSION=1.0.0
+  - HVAC_VAULT_VERSION=0.11.6
+  - HVAC_VAULT_VERSION=1.0.1
   - HVAC_VAULT_VERSION=HEAD
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,5 +32,4 @@ install:
   - tests/scripts/install-vault.sh ${HVAC_VAULT_VERSION}
   - pip install tox-travis
 script:
-  - export PATH=$HOME/bin:$PATH
   - make test

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36, flake8-{py27,py36}
+envlist = py27, py36, flake8-py{27,36,37}
 
 [flake8]
 max-line-length = 160
@@ -19,5 +19,10 @@ commands = flake8 {posargs}
 
 [testenv:flake8-py36]
 basepython = python3.6
+deps = flake8
+commands = flake8 {posargs}
+
+[testenv:flake8-py37]
+basepython = python3.7
 deps = flake8
 commands = flake8 {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36, flake8-py{27,36,37}
+envlist = py27, py36, py37, flake8-py{27,36,37}
 
 [flake8]
 max-line-length = 160

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36, {py27,py36}-flake8
+envlist = py27, py36, flake8-{py27,py36}
 
 [flake8]
 max-line-length = 160
@@ -12,12 +12,12 @@ deps = -rrequirements.txt
        -rrequirements-dev.txt
 passenv = CI TRAVIS TRAVIS_* HVAC_*
 
-[testenv:py27-flake8]
+[testenv:flake8-py27]
 basepython = python2.7
 deps = flake8
 commands = flake8 {posargs}
 
-[testenv:py36-flake8]
+[testenv:flake8-py36]
 basepython = python3.6
 deps = flake8
 commands = flake8 {posargs}


### PR DESCRIPTION
Giving the `.travis.yml` configuration file a once over here to:

* Move from using explicit matrix.include job definitions to implicit ones to make future python / Vault version tweaks easier.
* Removing directives that are seemingly deprecated and/or superfluous for our needs (e.g., `sudo: false`, `export PATH=$HOME/bin:$PATH`, etc.)
* Installing [tox-travis](https://tox-travis.readthedocs.io/en/stable/?badge=stable) instead of plain 'ole tox so we drop all the explicit declarations for `TOXENV`.
* Adding Python 3.7 (in addition to our previous 2.7 and 3.6 versions)
* Adding `fast_finish: true` which should keep the overall build times from increasing all the much even with the additional Python version build jobs. This option will see the build status reported before the Vault HEAD ref tests complete and building Vault for source for those jobs are the slowest bits of our CI/CD builds generally.
* Bumping Vault v0.11 and v1.0 patch versions to the latest available versions.