### PR TITLE
Actually do not install tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',
     ],
-    packages=find_packages(),
+    packages=find_packages(exclude=['docs*', 'tests*']),
     install_requires=[
         'requests>=2.21.0',
     ],


### PR DESCRIPTION
In #294 `tests` directory was moved out from `hvac` with the intention to not
install tests into site-packages. However, find_packages() still finds and
installs it, this time as a top-level package. Pass it into exclude to really
skip it.

Same thing for `docs`.