### PR TITLE
Add support for setting VAULT_ADDR and VAULT_TOKEN via env vars

### DIFF
--- a/hvac/utils.py
+++ b/hvac/utils.py
@@ -4,6 +4,7 @@ Misc utility functions and constants
 
 import functools
 import inspect
+import os
 import warnings
 from textwrap import dedent
 
@@ -216,3 +217,22 @@ def list_to_comma_delimited(list_param):
     if list_param is None:
         list_param = []
     return ','.join(list_param)
+
+
+def get_token_from_env():
+    """Get the token from env var, VAULT_TOKEN. If not set, attempt to get the token from, ~/.vault-token
+
+    :return: The vault token if set, else None
+    :rtype: str | None
+    """
+    token = os.getenv('VAULT_TOKEN')
+    if not token:
+        token_file_path = os.path.expanduser('~/.vault-token')
+        if os.path.exists(token_file_path):
+            with open(token_file_path, 'r') as f_in:
+                token = f_in.read().strip()
+
+    if not token:
+        return None
+
+    return token

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import json
+import os
 from base64 import b64encode
 
 from hvac import aws_utils, exceptions, adapters, utils, api
@@ -50,6 +51,8 @@ class Client(object):
         if adapter is not None:
             self._adapter = adapter
         else:
+            token = token if token is not None else utils.get_token_from_env()
+            url = os.getenv('VAULT_ADDR', url)
             self._adapter = adapters.Request(
                 base_uri=url,
                 token=token,


### PR DESCRIPTION
The PR adds the ability to set the `VAULT_ADDR` and `VAULT_TOKEN` from env vars.