### PR TITLE
include db engine as implemented class

### DIFF
--- a/hvac/api/secrets_engines/__init__.py
+++ b/hvac/api/secrets_engines/__init__.py
@@ -8,6 +8,7 @@ from hvac.api.secrets_engines.pki import Pki
 from hvac.api.secrets_engines.kv_v1 import KvV1
 from hvac.api.secrets_engines.kv_v2 import KvV2
 from hvac.api.secrets_engines.transit import Transit
+from hvac.api.secrets_engines.database import Database
 from hvac.api.vault_api_category import VaultApiCategory
 
 __all__ = (
@@ -21,6 +22,7 @@ __all__ = (
     'Pki',
     'Transit',
     'SecretsEngines',
+    'Database'
 )
 
 
@@ -35,13 +37,13 @@ class SecretsEngines(VaultApiCategory):
         Kv,
         Pki,
         Transit,
+        Database,
     ]
     unimplemented_classes = [
         'Ad',
         'AliCloud',
         'Azure',
         'Consul',
-        'Database',
         'GcpKms',
         'Nomad',
         'RabbitMq',


### PR DESCRIPTION
database secrets engine wasnt enabled though the code was included. probably a good example for why we need unit tests :)

also - @jeffwecan may want to investigate why the error said `'"%s" auth method class` instead of `database secret engine class`

fix for https://github.com/hvac/hvac/issues/454