### PR TITLE
Add slack notifications secret to travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,6 @@ install:
   - pip install tox-travis
 script:
   - make test
+notifications:
+  slack:
+    secure: looVR3I5wFEYMDursCKMd7jqEAijXc4dxlaIXQz9PRIepwr0BISBCBJO1XUNTPlSF5ZS8cJmHcMpM91LdHLSuCPrfqAvUj0E3QvUwgm7KoSI/zVSpASPS1H+NvdbJemHUXWMsoU1K9LOVN2frcKzYFsqkmb9cHTcqFxYl1fxyBE=


### PR DESCRIPTION
I'm considering options for using something like Slack as a forum for discussions among contributors and maintainers of this repository. As part of trying out options, I'm hooking in Travis CI's Slack integration into the hvac.slack.com workspace.