### PR TITLE
Add a Codeowners file for automatic reviewer assignments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# All changes must be approved by someone on the @hvac/hvac-maintainers team.
+# Reference: https://github.com/orgs/hvac/teams/hvac-maintainers/members
+* @hvac/hvac-maintainers


### PR DESCRIPTION
I personally like having outstanding PR's I need to review explicitly assigned to me (as a reviewer). This [file / feature](https://help.github.com/en/articles/about-code-owners) will handle that bit for this repository automatically.