### PR TITLE
Start Using Enterprise (Trial) Version of Vault For Travis CI Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
   # Don't wait on the "allow_failures" build jobs before reporting on the overall success/failure of the current build.
   fast_finish: true
 install:
-#  - tests/scripts/install-consul.sh
+  - tests/scripts/install-consul.sh
   - tests/scripts/install-vault.sh ${HVAC_VAULT_VERSION} ${HVAC_VAULT_LICENSE}
   - pip install tox-travis
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
   # Don't wait on the "allow_failures" build jobs before reporting on the overall success/failure of the current build.
   fast_finish: true
 install:
-  - tests/scripts/install-consul.sh
+#  - tests/scripts/install-consul.sh
   - tests/scripts/install-vault.sh ${HVAC_VAULT_VERSION}
   - pip install tox-travis
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
       env: TOXENV=docs
   allow_failures:
     # Ignore failed tests run against Vault builds using the HEAD ref at: https://github.com/hashicorp/vault.
-    - env: HVAC_VAULT_VERSION=HEAD
+    - env: HVAC_VAULT_VERSION=HEAD HVAC_VAULT_LICENSE=OSS
   # Don't wait on the "allow_failures" build jobs before reporting on the overall success/failure of the current build.
   fast_finish: true
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,16 @@ python:
   - '2.7'
   - '3.7'
 env:
-  - HVAC_VAULT_VERSION=0.11.0  # This ver kept explicitly; it has subsequently reverted backwards-incompatible changes.
-  - HVAC_VAULT_VERSION=1.0.3
-  - HVAC_VAULT_VERSION=1.1.3
-  - HVAC_VAULT_VERSION=HEAD
+  - HVAC_VAULT_VERSION=0.11.0 HVAC_VAULT_LICENSE=enterprise  # This ver kept explicitly; it has subsequently reverted backwards-incompatible changes.
+  - HVAC_VAULT_VERSION=1.0.3 HVAC_VAULT_LICENSE=enterprise
+  - HVAC_VAULT_VERSION=1.1.0 HVAC_VAULT_LICENSE=enterprise
+  - HVAC_VAULT_VERSION=HEAD HVAC_VAULT_LICENSE=OSS
   - TOXENV=flake8
 matrix:
   include:
+    - name: 'Vault OSS - Latest hvac-tested Release on Python 3.7'
+      python: '3.7'
+      env: HVAC_VAULT_VERSION=1.1.3 HVAC_VAULT_LICENSE=OSS
     - name: 'Test Documentation Build - Sphinx: "make html"'
       env: TOXENV=docs
   allow_failures:
@@ -20,7 +23,7 @@ matrix:
   fast_finish: true
 install:
 #  - tests/scripts/install-consul.sh
-  - tests/scripts/install-vault.sh ${HVAC_VAULT_VERSION}
+  - tests/scripts/install-vault.sh ${HVAC_VAULT_VERSION} ${HVAC_VAULT_LICENSE}
   - pip install tox-travis
 script:
   - make test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Feel free to open issues and/or pull requests with additional features or improv
 Integration tests will automatically start a Vault server in the background. Just make sure
 the latest `vault` binary is available in your `PATH`.
 
-1. [Install Vault](https://vaultproject.io/docs/install/index.html) or execute `VAULT_BRANCH=release tests/scripts/install-vault-release.sh`
+1. [Install Vault](https://vaultproject.io/docs/install/index.html) or execute `tests/scripts/install-vault.sh`. Note: by default this script installs the OSS version of Vault. An enterprise trial version of the Vault binary is available for testing (but has an explicitly limited runtime). To run integration test cases requiring enterprise Vault, you can invoke the installation script with: `install-vault.sh <desired version> 'enterprise'`
 2. [Install Tox](http://tox.readthedocs.org/en/latest/install.html)
 3. Run tests: `make test`
 

--- a/tests/scripts/install-vault.sh
+++ b/tests/scripts/install-vault.sh
@@ -29,8 +29,11 @@ function install_vault_release() {
 
     cd /tmp
 
-    curl -sOL https://releases.hashicorp.com/vault/${HVAC_VAULT_VERSION}/vault_${HVAC_VAULT_VERSION}_linux_amd64.zip
-    unzip vault_${HVAC_VAULT_VERSION}_linux_amd64.zip
+    #curl -sOL https://releases.hashicorp.com/vault/${HVAC_VAULT_VERSION}/vault_${HVAC_VAULT_VERSION}_linux_amd64.zip
+    #unzip vault_${HVAC_VAULT_VERSION}_linux_amd64.zip
+    curl -sOL https://s3-us-west-2.amazonaws.com/hc-enterprise-binaries/vault/ent/${HVAC_VAULT_VERSION}/vault-enterprise_${HVAC_VAULT_VERSION}%2Bent_linux_amd64.zip
+    unzip vault-enterprise_${HVAC_VAULT_VERSION}%2Bent_linux_amd64.zip
+
     mv vault $HOME/bin
 }
 

--- a/tests/scripts/install-vault.sh
+++ b/tests/scripts/install-vault.sh
@@ -30,12 +30,12 @@ function install_vault_release() {
     mkdir -p $HOME/bin
 
     cd /tmp
-    if [[ "$HVAC_VAULT_LICENSE" == "oss" ]]; then
-        curl -sOL https://releases.hashicorp.com/vault/${HVAC_VAULT_VERSION}/vault_${HVAC_VAULT_VERSION}_linux_amd64.zip
-        unzip vault_${HVAC_VAULT_VERSION}_linux_amd64.zip
-    else
+    if [[ "$HVAC_VAULT_LICENSE" == "enterprise" ]]; then
         curl -sOL https://s3-us-west-2.amazonaws.com/hc-enterprise-binaries/vault/ent/${HVAC_VAULT_VERSION}/vault-enterprise_${HVAC_VAULT_VERSION}%2Bent_linux_amd64.zip
         unzip vault-enterprise_${HVAC_VAULT_VERSION}%2Bent_linux_amd64.zip
+    else
+        curl -sOL https://releases.hashicorp.com/vault/${HVAC_VAULT_VERSION}/vault_${HVAC_VAULT_VERSION}_linux_amd64.zip
+        unzip vault_${HVAC_VAULT_VERSION}_linux_amd64.zip
     fi
 
     mv vault $HOME/bin

--- a/tests/scripts/install-vault.sh
+++ b/tests/scripts/install-vault.sh
@@ -2,7 +2,9 @@
 set -eux
 
 DEFAULT_VAULT_VERSION=1.1.3
+DEFAULT_VAULT_LICENSE=oss
 HVAC_VAULT_VERSION=${1:-$DEFAULT_VAULT_VERSION}
+HVAC_VAULT_LICENSE=${2:-DEFAULT_VAULT_LICENSE}
 
 function build_and_install_vault_head_ref() {
     mkdir -p $HOME/bin
@@ -28,11 +30,13 @@ function install_vault_release() {
     mkdir -p $HOME/bin
 
     cd /tmp
-
-    #curl -sOL https://releases.hashicorp.com/vault/${HVAC_VAULT_VERSION}/vault_${HVAC_VAULT_VERSION}_linux_amd64.zip
-    #unzip vault_${HVAC_VAULT_VERSION}_linux_amd64.zip
-    curl -sOL https://s3-us-west-2.amazonaws.com/hc-enterprise-binaries/vault/ent/${HVAC_VAULT_VERSION}/vault-enterprise_${HVAC_VAULT_VERSION}%2Bent_linux_amd64.zip
-    unzip vault-enterprise_${HVAC_VAULT_VERSION}%2Bent_linux_amd64.zip
+    if [[ "$HVAC_VAULT_LICENSE" == "oss" ]]; then
+        curl -sOL https://releases.hashicorp.com/vault/${HVAC_VAULT_VERSION}/vault_${HVAC_VAULT_VERSION}_linux_amd64.zip
+        unzip vault_${HVAC_VAULT_VERSION}_linux_amd64.zip
+    else
+        curl -sOL https://s3-us-west-2.amazonaws.com/hc-enterprise-binaries/vault/ent/${HVAC_VAULT_VERSION}/vault-enterprise_${HVAC_VAULT_VERSION}%2Bent_linux_amd64.zip
+        unzip vault-enterprise_${HVAC_VAULT_VERSION}%2Bent_linux_amd64.zip
+    fi
 
     mv vault $HOME/bin
 }

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -17,14 +17,27 @@ VERSION_REGEX = re.compile(r'Vault v([0-9.]+)')
 LATEST_VAULT_VERSION = '1.1.3'
 
 
-def get_installed_vault_version():
+def get_vault_version_string():
     command = ['vault', '-version']
     process = subprocess.Popen(**get_popen_kwargs(args=command, stdout=subprocess.PIPE))
     output, _ = process.communicate()
-    version = output.strip().split()[1].lstrip('v')
+    version_string = output.strip().split()[1].lstrip('v')
+    return version_string
+
+
+def get_installed_vault_version():
+    version_string = get_vault_version_string()
     # replace any '-beta1' type substrings with a StrictVersion parsable version. E.g., 1.0.0-beta1 => 1.0.0b1
-    version = version.replace('-', '').replace('beta', 'b')
+    version = version_string.replace('-', '').replace('beta', 'b')
+    version = version.replace('+ent', '')
     return version
+
+
+def is_enterprise():
+    version_string = get_vault_version_string()
+    if re.search(r'\+ent$', version_string) is not None:
+        return True
+    return False
 
 
 def if_vault_version(supported_version, comparison=operator.lt):

--- a/tests/utils/hvac_integration_test_case.py
+++ b/tests/utils/hvac_integration_test_case.py
@@ -6,7 +6,7 @@ import warnings
 
 from mock import patch
 
-from tests.utils import get_config_file_path, create_client
+from tests.utils import get_config_file_path, create_client, is_enterprise
 from tests.utils.server_manager import ServerManager
 import distutils.spawn
 
@@ -25,6 +25,10 @@ class HvacIntegrationTestCase(object):
         config_paths = [get_config_file_path('vault-tls.hcl')]
         if distutils.spawn.find_executable('consul') is None and cls.enable_vault_ha:
             logging.warning('Unable to run Vault in HA mode, consul binary not found in path.')
+            cls.enable_vault_ha = False
+        if is_enterprise():
+            # TODO: figure out why this bit isn't working
+            logging.warning('Unable to run Vault in HA mode, enterprise Vault version not currently supported.')
             cls.enable_vault_ha = False
         if cls.enable_vault_ha:
             config_paths = [


### PR DESCRIPTION
Building off @drewmullen's https://github.com/hvac/hvac/pull/474 PR here to start using Vault enterprise during Travis CI builds. This will allow us to add test cases for enterprise only features (e.g., Namespaces, MFA, etc.). While this is technically mergeable as is, I may take a bit more time to see about adding some additional bits. In particular:

- [x] Update documentation to clarify how to run tests with or without the enterprise Vault version locally.
- [x] Add at least one test case for an enterprise only feature that is skipped when testing against Vault OSS to serve as an example / pattern on how to do such things. (Would be nice to keep local test runs available for folks that only care about Vault OSS.)
- [x] Ideally fix whatever bits in the Vault HA (with Consul as the backend) aren't working with the Enterprise version of things. While the related test cases are automatically skipped without HA available in the test environment, and there aren't all that many of them at that, it would be nice to get this sorted so we're not reducing coverage overall.
- [x] Either see if HashiCorp can publish a 0.11.6 version of the Enterprise binary or update the Travis CI build matrix to drop this version.