### PR TITLE
Fix priority of client url and VAULT_ADDR environment variable

### DIFF
--- a/hvac/constants/client.py
+++ b/hvac/constants/client.py
@@ -20,3 +20,5 @@ DEPRECATED_PROPERTIES = {
         client_property='secrets',
     ),
 }
+
+DEFAULT_URL = 'http://localhost:8200'

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -17,7 +17,7 @@ except ImportError:
 class Client(object):
     """The hvac Client class for HashiCorp's Vault."""
 
-    def __init__(self, url='http://localhost:8200', token=None,
+    def __init__(self, url=None, token=None,
                  cert=None, verify=True, timeout=30, proxies=None,
                  allow_redirects=True, session=None, adapter=None, namespace=None):
         """Creates a new hvac client instance.
@@ -52,7 +52,7 @@ class Client(object):
             self._adapter = adapter
         else:
             token = token if token is not None else utils.get_token_from_env()
-            url = os.getenv('VAULT_ADDR', url)
+            url = url if url else os.getenv('VAULT_ADDR', 'http://localhost:8200')
             self._adapter = adapters.Request(
                 base_uri=url,
                 token=token,

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -5,7 +5,7 @@ import os
 from base64 import b64encode
 
 from hvac import aws_utils, exceptions, adapters, utils, api
-from hvac.constants.client import DEPRECATED_PROPERTIES
+from hvac.constants.client import DEPRECATED_PROPERTIES, DEFAULT_URL
 
 try:
     import hcl
@@ -52,7 +52,7 @@ class Client(object):
             self._adapter = adapter
         else:
             token = token if token is not None else utils.get_token_from_env()
-            url = url if url else os.getenv('VAULT_ADDR', 'http://localhost:8200')
+            url = url if url else os.getenv('VAULT_ADDR', DEFAULT_URL)
             self._adapter = adapters.Request(
                 base_uri=url,
                 token=token,


### PR DESCRIPTION
Fixes #421 

The behaviour of the vault CLI client is:
- if no -address cli parameter is set, try to use VAULT_ADDR environment variable
- if both -address and VAULT_ADDR are set, use the -address passed in the vault cli command.

This PR updates the hvac client with the same precedence (`url` client parameter > `VAULT_ADDR` environment variable > default client URL).