### PR TITLE
Update Travis CI Test Matrix With Latest Vault Version & Drop Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,9 @@ python:
   - '3.6'
   - '3.7'
 env:
-  - HVAC_VAULT_VERSION=0.10.4
   - HVAC_VAULT_VERSION=0.11.0  # This ver kept explicitly; it has subsequently reverted backwards-incompatible changes.
-  - HVAC_VAULT_VERSION=0.11.6
   - HVAC_VAULT_VERSION=1.0.3
-  - HVAC_VAULT_VERSION=1.1.0
+  - HVAC_VAULT_VERSION=1.1.3
   - HVAC_VAULT_VERSION=HEAD
   - TOXENV=flake8
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ dist: xenial
 language: python
 python:
   - '2.7'
-  - '3.6'
   - '3.7'
 env:
   - HVAC_VAULT_VERSION=0.11.0  # This ver kept explicitly; it has subsequently reverted backwards-incompatible changes.

--- a/tests/scripts/install-vault.sh
+++ b/tests/scripts/install-vault.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eux
 
-DEFAULT_VAULT_VERSION=0.11.4
+DEFAULT_VAULT_VERSION=1.1.3
 HVAC_VAULT_VERSION=${1:-$DEFAULT_VAULT_VERSION}
 
 function build_and_install_vault_head_ref() {

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -14,7 +14,7 @@ from hvac import Client
 logger = logging.getLogger(__name__)
 
 VERSION_REGEX = re.compile(r'Vault v([0-9.]+)')
-LATEST_VAULT_VERSION = '0.11.4'
+LATEST_VAULT_VERSION = '1.1.3'
 
 
 def get_installed_vault_version():


### PR DESCRIPTION
* Tweaking supported Vault versions a smidge. Was inspired by #478 
* Dropping Python 3.6 test runs. We already have Python 3.7 coverage and dropping 3.6 will decrease the runtime of Travis CI builds quite a bit...