### PR TITLE
Fix a bug when creating external groups

### DIFF
--- a/hvac/api/secrets_engines/identity.py
+++ b/hvac/api/secrets_engines/identity.py
@@ -815,6 +815,9 @@ class Identity(VaultApiBase):
             mount_point=mount_point,
             name=name,
         )
+        filtered = {k: v for k, v in params.items() if v is not None}
+        params.clear()
+        params.update(filtered)
         response = self._adapter.post(
             url=api_path,
             json=params,


### PR DESCRIPTION
When creating external group, the API call includes the members keys even if they are null, and this results in the API responding with the error "Exception: member entities can't be set manually for external groups"