### PR TITLE
Include Recently Added Namespace Documentation In Toctree

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Any given requirements file can be manually updated by following the pip-compile
 
 ## Documentation
 
-## Testing Docs
+### Testing Docs
 
 ```
 cd docs/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,14 @@ Any given requirements file can be manually updated by following the pip-compile
 
 ## Documentation
 
+### Adding New Documentation Files
+
+When adding documentation for an entirely new feature / class, it often makes sense to place the documentation in a new `.rst` file. After drafting the new file, be sure to add the file as an entry to at least one table of contents directive (e.g., `toctree`) to ensure it gets rendered and published on https://hvac.readthedocs.io/. As an example, the process for adding a new documentation file for a secrets engine related to Active Directory could involve:
+
+1. Add a new file to `docs/usage/secrets_engines` with a name along the lines of `active_directory.rst`.
+2. Update the `toctree` directive within `docs/usage/secrets_engines/index.rst` to add a line for `active_directory`
+3. Verify the new file is being included and rendered as expected by running `make html` from the `docs/` subdirectory. You can then view the rendered HTML documentation, in a browser or otherwise, by opening `docs/_build/html/index.html`.
+
 ### Testing Docs
 
 ```

--- a/docs/usage/system_backend/index.rst
+++ b/docs/usage/system_backend/index.rst
@@ -12,6 +12,7 @@ System Backend
    leader
    lease
    mount
+   namespace
    policy
    seal
    wrapping

--- a/docs/usage/system_backend/namespace.rst
+++ b/docs/usage/system_backend/namespace.rst
@@ -1,5 +1,5 @@
 Namespace
-=====
+=========
 
 .. contents::
    :local:

--- a/docs/usage/system_backend/namespace.rst
+++ b/docs/usage/system_backend/namespace.rst
@@ -16,7 +16,7 @@ Examples
 ````````
 
 .. testcode:: sys_namespace
-    :skipif: not test_utils.is_enterprise() 
+    :skipif: not test_utils.is_enterprise()
 
     import hvac
     client = hvac.Client(url='https://127.0.0.1:8200')
@@ -46,8 +46,8 @@ Examples
 ````````
 
 .. testcode:: sys_namespace
-    :skipif: not test_utils.is_enterprise() 
-    
+    :skipif: not test_utils.is_enterprise()
+
     import hvac
     client = hvac.Client(url='https://127.0.0.1:8200')
     client.sys.create_namespace(path='testns')


### PR DESCRIPTION
Funny story @drewmullen, we never actually patched in namespace.rst into a place that would get it pulled into the rendered docs / https://hvac.readthedocs.io! 

```
checking consistency... 
/[...]/workspace/hvac/docs/usage/system_backend/namespace.rst: 
WARNING: document isn't included in any toctree
```

Tried to add a bit to the contributing docs to help folks avoid a similar deal in the future. 

