### PR TITLE
Set "skip_missing_interpreters" to true in global tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = py27, py36, py37, flake8-py{27,36,37}
+skip_missing_interpreters = true
 
 [flake8]
 max-line-length = 160

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36, py37, flake8-py{27,36,37}
+envlist = {,flake8-}py{27,36,37}
 skip_missing_interpreters = true
 
 [flake8]


### PR DESCRIPTION
Especially now that we're configuring tox to support three different Python versions, it would be nice to include this `skip_missing_interpreters = true` config directive for local dev.