### PR TITLE
Simplify flake8 env for travis-ci + tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,18 +11,8 @@ env:
   - HVAC_VAULT_VERSION=0.11.6
   - HVAC_VAULT_VERSION=1.0.1
   - HVAC_VAULT_VERSION=HEAD
+  - TOXENV=flake8
 matrix:
-  include:
-    # Explicitly include our flake8 tox jobs so they're only run once per Python version and have independent results.
-    - name: 'Linting (flake8) - Python v2.7'
-      python: '2.7'
-      env: TOXENV=flake8-py27
-    - name: 'Linting (flake8) - Python v3.6'
-      python: '3.6'
-      env: TOXENV=flake8-py36
-    - name: 'Linting (flake8) - Python v3.7'
-      python: '3.7'
-      env: TOXENV=flake8-py37
   allow_failures:
     # Ignore failed tests run against Vault builds using the HEAD ref at: https://github.com/hashicorp/vault.
     - env: HVAC_VAULT_VERSION=HEAD

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {,flake8-}py{27,36,37}
+envlist = py{27,36,37} flake8
 skip_missing_interpreters = true
 
 [flake8]
@@ -13,17 +13,6 @@ deps = -rrequirements.txt
        -rrequirements-dev.txt
 passenv = CI TRAVIS TRAVIS_* HVAC_*
 
-[testenv:flake8-py27]
-basepython = python2.7
-deps = flake8
-commands = flake8 {posargs}
-
-[testenv:flake8-py36]
-basepython = python3.6
-deps = flake8
-commands = flake8 {posargs}
-
-[testenv:flake8-py37]
-basepython = python3.7
+[testenv:flake8]
 deps = flake8
 commands = flake8 {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,36,37} flake8
+envlist = py{27,36,37}, flake8
 skip_missing_interpreters = true
 
 [flake8]


### PR DESCRIPTION
Building on https://github.com/hvac/hvac/pull/360 a bit to make the travis-ci / tox config re: flake8 a good bit simpler.