### PR TITLE
Fix Travis HEAD build + Overhaul install scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   - HVAC_VAULT_VERSION=1.1.3 HVAC_VAULT_LICENSE=enterprise
   - HVAC_VAULT_VERSION=1.0.3 HVAC_VAULT_LICENSE=enterprise
   - HVAC_VAULT_VERSION=0.11.0 HVAC_VAULT_LICENSE=enterprise  # This ver kept explicitly; it has subsequently reverted backwards-incompatible changes.
-  - HVAC_VAULT_VERSION=HEAD HVAC_VAULT_LICENSE=OSS
+  - HVAC_VAULT_VERSION=STABLE HVAC_VAULT_LICENSE=OSS
   - TOXENV=flake8
 matrix:
   include:
@@ -32,8 +32,8 @@ matrix:
         on:
           tags: true
   allow_failures:
-    # Ignore failed tests run against Vault builds using the HEAD ref at: https://github.com/hashicorp/vault.
-    - env: HVAC_VAULT_VERSION=HEAD HVAC_VAULT_LICENSE=OSS
+    # Ignore failed tests run against Vault development builds compiled from https://github.com/hashicorp/vault.
+    - env: HVAC_VAULT_VERSION=STABLE HVAC_VAULT_LICENSE=OSS
   # Don't wait on the "allow_failures" build jobs before reporting on the overall success/failure of the current build.
   fast_finish: true
 install:

--- a/tests/scripts/install-consul.sh
+++ b/tests/scripts/install-consul.sh
@@ -1,17 +1,21 @@
 #!/bin/bash
 set -eux
 
-DEFAULT_CONSUL_VERSION=1.4.0
-HVAC_CONSUL_VERSION=${1:-$DEFAULT_CONSUL_VERSION}
+DEFAULT_CONSUL_VERSION="1.4.0"
+DEFAULT_CONSUL_DIRECTORY="${HOME}/bin"
+HVAC_CONSUL_VERSION="${1:-$DEFAULT_CONSUL_VERSION}"
+HVAC_CONSUL_DIRECTORY="${2:-$DEFAULT_CONSUL_DIRECTORY}"
 
 function install_consul_release() {
-    mkdir -p $HOME/bin
+    cd "/tmp"
 
-    cd /tmp
+    download_url="https://releases.hashicorp.com/consul/${HVAC_CONSUL_VERSION}/consul_${HVAC_CONSUL_VERSION}_linux_amd64.zip"
+    download_file="consul_${HVAC_CONSUL_VERSION}.zip"
+    curl -sL "${download_url}" -o "${download_file}"
+    unzip "${download_file}"
 
-    curl -sOL https://releases.hashicorp.com/consul/${HVAC_CONSUL_VERSION}/consul_${HVAC_CONSUL_VERSION}_linux_amd64.zip
-    unzip consul_${HVAC_CONSUL_VERSION}_linux_amd64.zip
-    mv consul $HOME/bin
+    mkdir -p "${HVAC_CONSUL_DIRECTORY}"
+    mv "consul" "${HVAC_CONSUL_DIRECTORY}"
 }
 
 install_consul_release

--- a/tests/scripts/install-vault.sh
+++ b/tests/scripts/install-vault.sh
@@ -9,7 +9,7 @@ HVAC_VAULT_LICENSE="${2:-$DEFAULT_VAULT_LICENSE}"
 HVAC_VAULT_DIRECTORY="${3:-$DEFAULT_VAULT_DIRECTORY}"
 
 function build_and_install_vault_ref() {
-    if ! command -v go &>"/dev/null"; then
+    if command -v gimme &>"/dev/null"; then
         eval "$(GIMME_GO_VERSION=1.12.7 gimme)"
     fi
     export PATH="$(go env GOPATH)/bin:${PATH}"

--- a/tests/scripts/install-vault.sh
+++ b/tests/scripts/install-vault.sh
@@ -16,8 +16,9 @@ function build_and_install_vault_head_ref() {
 
     export PATH=$GOPATH/bin:$PATH
 
-    git clone https://github.com/hashicorp/vault.git $GOPATH/src/github.com/hashicorp/vault
-    cd $GOPATH/src/github.com/hashicorp/vault
+    build_dir="/tmp/src/github.com/hashicorp/vault"
+    git clone https://github.com/hashicorp/vault.git "${build_dir}"
+    cd "${build_dir}"
     make bootstrap dev
 
     mv bin/vault $HOME/bin

--- a/tests/scripts/install-vault.sh
+++ b/tests/scripts/install-vault.sh
@@ -1,46 +1,64 @@
 #!/bin/bash
 set -eux
 
-DEFAULT_VAULT_VERSION=1.1.3
-DEFAULT_VAULT_LICENSE=oss
-HVAC_VAULT_VERSION=${1:-$DEFAULT_VAULT_VERSION}
-HVAC_VAULT_LICENSE=${2:-DEFAULT_VAULT_LICENSE}
+DEFAULT_VAULT_VERSION="1.1.3"
+DEFAULT_VAULT_LICENSE="oss"
+DEFAULT_VAULT_DIRECTORY="${HOME}/bin"
+HVAC_VAULT_VERSION="${1:-$DEFAULT_VAULT_VERSION}"
+HVAC_VAULT_LICENSE="${2:-$DEFAULT_VAULT_LICENSE}"
+HVAC_VAULT_DIRECTORY="${3:-$DEFAULT_VAULT_DIRECTORY}"
 
-function build_and_install_vault_head_ref() {
-    mkdir -p $HOME/bin
-
-    eval "$(GIMME_GO_VERSION=1.12.7 gimme)"
-
-    export GOPATH=$HOME/go
-    mkdir $GOPATH
-
-    export PATH=$GOPATH/bin:$PATH
+function build_and_install_vault_ref() {
+    if ! command -v go &>"/dev/null"; then
+        eval "$(GIMME_GO_VERSION=1.12.7 gimme)"
+    fi
+    export PATH="$(go env GOPATH)/bin:${PATH}"
 
     build_dir="/tmp/src/github.com/hashicorp/vault"
-    git clone https://github.com/hashicorp/vault.git "${build_dir}"
+    if [[ ! -d "${build_dir}" ]]; then
+        git clone "https://github.com/hashicorp/vault.git" "${build_dir}"
+    fi
     cd "${build_dir}"
+
+    case "${HVAC_VAULT_VERSION}" in
+        "head"|"master")
+            git checkout master
+            ;;
+        "stable")
+            latest_tag_hash=$(git rev-list --tags --max-count=1)
+            git checkout "${latest_tag_hash}"
+            ;;
+    esac
+
     make bootstrap dev
 
-    mv bin/vault $HOME/bin
+    mkdir -p "${HVAC_VAULT_DIRECTORY}"
+    mv "bin/vault" "${HVAC_VAULT_DIRECTORY}"
 }
 
 function install_vault_release() {
-    mkdir -p $HOME/bin
+    cd "/tmp"
 
-    cd /tmp
-    if [[ "$HVAC_VAULT_LICENSE" == "enterprise" ]]; then
-        curl -sOL https://s3-us-west-2.amazonaws.com/hc-enterprise-binaries/vault/ent/${HVAC_VAULT_VERSION}/vault-enterprise_${HVAC_VAULT_VERSION}%2Bent_linux_amd64.zip
-        unzip vault-enterprise_${HVAC_VAULT_VERSION}%2Bent_linux_amd64.zip
+    if [[ "${HVAC_VAULT_LICENSE}" == "enterprise" ]]; then
+        download_url="https://s3-us-west-2.amazonaws.com/hc-enterprise-binaries/vault/ent/${HVAC_VAULT_VERSION}/vault-enterprise_${HVAC_VAULT_VERSION}%2Bent_linux_amd64.zip"
     else
-        curl -sOL https://releases.hashicorp.com/vault/${HVAC_VAULT_VERSION}/vault_${HVAC_VAULT_VERSION}_linux_amd64.zip
-        unzip vault_${HVAC_VAULT_VERSION}_linux_amd64.zip
+        download_url="https://releases.hashicorp.com/vault/${HVAC_VAULT_VERSION}/vault_${HVAC_VAULT_VERSION}_linux_amd64.zip"
     fi
+    download_file="vault_${HVAC_VAULT_LICENSE}_${HVAC_VAULT_VERSION}.zip"
 
-    mv vault $HOME/bin
+    curl -sL "${download_url}" -o "${download_file}"
+    unzip "${download_file}"
+
+    mkdir -p "${HVAC_VAULT_DIRECTORY}"
+    mv "vault" "${HVAC_VAULT_DIRECTORY}"
 }
 
-if [[ "$(tr [A-Z] [a-z] <<<"$HVAC_VAULT_VERSION")" == "head" ]]; then
-    build_and_install_vault_head_ref
-else
-    install_vault_release
-fi
+HVAC_VAULT_VERSION=$(tr '[:upper:]' '[:lower:]' <<< "${HVAC_VAULT_VERSION}")
+case "${HVAC_VAULT_VERSION}" in
+    "head"|"master"|"stable")
+        build_and_install_vault_ref
+        ;;
+    *)
+        install_vault_release
+        ;;
+esac

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -18,17 +18,16 @@ logger = logging.getLogger(__name__)
 VERSION_REGEX = re.compile(r'Vault v([0-9.]+)')
 LATEST_VAULT_VERSION = '1.1.3'
 
-__VAULT_VERSION_STRING = None
 def get_vault_version_string():
-    if __VAULT_VERSION_STRING is not None:
-        return __VAULT_VERSION_STRING
+    if 'cache' in get_vault_version_string.__dict__:
+        return get_vault_version_string.cache
     if not find_executable('vault'):
         raise SkipTest('Vault executable not found')
     command = ['vault', '-version']
     process = subprocess.Popen(**get_popen_kwargs(args=command, stdout=subprocess.PIPE))
     output, _ = process.communicate()
     version_string = output.strip().split()[1].lstrip('v')
-    __VAULT_VERSION_STRING = version_string
+    get_vault_version_string.cache = version_string
     return version_string
 
 

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -18,14 +18,17 @@ logger = logging.getLogger(__name__)
 VERSION_REGEX = re.compile(r'Vault v([0-9.]+)')
 LATEST_VAULT_VERSION = '1.1.3'
 
-
+__VAULT_VERSION_STRING = None
 def get_vault_version_string():
+    if __VAULT_VERSION_STRING is not None:
+        return __VAULT_VERSION_STRING
     if not find_executable('vault'):
         raise SkipTest('Vault executable not found')
     command = ['vault', '-version']
     process = subprocess.Popen(**get_popen_kwargs(args=command, stdout=subprocess.PIPE))
     output, _ = process.communicate()
     version_string = output.strip().split()[1].lstrip('v')
+    __VAULT_VERSION_STRING = version_string
     return version_string
 
 
@@ -45,10 +48,7 @@ def is_enterprise():
 
 
 def if_vault_version(supported_version, comparison=operator.lt):
-    current_version = os.getenv('HVAC_VAULT_VERSION')
-    if current_version is None or current_version.lower() == 'head':
-        current_version = get_installed_vault_version()
-
+    current_version = get_installed_vault_version()
     return comparison(StrictVersion(current_version), StrictVersion(supported_version))
 
 

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 VERSION_REGEX = re.compile(r'Vault v([0-9.]+)')
 LATEST_VAULT_VERSION = '1.1.3'
 
+
 def get_vault_version_string():
     if 'cache' in get_vault_version_string.__dict__:
         return get_vault_version_string.cache


### PR DESCRIPTION
The root cause of the Travis HEAD builds failing was that the git repo was cloned under the `$GOPATH/src` directory.  This was causing go to get confused when looking for modules.

I also took the liberty of overhauling the installer scripts to add a few features:

1. The Vault and Consul installer scripts now pass [shellcheck](https://github.com/koalaman/shellcheck) with no warnings.
1. The Vault installer can now download/compile Vault outside of Travis.  This makes it easier for people like me to build from source.
1. The Vault installer now has a "stable" version option that builds the latest git tag instead of the latest master commit.  This should give _considerably_ more useful test results instead of intermittent failures from bad commits to master.

I went ahead and updated the Travis builds to use the "stable" version instead of "head".  The "head" builds _do_ compile, but they result extra test failures because the integration tests can't parse the version number (they end with a "dev" suffix).  It's something that will eventually need fixing, but it can probably wait for a later date.

All of that said, builds pass, but tests are failing on the "stable" builds. 😰