### PR TITLE
* Generate credentials updated to a post request.

### DIFF
--- a/hvac/api/secrets_engines/aws.py
+++ b/hvac/api/secrets_engines/aws.py
@@ -326,14 +326,8 @@ class Aws(VaultApiBase):
             name=name,
         )
 
-        if endpoint == 'sts':
-            response = self._adapter.post(
-                url=api_path,
-                json=params,
-            )
-        else:
-            response = self._adapter.get(
-                url=api_path,
-                json=params,
-            )
+        response = self._adapter.post(
+            url=api_path,
+            json=params,
+        )
         return response.json()

--- a/tests/unit_tests/api/secrets_engines/test_aws.py
+++ b/tests/unit_tests/api/secrets_engines/test_aws.py
@@ -75,7 +75,7 @@ class TestAws(TestCase):
         aws = Aws(adapter=Request())
         with requests_mock.mock() as requests_mocker:
             requests_mocker.register_uri(
-                method='GET',
+                method='POST',
                 url=mock_url,
                 status_code=expected_status_code,
                 json=mock_response,


### PR DESCRIPTION
* Myself and https://github.com/hvac/hvac/pull/403/files received an error when passing in TTL.   GET requests do not recognize json, so the passed in TTL always defaulted to `1h`.

* This PR uses a POST request to call the endpoint.