### PR TITLE
Set up release-drafter / _mostly_ automated releases

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,8 @@
 name-template: 'v$NEXT_PATCH_VERSION'
 tag-template: 'v$NEXT_PATCH_VERSION'
+branches:
+  - 'master'
+  - 'develop'
 exclude-lables:
   - 'release'
 categories:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -12,6 +12,9 @@ categories:
   - title: '🐛 Bug Fixes'
     labels:
       - 'bug'
+  - title: '📚 Documentation'
+    labels:
+      - 'documentation'
   - title: '🧰 Miscellaneous'
     labels:
       - 'misc'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,7 @@
 name-template: 'v$NEXT_PATCH_VERSION'
 tag-template: 'v$NEXT_PATCH_VERSION'
+exclude-lables:
+  - 'release'
 categories:
   - title: '🚀 Features'
     labels:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,18 @@
+name-template: 'v$NEXT_PATCH_VERSION'
+tag-template: 'v$NEXT_PATCH_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'bug'
+  - title: '🧰 Miscellaneous'
+    labels:
+      - 'misc'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+template: |
+
+  $CHANGES
+
+  Thanks to $CONTRIBUTORS for their lovely contributions.

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,13 @@ script:
 notifications:
   webhooks:
     secure: "IuHvo7I77oZKo++O9QSq1TOtYOvZnqSTg7uO1lr7/+6fMsFLZE4YQVVqa3qyJwn5Q2DafAIdzVj5OyWT9FK8hDTAhqkDL4iVnh+Bk+ph1WBYA0OzFv32K0M46byUwTMmeq51DIuTozhJ/v58pYk6d95MJT9J5/cXCeGmr2vAUqo="
+deploy:
+  provider: pypi
+  user: hvac-bot
+  password:
+    secure: 2iA1+OX1fzv6+p13S1hAfUA9l8Rqh4PTjwTkZTiaRGoXNmdRVTG8F6Nyz4yW38bTROyHPD++/pTTtsQtCthH0595EDySBQG3DhRBMxXqZFMbLLQjWUpo3I2GCeEuWNblprsu7htMd41MKlQng8Qn8LdYFO51xtp577zVhA37hXM=
+  distributions: "sdist bdist_wheel"
+  skip_existing: true
+  skip_cleanup: true
+  on:
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ script:
 notifications:
   webhooks:
     secure: "IuHvo7I77oZKo++O9QSq1TOtYOvZnqSTg7uO1lr7/+6fMsFLZE4YQVVqa3qyJwn5Q2DafAIdzVj5OyWT9FK8hDTAhqkDL4iVnh+Bk+ph1WBYA0OzFv32K0M46byUwTMmeq51DIuTozhJ/v58pYk6d95MJT9J5/cXCeGmr2vAUqo="
+before_deploy:
+  - make package
 deploy:
   provider: pypi
   user: hvac-bot

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ deploy:
   provider: pypi
   user: hvac-bot
   password:
-    secure: 2iA1+OX1fzv6+p13S1hAfUA9l8Rqh4PTjwTkZTiaRGoXNmdRVTG8F6Nyz4yW38bTROyHPD++/pTTtsQtCthH0595EDySBQG3DhRBMxXqZFMbLLQjWUpo3I2GCeEuWNblprsu7htMd41MKlQng8Qn8LdYFO51xtp577zVhA37hXM=
+    secure: s9LLuUp1+ZTE3xvXdW9tF9hPUk7jxsFvol3PouDXdSVBNeVUhyHG1fMxOi1p8UOhx7e/iOGv8Bi77z0gDQgcynrFywhHEGbuna92Am40wMFT/Lu+JzHi8y2zBdahNsi80FnlNhW3MEtCNkXI6HgIlBpzEcfSm0ovfuncT0+5fCI=
   distributions: "sdist bdist_wheel"
   skip_existing: true
   skip_cleanup: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,9 +29,7 @@ Due to the close connection between this module and HashiCorp Vault versions, br
 * A deprecation notice should be displayed to callers of the module until the minor revision +2. E.g., a notice added in version 0.6.2 could see the marked method / functionality removed in version 0.8.0.
 * Breaking changes should be called out in the [CHANGELOG.md](CHANGELOG.md) for the affected version.
 
-## Package Publishing Checklist
-
-The follow list uses version number `0.6.2`, this string should be updated to match the intended release version. It is based on this document: [https://gist.github.com/audreyr/5990987](https://gist.github.com/audreyr/5990987)
+## Creating / Publishing Releases
 
 - [ ] Ensure your working directory is clear by running:
   ```
@@ -42,58 +40,15 @@ The follow list uses version number `0.6.2`, this string should be updated to ma
   git checkout develop
   git pull
   ```
-- [ ] Update [CHANGELOG.md](CHANGELOG.md) with a list of the included changes. Those changes can be reviewed, and their associated GitHub PR number confirmed, via GitHub's pull request diff. E.g.: [https://github.com/hvac/hvac/compare/master...develop](https://github.com/hvac/hvac/compare/master...develop). Then commit the changes:
+- [ ] Update the version number using [bumpversion](https://github.com/peritus/bumpversion). Releases typically just use the "patch" bumpversion option; but "minor" and "major" are available as needed as needed. This will also add an appropriate git commit for the new version.
   ```
-  git commit CHANGELOG.md -m 'Changelog updates for vX.X.X release'
+  bumpversion --no-tag {patch|minor|major}
   ```
-- [ ] Update version number using [bumpversion](https://github.com/peritus/bumpversion). Releases typically just use the "patch" bumpversion option; but "minor" and "major" are available as needed as needed. This will also add an appropriate git commit and tag for the new version.
+- [ ] Pull up the current draft [hvac release](https://github.com/hvac/hvac/releases/) and use the [release-drafter](https://github.com/toolmantim/release-drafter) generated release body to update [CHANGELOG.md](CHANGELOG.md). Then commit the changes:
   ```
-  bumpversion {patch|minor|major}
+  git commit CHANGELOG.md -m "Changelog updates for v$(grep -oP '(?<=current_version = ).*' .bumpversion.cfg)"
   ```
-- [ ] Install the package again for local development, but with the new version number:
-  ```
-  python setup.py develop
-  ```
-- [ ] Run the tests and verify that they all pass:
-  ```
-  make test
-  ```
-- [ ] Invoke setup.py / setuptools via the "package" Makefile job to create the release version's sdist and wheel artifacts:
-  ```
-  make package
-  ```
+- [ ] Git push the updated develop branch (`git push`) and open a PR to merge the develop branch into master:  [https://github.com/hvac/hvac/compare/master...develop](https://github.com/hvac/hvac/compare/master...develop). Ensure the PR has the "release" label applied and then merge it.
 
-- [ ] Publish the sdist and wheel artifacts to [TestPyPI](https://packaging.python.org/guides/using-testpypi/) using [twine](https://pypi.org/project/twine/):
-  ```
-  twine upload --repository-url https://test.pypi.org/legacy/ dist/*.tar.gz dist/*.whl
-  ```
-- [ ] Check the TestPyPI project page to make sure that the README, and release notes display properly: [https://test.pypi.org/project/hvac/](https://test.pypi.org/project/hvac/)
-- [ ] Test that the version is correctly listed and it pip installs (`mktmpenv` is available via the [virtualenvwrapper module](http://virtualenvwrapper.readthedocs.io/en/latest/install.html#shell-startup-file)) using the [TestPyPI](https://packaging.python.org/guides/using-testpypi/) repository (Note: installation will currently fail due to missing recent releases of `requests` on TestPyPI):
-  ```
-  mktmpenv
-  pip install --no-cache-dir --index-url https://test.pypi.org/simple hvac==
-  <verify releaes version shows up with the correct formatting in the resulting list>
-  pip install --no-cache-dir --index-url https://test.pypi.org/simple hvac==0.6.2
-  <verify hvac functionality>
-  deactivate
-  ```
-- [ ] Create a **draft** GitHub release using the contents of the new release version's [CHANGELOG.md](CHANGELOG.md) content: https://github.com/hvac/hvac/releases/new
-- [ ] Upload the sdist and whl files to the draft GitHub release as attached "binaries".
-- [ ] Git push the updated develop branch (`git push`) and open a PR to merge the develop branch into master:  [https://github.com/hvac/hvac/compare/master...develop](https://github.com/hvac/hvac/compare/master...develop)
-
-- [ ] Publish the sdist and wheel artifacts to [PyPI](https://pypi.org/) using [twine](https://pypi.org/project/twine/):
-  ```
-  twine upload dist/*.tar.gz dist/*.whl
-  ```
-- [ ] Check the PyPI project page to make sure that the README, and release notes display properly: [https://pypi.org/project/hvac/](https://pypi.org/project/hvac/)
-- [ ] Test that the version is correctly listed and it pip installs (`mktmpenv` is available via the [virtualenvwrapper module](http://virtualenvwrapper.readthedocs.io/en/latest/install.html#shell-startup-file)) using the [TestPyPI](https://packaging.python.org/guides/using-testpypi/) repository:
-  ```
-  mktmpenv
-  pip install --no-cache-dir hvac==
-  <verify releaes version shows up with the correct formatting in the resulting list>
-  pip install --no-cache-dir hvac==0.6.2
-  <verify hvac functionality>
-  deactivate
-  ```
-
-- [ ] Publish the draft release on GitHub: [https://github.com/hvac/hvac/releases](https://github.com/hvac/hvac/releases)
+- [ ] Publish the draft release on GitHub: [https://github.com/hvac/hvac/releases](https://github.com/hvac/hvac/releases).
+  NOTE: [release-drafter](https://github.com/toolmantim/release-drafter) sets the release name and tag to the next patch version by default. If performing a minor or major update, these values will need to be manually updated before publishing the draft release subsequently.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,10 +31,6 @@ Due to the close connection between this module and HashiCorp Vault versions, br
 
 ## Creating / Publishing Releases
 
-- [ ] Ensure your working directory is clear by running:
-  ```
-  make distclean
-  ```
 - [ ] Checkout the `develop` branch:
   ```
   git checkout develop


### PR DESCRIPTION
* Trying [this app out](https://github.com/toolmantim/release-drafter) as part of speeding up management of releases
* Enabling publication of git tagged commits / releases to pypi automatically via travis-ci once again
* Simplify steps for releases generally