### PR TITLE
Fix logging no-handlers warning

### DIFF
--- a/hvac/adapters.py
+++ b/hvac/adapters.py
@@ -11,6 +11,7 @@ import requests.exceptions
 
 from hvac import utils
 
+logging.basicConfig()
 logger = logging.getLogger(__name__)
 
 DEFAULT_BASE_URI = 'http://localhost:8200'

--- a/hvac/adapters.py
+++ b/hvac/adapters.py
@@ -3,16 +3,12 @@
 HTTP Client Library Adapters
 
 """
-import logging
 from abc import ABCMeta, abstractmethod
 
 import requests
 import requests.exceptions
 
 from hvac import utils
-
-logging.basicConfig()
-logger = logging.getLogger(__name__)
 
 DEFAULT_BASE_URI = 'http://localhost:8200'
 
@@ -239,7 +235,6 @@ class Request(Adapter):
         if '//' in url:
             # Vault CLI treats a double forward slash ('//') as a single forward slash for a given path.
             # To avoid issues with the requests module's redirection logic, we perform the same translation here.
-            logger.warning('Replacing double-slashes ("//") in path with single slash ("/") to avoid Vault redirect response.')
             url = url.replace('//', '/')
 
         url = self.urljoin(self.base_uri, url)


### PR DESCRIPTION
The exciting conclusion to https://github.com/hvac/hvac/pull/400