### PR TITLE
Handle bad gateway from Vault

### DIFF
--- a/hvac/exceptions.py
+++ b/hvac/exceptions.py
@@ -44,5 +44,9 @@ class UnexpectedError(VaultError):
     pass
 
 
+class BadGateway(VaultError):
+    pass
+
+
 class ParamValidationError(VaultError):
     pass

--- a/hvac/utils.py
+++ b/hvac/utils.py
@@ -42,10 +42,12 @@ def raise_for_error(status_code, message=None, errors=None):
         raise exceptions.InternalServerError(message, errors=errors)
     elif status_code == 501:
         raise exceptions.VaultNotInitialized(message, errors=errors)
+    elif status_code == 502:
+        raise exceptions.BadGateway(message, errors=errors)
     elif status_code == 503:
         raise exceptions.VaultDown(message, errors=errors)
     else:
-        raise exceptions.UnexpectedError(message)
+        raise exceptions.UnexpectedError(message or errors)
 
 
 def generate_method_deprecation_message(to_be_removed_in_version, old_method_name, method_name=None, module_name=None):


### PR DESCRIPTION
We were getting vault 502's that were not coming through in the client properly.

This pull requests add explicit support for 502 Bad Gateway errors from vault.

This also handles the case where vault returns a set of JSON errors but a status code that is unrecognized by the client.  Previously this would cause message to be None and UnexpectedException(None) would be returned.