### PR TITLE
AWS: ensure request parameters are sent with generate_credentials

### DIFF
--- a/hvac/api/secrets_engines/aws.py
+++ b/hvac/api/secrets_engines/aws.py
@@ -325,7 +325,7 @@ class Aws(VaultApiBase):
             endpoint=endpoint,
             name=name,
         )
-        response = self._adapter.get(
+        response = self._adapter.post(
             url=api_path,
             json=params,
         )

--- a/hvac/api/secrets_engines/aws.py
+++ b/hvac/api/secrets_engines/aws.py
@@ -325,8 +325,8 @@ class Aws(VaultApiBase):
             endpoint=endpoint,
             name=name,
         )
-        response = self._adapter.post(
+        response = self._adapter.get(
             url=api_path,
-            json=params,
+            params=params,
         )
         return response.json()

--- a/tests/integration_tests/api/secrets_engines/test_aws.py
+++ b/tests/integration_tests/api/secrets_engines/test_aws.py
@@ -254,7 +254,8 @@ class TestAws(HvacIntegrationTestCase, TestCase):
                     d1=json.loads(read_role_response['data']['policy']),
                     d2=self.TEST_POLICY_DOCUMENT,
                 )
-            elif 'credential_types' in read_role_response['data']:
+            # https://github.com/hashicorp/vault/commit/2dcd0aed2a242f53dae03318b4d68693f7d92b81
+            elif vault_version_lt('1.0.2'):
                 self.assertEqual(
                     first=read_role_response['data']['credential_types'],
                     second=['iam_user'],

--- a/tests/integration_tests/api/secrets_engines/test_aws.py
+++ b/tests/integration_tests/api/secrets_engines/test_aws.py
@@ -254,10 +254,15 @@ class TestAws(HvacIntegrationTestCase, TestCase):
                     d1=json.loads(read_role_response['data']['policy']),
                     d2=self.TEST_POLICY_DOCUMENT,
                 )
-            else:
+            elif 'credential_types' in read_role_response['data']:
                 self.assertEqual(
                     first=read_role_response['data']['credential_types'],
                     second=['iam_user'],
+                )
+            else:
+                self.assertEqual(
+                    first=read_role_response['data']['credential_type'],
+                    second='iam_user',
                 )
 
     @parameterized.expand([

--- a/tests/unit_tests/api/secrets_engines/test_aws.py
+++ b/tests/unit_tests/api/secrets_engines/test_aws.py
@@ -75,7 +75,7 @@ class TestAws(TestCase):
         aws = Aws(adapter=Request())
         with requests_mock.mock() as requests_mocker:
             requests_mocker.register_uri(
-                method='POST',
+                method='GET',
                 url=mock_url,
                 status_code=expected_status_code,
                 json=mock_response,

--- a/tests/unit_tests/api/secrets_engines/test_aws.py
+++ b/tests/unit_tests/api/secrets_engines/test_aws.py
@@ -75,7 +75,7 @@ class TestAws(TestCase):
         aws = Aws(adapter=Request())
         with requests_mock.mock() as requests_mocker:
             requests_mocker.register_uri(
-                method='GET',
+                method='POST',
                 url=mock_url,
                 status_code=expected_status_code,
                 json=mock_response,


### PR DESCRIPTION
The JSON body is not read on GET requests, we either need to POST or
pass the arguments as query parameters.