### PR TITLE
Fix logging no-handlers warning

### DIFF
--- a/hvac/adapters.py
+++ b/hvac/adapters.py
@@ -11,6 +11,7 @@ import requests.exceptions
 
 from hvac import utils
 
+logging.basicConfig()
 logger = logging.getLogger(__name__)
 
 DEFAULT_BASE_URI = 'http://localhost:8200'


### PR DESCRIPTION
If a user requests a URI starting with a slash like "/some/path/...", it gets prepended with "/v1/" in the hvac Client class, resulting in a final URL here of "/v1//some/path/..." We then try to log a warning about this (see line 239). However, the python "logging" module requires at least some basic setup before it can be used, so the call on line 242 to logger.warning() actually throws its own non-critical error: 

   No handlers could be found for logger "hvac.adapters"

This change adds the easiest fix, which is to call logging.basicConfig() before instantiating our logger at the top of this file. 

P.S. As a shortcut, logging.warning() calls basicConfg() for you, if you haven't already started with getLogger(). So, confusingly, another fix here would be to remove this entirely:
    logger = logging.getLogger(__name__)
and call this:
    logging.warning('Replacing double-slashes...')
instead of this:
    logger.warning('Replacing double-slashes...')

I feel my fix here is cleaner.