### PR TITLE
Fix For Intermittent Health Test Case Failure

### DIFF
--- a/tests/integration_tests/api/system_backend/test_health.py
+++ b/tests/integration_tests/api/system_backend/test_health.py
@@ -82,7 +82,6 @@ class TestHealth(HvacIntegrationTestCase, TestCase):
         logging.debug('vault_addr being used: %s' % vault_addr)
         client = create_client(url=vault_addr)
 
-        logging.debug('vault processes: %s' % self.manager._processes)
         read_status_response = client.sys.read_health_status(
             method=method,
         )

--- a/tests/integration_tests/api/system_backend/test_health.py
+++ b/tests/integration_tests/api/system_backend/test_health.py
@@ -76,12 +76,12 @@ class TestHealth(HvacIntegrationTestCase, TestCase):
             # Standby nodes can't be sealed directly.
             # I.e.: "vault cannot seal when in standby mode; please restart instead"
             self.manager.restart_vault_cluster()
-        if use_standby_node:
-            standby_vault_addr = self.get_standby_vault_addr()
-            logging.debug('standby_vault_addr being used: %s' % standby_vault_addr)
-            client = create_client(url=standby_vault_addr)
-        else:
-            client = self.client
+
+        # Grab a Vault node address for our desired standby status and create a one-off client configured for that address.
+        vault_addr = self.get_vault_addr_by_standby_status(standby_status=use_standby_node)
+        logging.debug('vault_addr being used: %s' % vault_addr)
+        client = create_client(url=vault_addr)
+
         logging.debug('vault processes: %s' % self.manager._processes)
         read_status_response = client.sys.read_health_status(
             method=method,

--- a/tests/utils/hvac_integration_test_case.py
+++ b/tests/utils/hvac_integration_test_case.py
@@ -155,14 +155,16 @@ class HvacIntegrationTestCase(object):
         """
         self.client.disable_secret_backend(mount_point)
 
-    def get_standby_vault_addr(self):
+    def get_vault_addr_by_standby_status(self, standby_status=True):
         """Get an address for a Vault HA node currently in standby.
 
+        :param standby_status: Value of the 'standby' key from the health status response to match.
+        :type standby_status: bool
         :return: Standby Vault address.
         :rtype: str
         """
         vault_addresses = self.manager.get_active_vault_addresses()
         for vault_address in vault_addresses:
             health_status = create_client(url=vault_address).sys.read_health_status(method='GET')
-            if health_status['standby']:
+            if health_status['standby'] == standby_status:
                 return vault_address


### PR DESCRIPTION
Tweaking things a bit here to avoid this sort of intermittent failure:

```
======================================================================
FAIL: Test the Health system backend class's "read_health_status" method [with label='default params', method='HEAD', use_standby_node=False, expected_status_code=200, seal_first=False, ha_required=False].
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/hvac/hvac/.tox/py27/lib/python2.7/site-packages/parameterized/parameterized.py", line 392, in standalone_func
    return func(*(a + p.args), **p.kwargs)
  File "/home/travis/build/hvac/hvac/tests/integration_tests/api/system_backend/test_health.py", line 93, in test_read_health_status
    second=expected_status_code,
AssertionError: 429 != 200
```