### PR TITLE
Improve Integration Test Error Handling

### DIFF
--- a/tests/integration_tests/api/auth_methods/test_github.py
+++ b/tests/integration_tests/api/auth_methods/test_github.py
@@ -33,7 +33,7 @@ class TestGithub(HvacIntegrationTestCase, TestCase):
             cls.mock_server_thread = Thread(target=cls.mock_server.serve_forever)
             cls.mock_server_thread.setDaemon(True)
             cls.mock_server_thread.start()
-        except:
+        except Exception:
             # Ensure that Vault server is taken down if setUpClass fails
             super(TestGithub, cls).tearDownClass()
             raise

--- a/tests/integration_tests/api/auth_methods/test_github.py
+++ b/tests/integration_tests/api/auth_methods/test_github.py
@@ -21,16 +21,22 @@ class TestGithub(HvacIntegrationTestCase, TestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestGithub, cls).setUpClass()
-        # Configure mock server.
-        cls.mock_server_port = utils.get_free_port()
-        cls.mock_server = HTTPServer(('localhost', cls.mock_server_port), MockGithubRequestHandler)
+        try:
+            super(TestGithub, cls).setUpClass()
 
-        # Start running mock server in a separate thread.
-        # Daemon threads automatically shut down when the main process exits.
-        cls.mock_server_thread = Thread(target=cls.mock_server.serve_forever)
-        cls.mock_server_thread.setDaemon(True)
-        cls.mock_server_thread.start()
+            # Configure mock server.
+            cls.mock_server_port = utils.get_free_port()
+            cls.mock_server = HTTPServer(('localhost', cls.mock_server_port), MockGithubRequestHandler)
+
+            # Start running mock server in a separate thread.
+            # Daemon threads automatically shut down when the main process exits.
+            cls.mock_server_thread = Thread(target=cls.mock_server.serve_forever)
+            cls.mock_server_thread.setDaemon(True)
+            cls.mock_server_thread.start()
+        except:
+            # Ensure that Vault server is taken down if setUpClass fails
+            super(TestGithub, cls).tearDownClass()
+            raise
 
     def setUp(self):
         super(TestGithub, self).setUp()

--- a/tests/integration_tests/api/auth_methods/test_ldap.py
+++ b/tests/integration_tests/api/auth_methods/test_ldap.py
@@ -27,7 +27,7 @@ class TestLdap(HvacIntegrationTestCase, TestCase):
             cls.mock_server_port = utils.get_free_port()
             cls.ldap_server = MockLdapServer()
             cls.ldap_server.start()
-        except:
+        except Exception:
             # Ensure that Vault server is taken down if setUpClass fails
             super(TestLdap, cls).tearDownClass()
             raise

--- a/tests/integration_tests/api/auth_methods/test_ldap.py
+++ b/tests/integration_tests/api/auth_methods/test_ldap.py
@@ -18,7 +18,7 @@ class TestLdap(HvacIntegrationTestCase, TestCase):
     def setUpClass(cls):
         # The mock LDAP server requires Java runtime
         if not distutils.spawn.find_executable('java'):
-            raise SkipTest
+            raise SkipTest('The mock LDAP server requires Java runtime')
 
         try:
             super(TestLdap, cls).setUpClass()

--- a/tests/integration_tests/api/auth_methods/test_ldap.py
+++ b/tests/integration_tests/api/auth_methods/test_ldap.py
@@ -1,5 +1,6 @@
+import distutils.spawn
 import logging
-from unittest import TestCase
+from unittest import TestCase, SkipTest
 
 from parameterized import parameterized, param
 
@@ -15,12 +16,21 @@ class TestLdap(HvacIntegrationTestCase, TestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestLdap, cls).setUpClass()
-        logging.getLogger('ldap_test').setLevel(logging.ERROR)
+        # The mock LDAP server requires Java runtime
+        if not distutils.spawn.find_executable('java'):
+            raise SkipTest
 
-        cls.mock_server_port = utils.get_free_port()
-        cls.ldap_server = MockLdapServer()
-        cls.ldap_server.start()
+        try:
+            super(TestLdap, cls).setUpClass()
+            logging.getLogger('ldap_test').setLevel(logging.ERROR)
+
+            cls.mock_server_port = utils.get_free_port()
+            cls.ldap_server = MockLdapServer()
+            cls.ldap_server.start()
+        except:
+            # Ensure that Vault server is taken down if setUpClass fails
+            super(TestLdap, cls).tearDownClass()
+            raise
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/scripts/install-vault.sh
+++ b/tests/scripts/install-vault.sh
@@ -16,12 +16,9 @@ function build_and_install_vault_head_ref() {
 
     export PATH=$GOPATH/bin:$PATH
 
-    go get github.com/tools/godep
-    go get github.com/mitchellh/gox
-
     git clone https://github.com/hashicorp/vault.git $GOPATH/src/github.com/hashicorp/vault
     cd $GOPATH/src/github.com/hashicorp/vault
-    make dev
+    make bootstrap dev
 
     mv bin/vault $HOME/bin
 }

--- a/tests/scripts/install-vault.sh
+++ b/tests/scripts/install-vault.sh
@@ -9,7 +9,7 @@ HVAC_VAULT_LICENSE=${2:-DEFAULT_VAULT_LICENSE}
 function build_and_install_vault_head_ref() {
     mkdir -p $HOME/bin
 
-    eval "$(GIMME_GO_VERSION=1.11 gimme)"
+    eval "$(GIMME_GO_VERSION=1.12.7 gimme)"
 
     export GOPATH=$HOME/go
     mkdir $GOPATH

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -20,8 +20,8 @@ LATEST_VAULT_VERSION = '1.1.3'
 
 
 def get_vault_version_string():
-    if not find_executable("vault"):
-        raise SkipTest
+    if not find_executable('vault'):
+        raise SkipTest('Vault executable not found')
     command = ['vault', '-version']
     process = subprocess.Popen(**get_popen_kwargs(args=command, stdout=subprocess.PIPE))
     output, _ = process.communicate()

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -7,6 +7,8 @@ import re
 import socket
 import subprocess
 import sys
+from unittest import SkipTest
+from distutils.spawn import find_executable
 from distutils.version import StrictVersion
 
 from hvac import Client
@@ -18,6 +20,8 @@ LATEST_VAULT_VERSION = '1.1.3'
 
 
 def get_vault_version_string():
+    if not find_executable("vault"):
+        raise SkipTest
     command = ['vault', '-version']
     process = subprocess.Popen(**get_popen_kwargs(args=command, stdout=subprocess.PIPE))
     output, _ = process.communicate()

--- a/tests/utils/hvac_integration_test_case.py
+++ b/tests/utils/hvac_integration_test_case.py
@@ -40,14 +40,19 @@ class HvacIntegrationTestCase(object):
             client=create_client(),
             use_consul=cls.enable_vault_ha,
         )
-        cls.manager.start()
-        cls.manager.initialize()
-        cls.manager.unseal()
+        try:
+            cls.manager.start()
+            cls.manager.initialize()
+            cls.manager.unseal()
+        except:
+            cls.manager.stop()
+            raise
 
     @classmethod
     def tearDownClass(cls):
         """Stop the vault server process at the conclusion of a test class."""
-        cls.manager.stop()
+        if cls.manager:
+            cls.manager.stop()
 
     def setUp(self):
         """Set the client attribute to an authenticated hvac Client instance."""

--- a/tests/utils/hvac_integration_test_case.py
+++ b/tests/utils/hvac_integration_test_case.py
@@ -44,7 +44,7 @@ class HvacIntegrationTestCase(object):
             cls.manager.start()
             cls.manager.initialize()
             cls.manager.unseal()
-        except:
+        except Exception:
             cls.manager.stop()
             raise
 

--- a/tests/utils/hvac_integration_test_case.py
+++ b/tests/utils/hvac_integration_test_case.py
@@ -5,7 +5,6 @@ import re
 import warnings
 
 from mock import patch
-from unittest import SkipTest
 
 from tests.utils import get_config_file_path, create_client, is_enterprise
 from tests.utils.server_manager import ServerManager
@@ -24,8 +23,6 @@ class HvacIntegrationTestCase(object):
     def setUpClass(cls):
         """Use the ServerManager class to launch a vault server process."""
         config_paths = [get_config_file_path('vault-tls.hcl')]
-        if distutils.spawn.find_executable('vault') is None:
-            raise SkipTest
         if distutils.spawn.find_executable('consul') is None and cls.enable_vault_ha:
             logging.warning('Unable to run Vault in HA mode, consul binary not found in path.')
             cls.enable_vault_ha = False

--- a/tests/utils/hvac_integration_test_case.py
+++ b/tests/utils/hvac_integration_test_case.py
@@ -5,6 +5,7 @@ import re
 import warnings
 
 from mock import patch
+from unittest import SkipTest
 
 from tests.utils import get_config_file_path, create_client, is_enterprise
 from tests.utils.server_manager import ServerManager
@@ -23,6 +24,8 @@ class HvacIntegrationTestCase(object):
     def setUpClass(cls):
         """Use the ServerManager class to launch a vault server process."""
         config_paths = [get_config_file_path('vault-tls.hcl')]
+        if distutils.spawn.find_executable('vault') is None:
+            raise SkipTest
         if distutils.spawn.find_executable('consul') is None and cls.enable_vault_ha:
             logging.warning('Unable to run Vault in HA mode, consul binary not found in path.')
             cls.enable_vault_ha = False

--- a/tests/utils/server_manager.py
+++ b/tests/utils/server_manager.py
@@ -7,6 +7,8 @@ import time
 import requests
 import hcl
 
+import distutils.spawn
+from unittest import SkipTest
 from tests.utils import get_config_file_path, load_config_file, create_client
 
 logger = logging.getLogger(__name__)
@@ -36,6 +38,9 @@ class ServerManager(object):
         """Launch the vault server process and wait until its online and ready."""
         if self.use_consul:
             self.start_consul()
+
+        if distutils.spawn.find_executable('vault') is None:
+            raise SkipTest('Vault executable not found')
 
         # If a vault server is already running then we won't be able to start another one.
         # If we can't start our vault server then we don't know what we're testing against.
@@ -82,6 +87,9 @@ class ServerManager(object):
                 )
 
     def start_consul(self):
+        if distutils.spawn.find_executable('consul') is None:
+            raise SkipTest('Consul executable not found')
+
         try:
             requests.get('http://127.0.0.1:8500/v1/catalog/nodes')
         except Exception:


### PR DESCRIPTION
This MR fixes issue #530 and partially fixes #207.

It includes the following changes:

- Throw an exception if a Vault instance is already running.
  - This is mainly to prevent interacting with someone's personal Vault instance or tunnel as if it were a test instance.
- If any integration test fails, the created Vault instance(s) are terminated.
  - The ServerManager's stop method works correctly regardless if any instances were actually created, so it's always safe to call it.
- An exception is now thrown if the Vault instance terminates before becoming ready.
  - This handles cases where the port is already in use or some other unspecified error occurs.
- If a Vault executable isn't found, the integration tests are skipped.
- If a Java executable isn't found, the LDAP integration tests are skipped.
- Added a few extra debug statements when starting/killing Vault instances to include process IDs.
- Minor rewording of variables and docstrings in the ServerManager class.