### PR TITLE
Add a correct endpoint for CRL retrieving 

### DIFF
--- a/hvac/api/secrets_engines/pki.py
+++ b/hvac/api/secrets_engines/pki.py
@@ -203,20 +203,26 @@ class Pki(VaultApiBase):
             json=params,
         )
 
-    def read_crl(self, mount_point=DEFAULT_MOUNT_POINT):
+    def read_crl(self, mount_point=DEFAULT_MOUNT_POINT, pem=False):
         """Read CRL.
 
-        Retrieves the current CRL **in raw DER-encoded form**.
+        Retrieves the current CRL **in raw DER-encoded form** by default.
+        You can retrieve CRL in the PEM format if a param 'pem' is set to True.
 
         Supported methods:
-            GET: /{mount_point}/config/crl. Produces: 200 application/json
+            GET: /{mount_point}/crl. Produces: 200 application/json
+            GET: /{mount_point}/crl/pem. Produces: 200 application/json
 
         :param mount_point: The "path" the method/backend was mounted on.
         :type mount_point: str | unicode
+        :param pem: Request CRL in PEM format.
+        :type pem: boolean
         :return: The JSON response of the request.
         :rtype: dict
         """
         api_path = utils.format_url('/v1/{mount_point}/config/crl', mount_point=mount_point)
+        if pem:
+            api_path = utils.format_url('{api_path}/pem', api_path=api_path)
         response = self._adapter.get(
             url=api_path,
         )

--- a/hvac/api/secrets_engines/pki.py
+++ b/hvac/api/secrets_engines/pki.py
@@ -208,25 +208,27 @@ class Pki(VaultApiBase):
 
         Retrieves the current CRL **in raw DER-encoded form** by default.
         You can retrieve CRL in the PEM format if a param 'pem' is set to True.
+        This endpoint is an unauthenticated.
+
 
         Supported methods:
-            GET: /{mount_point}/crl. Produces: 200 application/json
-            GET: /{mount_point}/crl/pem. Produces: 200 application/json
+            GET: /{mount_point}/crl. Produces: 200 application/pkix-crl
+            GET: /{mount_point}/crl/pem. Produces: 200 application/pkix-crl
 
         :param mount_point: The "path" the method/backend was mounted on.
         :type mount_point: str | unicode
         :param pem: Request CRL in PEM format.
         :type pem: boolean
-        :return: The JSON response of the request.
-        :rtype: dict
+        :return: The content of the request e.g. CRL string representation.
+        :rtype: str
         """
-        api_path = utils.format_url('/v1/{mount_point}/config/crl', mount_point=mount_point)
+        api_path = utils.format_url('/v1/{mount_point}/crl', mount_point=mount_point)
+
         if pem:
             api_path = utils.format_url('{api_path}/pem', api_path=api_path)
-        response = self._adapter.get(
-            url=api_path,
-        )
-        return response.json()
+
+        response = self._adapter.get(url=api_path)
+        return response.text
 
     def rotate_crl(self, mount_point=DEFAULT_MOUNT_POINT):
         """Rotate CRLs.

--- a/hvac/api/secrets_engines/pki.py
+++ b/hvac/api/secrets_engines/pki.py
@@ -203,32 +203,24 @@ class Pki(VaultApiBase):
             json=params,
         )
 
-    def read_crl(self, mount_point=DEFAULT_MOUNT_POINT, pem=False):
+    def read_crl(self, mount_point=DEFAULT_MOUNT_POINT):
         """Read CRL.
 
-        Retrieves the current CRL **in raw DER-encoded form** by default.
-        You can retrieve CRL in the PEM format if a param 'pem' is set to True.
+        Retrieves the current CRL in PEM format.
         This endpoint is an unauthenticated.
 
-
         Supported methods:
-            GET: /{mount_point}/crl. Produces: 200 application/pkix-crl
             GET: /{mount_point}/crl/pem. Produces: 200 application/pkix-crl
 
         :param mount_point: The "path" the method/backend was mounted on.
         :type mount_point: str | unicode
-        :param pem: Request CRL in PEM format.
-        :type pem: boolean
         :return: The content of the request e.g. CRL string representation.
         :rtype: str
         """
-        api_path = utils.format_url('/v1/{mount_point}/crl', mount_point=mount_point)
-
-        if pem:
-            api_path = utils.format_url('{api_path}/pem', api_path=api_path)
-
+        api_path = utils.format_url('/v1/{mount_point}/crl/pem', mount_point=mount_point)
         response = self._adapter.get(url=api_path)
-        return response.text
+        # python2.7 uses unicode
+        return str(response.text)
 
     def rotate_crl(self, mount_point=DEFAULT_MOUNT_POINT):
         """Rotate CRLs.

--- a/tests/integration_tests/api/secrets_engines/test_pki.py
+++ b/tests/integration_tests/api/secrets_engines/test_pki.py
@@ -236,7 +236,7 @@ class TestPki(HvacIntegrationTestCase, TestCase):
         logging.debug('read_crl_response: %s' % read_crl_response)
         self.assertIsInstance(
             obj=read_crl_response,
-            cls=dict,
+            cls=str,
         )
 
     # Rotate CRLs


### PR DESCRIPTION
Use a correct Vault endpoint to fetch `CRL` in `PEM` format - see [DOC](https://www.vaultproject.io/api/secret/pki/index.html#read-crl). 