### PR TITLE
When creating an alias that already exists this creates an error

### DIFF
--- a/hvac/api/secrets_engines/identity.py
+++ b/hvac/api/secrets_engines/identity.py
@@ -370,7 +370,10 @@ class Identity(VaultApiBase):
             url=api_path,
             json=params,
         )
-        return response.json()
+        if response.status_code == 204:
+            return response
+        else:
+            return response.json()
 
     def read_entity_alias(self, alias_id, mount_point=DEFAULT_MOUNT_POINT):
         """Query the entity alias by its identifier.


### PR DESCRIPTION
Fixed by using logic also used for other created objects (that already exists and returns status 204).
If you create an alias on an entity that already exists this gives following error:
```
======================================================================
ERROR: test_create_entity (__main__.TeamTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/tom/repositories/gitlab-a/vault-provisioner/tests.py", line 40, in test_create_entity
    self.entity_handler.create(user)
  File "/home/tom/repositories/gitlab-a/vault-provisioner/handlers/entity_handler.py", line 29, in create
    self._create_alias(entity_id, user.id)
  File "/home/tom/repositories/gitlab-a/vault-provisioner/handlers/entity_handler.py", line 24, in _create_alias
    mount_accessor=self.__config.oidc_accessor,
  File "/home/tom/repositories/gitlab-a/vault-provisioner/venv/lib/python3.6/site-packages/hvac/api/secrets_engines/identity.py", line 373, in create_or_update_entity_alias
    return response.json()
  File "/home/tom/repositories/gitlab-a/vault-provisioner/venv/lib/python3.6/site-packages/requests/models.py", line 897, in json
    return complexjson.loads(self.text, **kwargs)
  File "/usr/lib/python3.6/json/__init__.py", line 354, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.6/json/decoder.py", line 339, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.6/json/decoder.py", line 357, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```