### PR TITLE
Added list & create_update_policies definitions to access [child-namespaces] policies from [root-namespace]

### DIFF
--- a/hvac/api/system_backend/namespace.py
+++ b/hvac/api/system_backend/namespace.py
@@ -99,4 +99,3 @@ class Namespace(SystemBackendMixin):
             url=api_path,
             json=params,
         )
-

--- a/hvac/api/system_backend/namespace.py
+++ b/hvac/api/system_backend/namespace.py
@@ -1,3 +1,4 @@
+import json
 from hvac.api.system_backend.system_backend_mixin import SystemBackendMixin
 
 

--- a/hvac/api/system_backend/namespace.py
+++ b/hvac/api/system_backend/namespace.py
@@ -47,3 +47,55 @@ class Namespace(SystemBackendMixin):
             url=api_path,
         )
         return response
+
+    def list_policies_namespace(self, path):
+        """List all configured policies in namespaces.
+
+        Supported methods:
+            GET: {path}/sys/policy. Produces: 200 application/json
+
+        :param path: Specifies the namespace_name to list policies. This is specified as part of the URL.
+        :type path: str | unicode
+        :return: The JSON response of the request.
+        :rtype: dict
+        """
+        api_path = '/v1/{path}/sys/policy'.format(path=path)
+        response = self._adapter.get(
+            url=api_path,
+        )
+        return response.json()
+
+    def create_or_update_policy_namespace(self, path, name, policy, pretty_print=True):
+        """Add a new or update an existing policy.
+
+        Once a policy is updated, it takes effect immediately to all associated users.
+
+        Supported methods:
+            PUT: {path}/sys/policy/{name}. Produces: 204 (empty body)
+
+        :param name: Specifies the name of the policy to create.
+        :type name: str | unicode
+        :param policy: Specifies the policy document.
+        :type policy: str | unicode | dict
+        :param path: Specifies the namespace_name to create/update policies. This is specified as part of the URL.
+        :type path: str | unicode
+        :param pretty_print: If True, and provided a dict for the policy argument, send the policy JSON to Vault with
+            "pretty" formatting.
+        :type pretty_print: bool
+        :return: The response of the request.
+        :rtype: requests.Response
+        """
+        if isinstance(policy, dict):
+            if pretty_print:
+                policy = json.dumps(policy, indent=4, sort_keys=True)
+            else:
+                policy = json.dumps(policy)
+        params = {
+            'policy': policy,
+        }
+        api_path = '/v1/{path}/sys/policy/{name}'.format(path=path, name=name)
+        return self._adapter.put(
+            url=api_path,
+            json=params,
+        )
+


### PR DESCRIPTION
- Added definitions to list and create/update policy in specific namespace from root namespace
- Not sure if this is correct place for them to be
- This is added because I did not find a way to access the child-namespace/* from root-namespace, 
   Current module policy.py only allow us to GET/POST/LIST... to the namespace we are in