### PR TITLE
Fix delete_role_secret_id_accessor method

### DIFF
--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -1369,7 +1369,7 @@ class Client(object):
         return self._adapter.post(url, json=params)
 
     def delete_role_secret_id_accessor(self, role_name, secret_id_accessor, mount_point='approle'):
-        """DELETE /auth/<mount_point>/role/<role name>/secret-id/<secret_id_accessor>
+        """POST /auth/<mount_point>/role/<role name>/secret-id-accessor/destroy
 
         :param role_name:
         :type role_name:
@@ -1380,8 +1380,11 @@ class Client(object):
         :return:
         :rtype:
         """
-        url = '/v1/auth/{0}/role/{1}/secret-id-accessor/{2}'.format(mount_point, role_name, secret_id_accessor)
-        return self._adapter.delete(url)
+        url = '/v1/auth/{0}/role/{1}/secret-id-accessor/destroy'.format(mount_point, role_name)
+        params = {
+            'secret_id_accessor': secret_id_accessor
+        }
+        return self._adapter.post(url, json=params)
 
     def create_role_custom_secret_id(self, role_name, secret_id, meta=None, mount_point='approle'):
         """POST /auth/<mount_point>/role/<role name>/custom-secret-id

--- a/tests/unit_tests/v1/test_approle_routes.py
+++ b/tests/unit_tests/v1/test_approle_routes.py
@@ -465,13 +465,12 @@ class TestApproleRoutes(TestCase):
     def test_delete_role_secret_id_accessor(self, test_label, mount_point, role_name, secret_id_accessor, requests_mocker):
         expected_status_code = 204
 
-        mock_url = 'http://localhost:8200/v1/auth/{0}/role/{1}/secret-id-accessor/{2}'.format(
+        mock_url = 'http://localhost:8200/v1/auth/{0}/role/{1}/secret-id-accessor/destroy'.format(
             'approle' if mount_point is None else mount_point,
             role_name,
-            secret_id_accessor,
         )
         requests_mocker.register_uri(
-            method='DELETE',
+            method='POST',
             url=mock_url,
             status_code=expected_status_code,
         )


### PR DESCRIPTION
The current `delete_role_secret_id_accessor` method doesn't work. This patch fix this.

Resolves #297