### PR TITLE
Switch to new common token fields for auth backends

### DIFF
--- a/docs/usage/auth_methods/azure.rst
+++ b/docs/usage/auth_methods/azure.rst
@@ -85,7 +85,7 @@ Create a Role
 
     client.auth.azure.create_role(
         name='my-role',
-        policies=policies,
+        token_policies=policies,
         bound_service_principal_ids=bound_service_principal_ids,
     )
 
@@ -105,7 +105,7 @@ Read A Role
     )
     print('Policies for role "{name}": {policies}'.format(
         name='my-role',
-        policies=','.join(read_role_response['policies']),
+        policies=','.join(read_role_response['token_policies']),
     ))
 
 List Roles

--- a/docs/usage/auth_methods/gcp.rst
+++ b/docs/usage/auth_methods/gcp.rst
@@ -142,7 +142,7 @@ Source reference: :py:meth:`hvac.api.auth.Gcp.read_role`
 
     print('Policies for role "{name}": {policies}'.format(
         name='my-role',
-        policies=','.join(read_role_response['policies']),
+        policies=','.join(read_role_response['token_policies']),
     ))
 
 List Roles

--- a/docs/usage/auth_methods/github.rst
+++ b/docs/usage/auth_methods/github.rst
@@ -39,7 +39,7 @@ Configure Connection Parameters
 
     client.auth.github.configure(
         organization='our-lovely-company',
-        max_ttl='48h',  # i.e., A given token can only be renewed for up to 48 hours
+        token_max_ttl='48h',  # i.e., A given token can only be renewed for up to 48 hours
     )
 
 Reading Configuration
@@ -54,7 +54,7 @@ Reading Configuration
 
     github_config = client.auth.github.read_configuration()
     print('The Github auth method is configured with a ttl of: {ttl}'.format(
-        ttl=github_config['data']['ttl']
+        ttl=github_config['data']['token_ttl']
     )
 
 

--- a/hvac/api/auth_methods/aws.py
+++ b/hvac/api/auth_methods/aws.py
@@ -418,9 +418,10 @@ class Aws(VaultApiBase):
                     bound_region=None, bound_vpc_id=None, bound_subnet_id=None, bound_iam_role_arn=None,
                     bound_iam_instance_profile_arn=None, bound_ec2_instance_id=None, role_tag=None,
                     bound_iam_principal_arn=None, inferred_entity_type=None, inferred_aws_region=None,
-                    resolve_aws_unique_ids=None, ttl=None, max_ttl=None, period=None, policies=None,
-                    allow_instance_migration=None, disallow_reauthentication=None,
-                    mount_point=AWS_DEFAULT_MOUNT_POINT):
+                    resolve_aws_unique_ids=None, allow_instance_migration=None, disallow_reauthentication=None,
+                    token_ttl=None, token_max_ttl=None, token_policies=None, token_bound_cidrs=None,
+                    token_explicit_max_ttl=None, token_no_default_policy=None, token_num_uses=None,
+                    token_period=None, token_type=None, mount_point=AWS_DEFAULT_MOUNT_POINT):
         """Registers a role in the method. Only those instances or principals which are using the role registered
             using this endpoint, will be able to perform the login operation
 
@@ -446,12 +447,17 @@ class Aws(VaultApiBase):
         :param inferred_entity_type:
         :param inferred_aws_region:
         :param resolve_aws_unique_ids:
-        :param ttl:
-        :param max_ttl:
-        :param period:
-        :param policies:
         :param allow_instance_migration:
         :param disallow_reauthentication:
+        :param token_ttl:
+        :param token_max_ttl:
+        :param token_policies:
+        :param token_bound_cidrs:
+        :param token_explicit_max_ttl:
+        :param token_no_default_policy:
+        :param token_num_uses:
+        :param token_period:
+        :param token_type:
         :param mount_point:
         :return:
         """
@@ -462,7 +468,6 @@ class Aws(VaultApiBase):
         params.update(
             utils.remove_nones({
                 'auth_type': auth_type,
-                'resolve_aws_unique_ids': resolve_aws_unique_ids,
                 'bound_ami_id': bound_ami_id,
                 'bound_account_id': bound_account_id,
                 'bound_region': bound_region,
@@ -475,12 +480,18 @@ class Aws(VaultApiBase):
                 'bound_iam_principal_arn': bound_iam_principal_arn,
                 'inferred_entity_type': inferred_entity_type,
                 'inferred_aws_region': inferred_aws_region,
-                'ttl': ttl,
-                'max_ttl': max_ttl,
-                'period': period,
-                'policies': policies,
+                'resolve_aws_unique_ids': resolve_aws_unique_ids,
                 'allow_instance_migration': allow_instance_migration,
                 'disallow_reauthentication': disallow_reauthentication,
+                'token_ttl': token_ttl,
+                'token_max_ttl': token_max_ttl,
+                'token_policies': token_policies,
+                'token_bound_cidrs': token_bound_cidrs,
+                'token_explicit_max_ttl': token_explicit_max_ttl,
+                'token_no_default_policy': token_no_default_policy,
+                'token_num_uses': token_num_uses,
+                'token_period': token_period,
+                'token_type': token_type,
             })
         )
         return self._adapter.post(

--- a/hvac/api/auth_methods/github.py
+++ b/hvac/api/auth_methods/github.py
@@ -13,7 +13,9 @@ class Github(VaultApiBase):
     Reference: https://www.vaultproject.io/api/auth/github/index.html
     """
 
-    def configure(self, organization, base_url=None, ttl=None, max_ttl=None, mount_point=DEFAULT_MOUNT_POINT):
+    def configure(self, organization, base_url=None, token_ttl=None, token_max_ttl=None, token_policies=None,
+                  token_bound_cidrs=None, token_explicit_max_ttl=None, token_no_default_policy=None,
+                  token_num_uses=None, token_period=None, token_type=None, mount_point=DEFAULT_MOUNT_POINT):
         """Configure the connection parameters for GitHub.
 
         This path honors the distinction between the create and update capabilities inside ACL policies.
@@ -27,11 +29,34 @@ class Github(VaultApiBase):
         :param base_url: The API endpoint to use. Useful if you are running GitHub Enterprise or an API-compatible
             authentication server.
         :type base_url: str | unicode
-        :param ttl: Duration after which authentication will be expired.
-        :type ttl: str | unicode
-        :param max_ttl: Maximum duration after which authentication will
-            be expired.
-        :type max_ttl: str | unicode
+        :param token_ttl: The incremental lifetime for generated tokens. This current value of this will be referenced
+            at renewal time.
+        :type token_ttl: str | unicode | int
+        :param token_max_ttl: The maximum lifetime for generated tokens. This current value of this will be referenced
+            at renewal time.
+        :type token_max_ttl: str | unicode | int
+        :param token_policies: List of policies to encode onto generated tokens. Depending on the auth method, this list
+            may be supplemented by user/group/other values.
+        :type token_policies: str | unicode | list
+        :param token_bound_cidrs: List of CIDR blocks; if set, specifies blocks of IP addresses which can authenticate
+            successfully, and ties the resulting token to these blocks as well.
+        :type token_bound_cidrs: str | unicode | list
+        :param token_explicit_max_ttl: If set, will encode an explicit max TTL onto the token. This is a hard cap even
+            if `token_ttl` and `token_max_ttl` would otherwise allow a renewal.
+        :type token_explicit_max_ttl: str | unicode | int
+        :param token_no_default_policy: If set, the default policy will not be set on generated tokens; otherwise it
+            will be added to the policies set in `token_policies`.
+        :type token_no_default_policy: bool
+        :param token_num_uses: The maximum number of times a generated token may be used (within its lifetime); 0 means
+            unlimited.
+        :type token_num_uses: int
+        :param token_period: The period, if any, to set on the token.
+        :type token_period: str | unicode | int
+        :param token_type: The type of token that should be generated. Can be `service`, `batch`, or `default` to use
+            the mount's tuned default (which unless changed will be `service` tokens). For token store roles, there are
+            two additional possibilities: `default-service` and `default-batch` which specify the type to return unless
+            the client requests a different type at generation time.
+        :type token_type: str | unicode
         :param mount_point: The "path" the method/backend was mounted on.
         :type mount_point: str | unicode
         :return: The response of the configure_method request.
@@ -43,8 +68,15 @@ class Github(VaultApiBase):
         params.update(
             utils.remove_nones({
                 'base_url': base_url,
-                'ttl': ttl,
-                'max_ttl': max_ttl,
+                'token_ttl': token_ttl,
+                'token_max_ttl': token_max_ttl,
+                'token_policies': token_policies,
+                'token_bound_cidrs': token_bound_cidrs,
+                'token_explicit_max_ttl': token_explicit_max_ttl,
+                'token_no_default_policy': token_no_default_policy,
+                'token_num_uses': token_num_uses,
+                'token_period': token_period,
+                'token_type': token_type,
             })
         )
         api_path = utils.format_url(

--- a/hvac/api/auth_methods/ldap.py
+++ b/hvac/api/auth_methods/ldap.py
@@ -16,7 +16,9 @@ class Ldap(VaultApiBase):
     def configure(self, user_dn=None, group_dn=None, url=None, case_sensitive_names=None, starttls=None,
                   tls_min_version=None, tls_max_version=None, insecure_tls=None, certificate=None, bind_dn=None,
                   bind_pass=None, user_attr=None, discover_dn=None, deny_null_bind=True, upn_domain=None,
-                  group_filter=None, group_attr=None, mount_point=DEFAULT_MOUNT_POINT):
+                  group_filter=None, group_attr=None, token_ttl=None, token_max_ttl=None, token_policies=None,
+                  token_bound_cidrs=None, token_explicit_max_ttl=None, token_no_default_policy=None,
+                  token_num_uses=None, token_period=None, token_type=None, mount_point=DEFAULT_MOUNT_POINT):
         """
         Configure the LDAP auth method.
 
@@ -72,6 +74,34 @@ class Ldap(VaultApiBase):
             membership. Examples: for groupfilter queries returning group objects, use: cn. For queries returning user
             objects, use: memberOf. The default is cn.
         :type group_attr: str | unicode
+        :param token_ttl: The incremental lifetime for generated tokens. This current value of this will be referenced
+            at renewal time.
+        :type token_ttl: str | unicode | int
+        :param token_max_ttl: The maximum lifetime for generated tokens. This current value of this will be referenced
+            at renewal time.
+        :type token_max_ttl: str | unicode | int
+        :param token_policies: List of policies to encode onto generated tokens. Depending on the auth method, this list
+            may be supplemented by user/group/other values.
+        :type token_policies: str | unicode | list
+        :param token_bound_cidrs: List of CIDR blocks; if set, specifies blocks of IP addresses which can authenticate
+            successfully, and ties the resulting token to these blocks as well.
+        :type token_bound_cidrs: str | unicode | list
+        :param token_explicit_max_ttl: If set, will encode an explicit max TTL onto the token. This is a hard cap even
+            if `token_ttl` and `token_max_ttl` would otherwise allow a renewal.
+        :type token_explicit_max_ttl: str | unicode | int
+        :param token_no_default_policy: If set, the default policy will not be set on generated tokens; otherwise it
+            will be added to the policies set in `token_policies`.
+        :type token_no_default_policy: bool
+        :param token_num_uses: The maximum number of times a generated token may be used (within its lifetime); 0 means
+            unlimited.
+        :type token_num_uses: int
+        :param token_period: The period, if any, to set on the token.
+        :type token_period: str | unicode | int
+        :param token_type: The type of token that should be generated. Can be `service`, `batch`, or `default` to use
+            the mount's tuned default (which unless changed will be `service` tokens). For token store roles, there are
+            two additional possibilities: `default-service` and `default-batch` which specify the type to return unless
+            the client requests a different type at generation time.
+        :type token_type: str | unicode
         :param mount_point: The "path" the method/backend was mounted on.
         :type mount_point: str | unicode
         :return: The response of the configure request.
@@ -96,6 +126,15 @@ class Ldap(VaultApiBase):
             'binddn': bind_dn,
             'bindpass': bind_pass,
             'certificate': certificate,
+            'token_ttl': token_ttl,
+            'token_max_ttl': token_max_ttl,
+            'token_policies': token_policies,
+            'token_bound_cidrs': token_bound_cidrs,
+            'token_explicit_max_ttl': token_explicit_max_ttl,
+            'token_no_default_policy': token_no_default_policy,
+            'token_num_uses': token_num_uses,
+            'token_period': token_period,
+            'token_type': token_type,
         })
 
         api_path = utils.format_url('/v1/auth/{mount_point}/config', mount_point=mount_point)

--- a/hvac/api/auth_methods/okta.py
+++ b/hvac/api/auth_methods/okta.py
@@ -13,8 +13,10 @@ class Okta(VaultApiBase):
     Reference: https://www.vaultproject.io/api/auth/okta/index.html
     """
 
-    def configure(self, org_name, api_token=None, base_url=None, ttl=None, max_ttl=None, bypass_okta_mfa=None,
-                  mount_point=DEFAULT_MOUNT_POINT):
+    def configure(self, org_name, api_token=None, base_url=None, bypass_okta_mfa=None,
+                  token_ttl=None, token_max_ttl=None, token_policies=None, token_bound_cidrs=None,
+                  token_explicit_max_ttl=None, token_no_default_policy=None, token_num_uses=None,
+                  token_period=None, token_type=None, mount_point=DEFAULT_MOUNT_POINT):
         """Configure the connection parameters for Okta.
 
         This path honors the distinction between the create and update capabilities inside ACL policies.
@@ -31,13 +33,37 @@ class Okta(VaultApiBase):
         :param base_url:  If set, will be used as the base domain for API requests.  Examples are okta.com,
             oktapreview.com, and okta-emea.com.
         :type base_url: str | unicode
-        :param ttl: Duration after which authentication will be expired.
-        :type ttl: str | unicode
-        :param max_ttl: Maximum duration after which authentication will be expired.
-        :type max_ttl: str | unicode
         :param bypass_okta_mfa: Whether to bypass an Okta MFA request. Useful if using one of Vault's built-in MFA
             mechanisms, but this will also cause certain other statuses to be ignored, such as PASSWORD_EXPIRED.
         :type bypass_okta_mfa: bool
+        :param token_ttl: The incremental lifetime for generated tokens. This current value of this will be referenced
+            at renewal time.
+        :type token_ttl: str | unicode | int
+        :param token_max_ttl: The maximum lifetime for generated tokens. This current value of this will be referenced
+            at renewal time.
+        :type token_max_ttl: str | unicode | int
+        :param token_policies: List of policies to encode onto generated tokens. Depending on the auth method, this list
+            may be supplemented by user/group/other values.
+        :type token_policies: str | unicode | list
+        :param token_bound_cidrs: List of CIDR blocks; if set, specifies blocks of IP addresses which can authenticate
+            successfully, and ties the resulting token to these blocks as well.
+        :type token_bound_cidrs: str | unicode | list
+        :param token_explicit_max_ttl: If set, will encode an explicit max TTL onto the token. This is a hard cap even
+            if `token_ttl` and `token_max_ttl` would otherwise allow a renewal.
+        :type token_explicit_max_ttl: str | unicode | int
+        :param token_no_default_policy: If set, the default policy will not be set on generated tokens; otherwise it
+            will be added to the policies set in `token_policies`.
+        :type token_no_default_policy: bool
+        :param token_num_uses: The maximum number of times a generated token may be used (within its lifetime); 0 means
+            unlimited.
+        :type token_num_uses: int
+        :param token_period: The period, if any, to set on the token.
+        :type token_period: str | unicode | int
+        :param token_type: The type of token that should be generated. Can be `service`, `batch`, or `default` to use
+            the mount's tuned default (which unless changed will be `service` tokens). For token store roles, there are
+            two additional possibilities: `default-service` and `default-batch` which specify the type to return unless
+            the client requests a different type at generation time.
+        :type token_type: str | unicode
         :param mount_point: The "path" the method/backend was mounted on.
         :type mount_point: str | unicode
         :return: The response of the request.
@@ -50,9 +76,16 @@ class Okta(VaultApiBase):
             utils.remove_nones({
                 'api_token': api_token,
                 'base_url': base_url,
-                'ttl': ttl,
-                'max_ttl': max_ttl,
                 'bypass_okta_mfa': bypass_okta_mfa,
+                'token_ttl': token_ttl,
+                'token_max_ttl': token_max_ttl,
+                'token_policies': token_policies,
+                'token_bound_cidrs': token_bound_cidrs,
+                'token_explicit_max_ttl': token_explicit_max_ttl,
+                'token_no_default_policy': token_no_default_policy,
+                'token_num_uses': token_num_uses,
+                'token_period': token_period,
+                'token_type': token_type,
             })
         )
         api_path = utils.format_url('/v1/auth/{mount_point}/config', mount_point=mount_point)

--- a/hvac/api/auth_methods/radius.py
+++ b/hvac/api/auth_methods/radius.py
@@ -14,7 +14,9 @@ class Radius(VaultApiBase):
     """
 
     def configure(self, host, secret, port=None, unregistered_user_policies=None, dial_timeout=None, nas_port=None,
-                  mount_point=DEFAULT_MOUNT_POINT):
+                  token_ttl=None, token_max_ttl=None, token_policies=None, token_bound_cidrs=None,
+                  token_explicit_max_ttl=None, token_no_default_policy=None, token_num_uses=None, token_period=None,
+                  token_type=None, mount_point=DEFAULT_MOUNT_POINT):
         """
         Configure the RADIUS auth method.
 
@@ -28,11 +30,39 @@ class Radius(VaultApiBase):
         :param port: The UDP port where the RADIUS server is listening on. Defaults is 1812.
         :type port: int
         :param unregistered_user_policies: A comma-separated list of policies to be granted to unregistered users.
-        :type unregistered_user_policies: list
+        :type unregistered_user_policies: str | unicode
         :param dial_timeout: Number of second to wait for a backend connection before timing out. Default is 10.
         :type dial_timeout: int
         :param nas_port: The NAS-Port attribute of the RADIUS request. Defaults is 10.
         :type nas_port: int
+        :param token_ttl: The incremental lifetime for generated tokens. This current value of this will be referenced
+            at renewal time.
+        :type token_ttl: str | unicode | int
+        :param token_max_ttl: The maximum lifetime for generated tokens. This current value of this will be referenced
+            at renewal time.
+        :type token_max_ttl: str | unicode | int
+        :param token_policies: List of policies to encode onto generated tokens. Depending on the auth method, this list
+            may be supplemented by user/group/other values.
+        :type token_policies: str | unicode | list
+        :param token_bound_cidrs: List of CIDR blocks; if set, specifies blocks of IP addresses which can authenticate
+            successfully, and ties the resulting token to these blocks as well.
+        :type token_bound_cidrs: str | unicode | list
+        :param token_explicit_max_ttl: If set, will encode an explicit max TTL onto the token. This is a hard cap even
+            if `token_ttl` and `token_max_ttl` would otherwise allow a renewal.
+        :type token_explicit_max_ttl: str | unicode | int
+        :param token_no_default_policy: If set, the default policy will not be set on generated tokens; otherwise it
+            will be added to the policies set in `token_policies`.
+        :type token_no_default_policy: bool
+        :param token_num_uses: The maximum number of times a generated token may be used (within its lifetime); 0 means
+            unlimited.
+        :type token_num_uses: int
+        :param token_period: The period, if any, to set on the token.
+        :type token_period: str | unicode | int
+        :param token_type: The type of token that should be generated. Can be `service`, `batch`, or `default` to use
+            the mount's tuned default (which unless changed will be `service` tokens). For token store roles, there are
+            two additional possibilities: `default-service` and `default-batch` which specify the type to return unless
+            the client requests a different type at generation time.
+        :type token_type: str | unicode
         :param mount_point: The "path" the method/backend was mounted on.
         :type mount_point: str | unicode
         :return: The response of the configure request.
@@ -47,6 +77,15 @@ class Radius(VaultApiBase):
                 'port': port,
                 'dial_timeout': dial_timeout,
                 'nas_port': nas_port,
+                'token_ttl': token_ttl,
+                'token_max_ttl': token_max_ttl,
+                'token_policies': token_policies,
+                'token_bound_cidrs': token_bound_cidrs,
+                'token_explicit_max_ttl': token_explicit_max_ttl,
+                'token_no_default_policy': token_no_default_policy,
+                'token_num_uses': token_num_uses,
+                'token_period': token_period,
+                'token_type': token_type,
             })
         )
         # Fill out params dictionary with any optional parameters provided

--- a/hvac/api/auth_methods/userpass.py
+++ b/hvac/api/auth_methods/userpass.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """USERPASS methods module."""
+from hvac import utils
 from hvac.api.vault_api_base import VaultApiBase
 
 DEFAULT_MOUNT_POINT = 'userpass'
@@ -11,7 +12,10 @@ class Userpass(VaultApiBase):
     Reference: https://www.vaultproject.io/api/auth/userpass/index.html
     """
 
-    def create_or_update_user(self, username, password, mount_point=DEFAULT_MOUNT_POINT):
+    def create_or_update_user(self, username, password, token_ttl=None, token_max_ttl=None, token_policies=None,
+                              token_bound_cidrs=None, token_explicit_max_ttl=None, token_no_default_policy=None,
+                              token_num_uses=None, token_period=None, token_type=None,
+                              mount_point=DEFAULT_MOUNT_POINT):
         """
         Create/update user in userpass.
 
@@ -22,12 +26,53 @@ class Userpass(VaultApiBase):
         :type username: str | unicode
         :param password: The password for the user. Only required when creating the user.
         :type password: str | unicode
+        :param token_ttl: The incremental lifetime for generated tokens. This current value of this will be referenced
+            at renewal time.
+        :type token_ttl: str | unicode | int
+        :param token_max_ttl: The maximum lifetime for generated tokens. This current value of this will be referenced
+            at renewal time.
+        :type token_max_ttl: str | unicode | int
+        :param token_policies: List of policies to encode onto generated tokens. Depending on the auth method, this list
+            may be supplemented by user/group/other values.
+        :type token_policies: str | unicode | list
+        :param token_bound_cidrs: List of CIDR blocks; if set, specifies blocks of IP addresses which can authenticate
+            successfully, and ties the resulting token to these blocks as well.
+        :type token_bound_cidrs: str | unicode | list
+        :param token_explicit_max_ttl: If set, will encode an explicit max TTL onto the token. This is a hard cap even
+            if `token_ttl` and `token_max_ttl` would otherwise allow a renewal.
+        :type token_explicit_max_ttl: str | unicode | int
+        :param token_no_default_policy: If set, the default policy will not be set on generated tokens; otherwise it
+            will be added to the policies set in `token_policies`.
+        :type token_no_default_policy: bool
+        :param token_num_uses: The maximum number of times a generated token may be used (within its lifetime); 0 means
+            unlimited.
+        :type token_num_uses: int
+        :param token_period: The period, if any, to set on the token.
+        :type token_period: str | unicode | int
+        :param token_type: The type of token that should be generated. Can be `service`, `batch`, or `default` to use
+            the mount's tuned default (which unless changed will be `service` tokens). For token store roles, there are
+            two additional possibilities: `default-service` and `default-batch` which specify the type to return unless
+            the client requests a different type at generation time.
+        :type token_type: str | unicode
         :param mount_point: The "path" the method/backend was mounted on.
         :type mount_point: str | unicode
         """
         params = {
             'password': password,
         }
+        params.update(
+            utils.remove_nones({
+                'token_ttl': token_ttl,
+                'token_max_ttl': token_max_ttl,
+                'token_policies': token_policies,
+                'token_bound_cidrs': token_bound_cidrs,
+                'token_explicit_max_ttl': token_explicit_max_ttl,
+                'token_no_default_policy': token_no_default_policy,
+                'token_num_uses': token_num_uses,
+                'token_period': token_period,
+                'token_type': token_type,
+            })
+        )
         api_path = '/v1/auth/{mount_point}/users/{username}'.format(mount_point=mount_point, username=username)
         return self._adapter.post(
             url=api_path,

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -667,7 +667,6 @@ class Client(object):
         :type mount_point: str.
         :return: parsed JSON response from the auth POST request
         :rtype: dict.
-
         """
         params = {'pkcs7': pkcs7}
         if nonce:
@@ -677,15 +676,34 @@ class Client(object):
 
         return self.login('/v1/auth/{0}/login'.format(mount_point), json=params, use_token=use_token)
 
-    def create_userpass(self, username, password, policies, mount_point='userpass', **kwargs):
+    def create_userpass(self, username, password, token_ttl=None, token_max_ttl=None, token_policies=None,
+                        token_bound_cidrs=None, token_explicit_max_ttl=None, token_no_default_policy=None,
+                        token_num_uses=None, token_period=None, token_type=None,
+                        mount_point='userpass', **kwargs):
         """POST /auth/<mount point>/users/<username>
 
         :param username:
         :type username:
         :param password:
         :type password:
-        :param policies:
-        :type policies:
+        :param token_ttl:
+        :type token_ttl:
+        :param token_max_ttl:
+        :type token_max_ttl:
+        :param token_policies:
+        :type token_policies:
+        :param token_bound_cidrs:
+        :type token_bound_cidrs:
+        :param token_explicit_max_ttl:
+        :type token_explicit_max_ttl:
+        :param token_no_default_policy:
+        :type token_no_default_policy:
+        :param token_num_uses:
+        :type token_num_uses:
+        :param token_period:
+        :type token_period:
+        :param token_type:
+        :type token_type:
         :param mount_point:
         :type mount_point:
         :param kwargs:
@@ -694,16 +712,23 @@ class Client(object):
         :rtype:
         """
 
-        # Users can have more than 1 policy. It is easier for the user to pass in the
-        # policies as a list so if they do, we need to convert to a , delimited string.
-        if isinstance(policies, (list, set, tuple)):
-            policies = ','.join(policies)
-
         params = {
             'password': password,
-            'policies': policies
         }
         params.update(kwargs)
+        params.update(
+            utils.remove_nones({
+                'token_ttl': token_ttl,
+                'token_max_ttl': token_max_ttl,
+                'token_policies': token_policies,
+                'token_bound_cidrs': token_bound_cidrs,
+                'token_explicit_max_ttl': token_explicit_max_ttl,
+                'token_no_default_policy': token_no_default_policy,
+                'token_num_uses': token_num_uses,
+                'token_period': token_period,
+                'token_type': token_type,
+            })
+        )
 
         return self._adapter.post('/v1/auth/{}/users/{}'.format(mount_point, username), json=params)
 
@@ -940,6 +965,7 @@ class Client(object):
         :type mount_point: str|unicode
         :return: The response of the request.
         :rtype: requests.Response
+
         """
         params = {
             'access_key': access_key,
@@ -1037,9 +1063,11 @@ class Client(object):
     )
     def create_ec2_role(self, role, bound_ami_id=None, bound_account_id=None, bound_iam_role_arn=None,
                         bound_iam_instance_profile_arn=None, bound_ec2_instance_id=None, bound_region=None,
-                        bound_vpc_id=None, bound_subnet_id=None, role_tag=None,  ttl=None, max_ttl=None, period=None,
-                        policies=None, allow_instance_migration=False, disallow_reauthentication=False,
-                        resolve_aws_unique_ids=None, mount_point='aws-ec2'):
+                        bound_vpc_id=None, bound_subnet_id=None, role_tag=None, allow_instance_migration=False,
+                        disallow_reauthentication=False, resolve_aws_unique_ids=None,
+                        token_ttl=None, token_max_ttl=None, token_policies=None, token_bound_cidrs=None,
+                        token_explicit_max_ttl=None, token_no_default_policy=None,
+                        token_num_uses=None, token_period=None, token_type=None, mount_point='aws-ec2'):
         """POST /auth/<mount_point>/role/<role>
 
         :param role:
@@ -1062,24 +1090,35 @@ class Client(object):
         :type bound_subnet_id:
         :param role_tag:
         :type role_tag:
-        :param ttl:
-        :type ttl:
-        :param max_ttl:
-        :type max_ttl:
-        :param period:
-        :type period:
-        :param policies:
-        :type policies:
         :param allow_instance_migration:
         :type allow_instance_migration:
         :param disallow_reauthentication:
         :type disallow_reauthentication:
         :param resolve_aws_unique_ids:
         :type resolve_aws_unique_ids:
+        :param token_ttl:
+        :type token_ttl:
+        :param token_max_ttl:
+        :type token_max_ttl:
+        :param token_policies:
+        :type token_policies:
+        :param token_bound_cidrs:
+        :type token_bound_cidrs:
+        :param token_explicit_max_ttl:
+        :type token_explicit_max_ttl:
+        :param token_no_default_policy:
+        :type token_no_default_policy:
+        :param token_num_uses:
+        :type token_num_uses:
+        :param token_period:
+        :type token_period:
+        :param token_type:
+        :type token_type:
         :param mount_point:
         :type mount_point:
         :return:
         :rtype:
+
         """
         params = {
             'role': role,
@@ -1106,20 +1145,20 @@ class Client(object):
             params['bound_subnet_id'] = bound_subnet_id
         if role_tag is not None:
             params['role_tag'] = role_tag
-        if ttl is not None:
-            params['ttl'] = ttl
+        if token_ttl is not None:
+            params['token_ttl'] = token_ttl
         else:
-            params['ttl'] = 0
-        if max_ttl is not None:
-            params['max_ttl'] = max_ttl
+            params['token_ttl'] = 0
+        if token_max_ttl is not None:
+            params['token_max_ttl'] = token_max_ttl
         else:
-            params['max_ttl'] = 0
-        if period is not None:
-            params['period'] = period
+            params['token_max_ttl'] = 0
+        if token_period is not None:
+            params['token_period'] = token_period
         else:
-            params['period'] = 0
-        if policies is not None:
-            params['policies'] = policies
+            params['token_period'] = 0
+        if token_policies is not None:
+            params['token_policies'] = token_policies
         if resolve_aws_unique_ids is not None:
             params['resolve_aws_unique_ids'] = resolve_aws_unique_ids
 
@@ -1198,6 +1237,7 @@ class Client(object):
         :type mount_point:
         :return:
         :rtype:
+
         """
         params = {
             'role': role,

--- a/tests/integration_tests/api/auth_methods/test_azure.py
+++ b/tests/integration_tests/api/auth_methods/test_azure.py
@@ -132,12 +132,12 @@ class TestAzure(HvacIntegrationTestCase, TestCase):
         param(
             'CSV policies arg',
             bound_service_principal_ids=['my-sp-id'],
-            policies='cats,dogs',
+            token_policies='cats,dogs',
         ),
         param(
             'list policies arg',
             bound_service_principal_ids=['my-sp-id'],
-            policies=['cats', 'dogs'],
+            token_policies=['cats', 'dogs'],
         ),
         param(
             'no bound constraints',
@@ -147,24 +147,24 @@ class TestAzure(HvacIntegrationTestCase, TestCase):
         param(
             'wrong policy arg type',
             bound_service_principal_ids=['my-sp-id'],
-            policies={'dict': 'bad'},
+            token_policies={'dict': 'bad'},
             raises=exceptions.ParamValidationError,
-            exception_message='unsupported policies argument provided',
+            exception_message='unsupported token_policies argument provided',
         ),
         param(
             'mixed policy arg type',
             bound_service_principal_ids=['my-sp-id'],
-            policies=['cats', 'dogs', None, 42],
+            token_policies=['cats', 'dogs', None, 42],
             raises=exceptions.ParamValidationError,
-            exception_message='unsupported policies argument provided',
+            exception_message='unsupported token_policies argument provided',
         )
     ])
-    def test_create_role(self, label, policies=None, bound_service_principal_ids=None, raises=None, exception_message=''):
+    def test_create_role(self, label, token_policies=None, bound_service_principal_ids=None, raises=None, exception_message=''):
         if raises:
             with self.assertRaises(raises) as cm:
                 self.client.auth.azure.create_role(
                     name='my-role',
-                    policies=policies,
+                    token_policies=token_policies,
                     bound_service_principal_ids=bound_service_principal_ids,
                     mount_point=self.TEST_MOUNT_POINT,
                 )
@@ -175,7 +175,7 @@ class TestAzure(HvacIntegrationTestCase, TestCase):
         else:
             create_role_response = self.client.auth.azure.create_role(
                 name='my-role',
-                policies=policies,
+                token_policies=token_policies,
                 bound_service_principal_ids=bound_service_principal_ids,
                 mount_point=self.TEST_MOUNT_POINT,
             )

--- a/tests/integration_tests/api/auth_methods/test_gcp.py
+++ b/tests/integration_tests/api/auth_methods/test_gcp.py
@@ -150,7 +150,7 @@ class TestGcp(HvacIntegrationTestCase, TestCase):
             exception_message='unsupported role_type argument provided',
         ),
     ])
-    def test_create_role(self, label, role_type, policies=None, bound_service_accounts=None, raises=None, exception_message=''):
+    def test_create_role(self, label, role_type, token_policies=None, bound_service_accounts=None, raises=None, exception_message=''):
         role_name = 'hvac'
         project_id = 'test-hvac-project-not-a-real-project'
         if raises:
@@ -159,7 +159,7 @@ class TestGcp(HvacIntegrationTestCase, TestCase):
                     name=role_name,
                     role_type=role_type,
                     project_id=project_id,
-                    policies=policies,
+                    token_policies=token_policies,
                     bound_service_accounts=bound_service_accounts,
                     mount_point=self.TEST_MOUNT_POINT,
                 )
@@ -172,7 +172,7 @@ class TestGcp(HvacIntegrationTestCase, TestCase):
                 name=role_name,
                 role_type=role_type,
                 project_id=project_id,
-                policies=policies,
+                token_policies=token_policies,
                 bound_service_accounts=bound_service_accounts,
                 mount_point=self.TEST_MOUNT_POINT,
             )

--- a/tests/integration_tests/api/auth_methods/test_github.py
+++ b/tests/integration_tests/api/auth_methods/test_github.py
@@ -54,12 +54,12 @@ class TestGithub(HvacIntegrationTestCase, TestCase):
     @parameterized.expand([
         ("just organization", 204, 'some-test-org', '', 0, 0, TEST_GITHUB_PATH),
     ])
-    def test_configure(self, test_label, expected_status_code, organization, base_url, ttl, max_ttl, mount_point):
+    def test_configure(self, test_label, expected_status_code, organization, base_url, token_ttl, token_max_ttl, mount_point):
         response = self.client.auth.github.configure(
             organization=organization,
             base_url=base_url,
-            ttl=ttl,
-            max_ttl=max_ttl,
+            token_ttl=token_ttl,
+            token_max_ttl=token_max_ttl,
             mount_point=mount_point,
         )
         self.assertEqual(
@@ -84,12 +84,12 @@ class TestGithub(HvacIntegrationTestCase, TestCase):
         ("custom ttl hours", 'some-test-org', '', '500h', ''),
         ("custom max ttl", 'some-test-org', '', '', '500s'),
     ])
-    def test_configure_and_read_configuration(self, test_label, organization, base_url, ttl, max_ttl):
+    def test_configure_and_read_configuration(self, test_label, organization, base_url, token_ttl, token_max_ttl):
         config_response = self.client.auth.github.configure(
             organization=organization,
             base_url=base_url,
-            ttl=ttl,
-            max_ttl=max_ttl,
+            token_ttl=token_ttl,
+            token_max_ttl=token_max_ttl,
             mount_point=self.TEST_GITHUB_PATH,
         )
         self.assertEqual(
@@ -109,12 +109,12 @@ class TestGithub(HvacIntegrationTestCase, TestCase):
             second=read_config_response['data']['base_url']
         )
         self.assertEqual(
-            first=self.convert_python_ttl_value_to_expected_vault_response(ttl_value=ttl),
-            second=read_config_response['data']['ttl']
+            first=self.convert_python_ttl_value_to_expected_vault_response(ttl_value=token_ttl),
+            second=read_config_response['data']['token_ttl']
         )
         self.assertEqual(
-            first=self.convert_python_ttl_value_to_expected_vault_response(ttl_value=max_ttl),
-            second=read_config_response['data']['max_ttl']
+            first=self.convert_python_ttl_value_to_expected_vault_response(ttl_value=token_max_ttl),
+            second=read_config_response['data']['token_max_ttl']
         )
 
     @parameterized.expand([

--- a/tests/integration_tests/api/auth_methods/test_ldap.py
+++ b/tests/integration_tests/api/auth_methods/test_ldap.py
@@ -56,6 +56,8 @@ class TestLdap(HvacIntegrationTestCase, TestCase):
         ('update binddn', dict(url=MockLdapServer.ldap_url, bind_dn='cn=vault,ou=Users,dc=hvac,dc=network')),
         ('update upn_domain', dict(url=MockLdapServer.ldap_url, upn_domain='python-hvac.org')),
         ('update certificate', dict(url=MockLdapServer.ldap_url, certificate=utils.load_config_file('server-cert.pem'))),
+        ('update token_explicit_max_ttl', dict(url=MockLdapServer.ldap_url, token_explicit_max_ttl=28800)),
+        ('token_bound_cidrs as list', dict(url=MockLdapServer.ldap_url, token_bound_cidrs=["192.168.26.30/16"])),
         ('incorrect tls version', dict(url=MockLdapServer.ldap_url, tls_min_version='cats'), exceptions.InvalidRequest,
          "invalid 'tls_min_version'"),
     ])

--- a/tests/integration_tests/v1/test_integration.py
+++ b/tests/integration_tests/v1/test_integration.py
@@ -81,7 +81,7 @@ class IntegrationTest(HvacIntegrationTestCase, TestCase):
 
         self.client.enable_auth_backend('userpass')
 
-        self.client.write('auth/userpass/users/testuser', password='testpass', policies='not_root')
+        self.client.write('auth/userpass/users/testuser', password='testpass', token_policies='not_root')
 
         result = self.client.auth_userpass('testuser', 'testpass')
 
@@ -95,7 +95,7 @@ class IntegrationTest(HvacIntegrationTestCase, TestCase):
         if 'userpass/' not in self.client.list_auth_backends()['data']:
             self.client.enable_auth_backend('userpass')
 
-        self.client.create_userpass('testcreateuser', 'testcreateuserpass', policies='not_root')
+        self.client.create_userpass('testcreateuser', 'testcreateuserpass', token_policies='not_root')
 
         result = self.client.auth_userpass('testcreateuser', 'testcreateuserpass')
 
@@ -104,7 +104,7 @@ class IntegrationTest(HvacIntegrationTestCase, TestCase):
 
         # Test ttl:
         self.client.token = self.manager.root_token
-        self.client.create_userpass('testcreateuser', 'testcreateuserpass', policies='not_root', ttl='10s')
+        self.client.create_userpass('testcreateuser', 'testcreateuserpass', token_policies='not_root', token_ttl='10s')
         self.client.token = result['auth']['client_token']
 
         result = self.client.auth_userpass('testcreateuser', 'testcreateuserpass')
@@ -119,8 +119,8 @@ class IntegrationTest(HvacIntegrationTestCase, TestCase):
             self.client.enable_auth_backend('userpass')
 
         # add some users and confirm that they show up in the list
-        self.client.create_userpass('testuserone', 'testuseronepass', policies='not_root')
-        self.client.create_userpass('testusertwo', 'testusertwopass', policies='not_root')
+        self.client.create_userpass('testuserone', 'testuseronepass', token_policies='not_root')
+        self.client.create_userpass('testusertwo', 'testusertwopass', token_policies='not_root')
 
         user_list = self.client.list_userpass()
         assert 'testuserone' in user_list['data']['keys']
@@ -138,11 +138,11 @@ class IntegrationTest(HvacIntegrationTestCase, TestCase):
             self.client.enable_auth_backend('userpass')
 
         # create user to read
-        self.client.create_userpass('readme', 'mypassword', policies='not_root')
+        self.client.create_userpass('readme', 'mypassword', token_policies='not_root')
 
         # test that user can be read
         read_user = self.client.read_userpass('readme')
-        assert 'not_root' in read_user['data']['policies']
+        assert 'not_root' in read_user['data']['token_policies']
 
         # teardown
         self.client.disable_auth_backend('userpass')
@@ -152,12 +152,12 @@ class IntegrationTest(HvacIntegrationTestCase, TestCase):
             self.client.enable_auth_backend('userpass')
 
         # create user and then update its policies
-        self.client.create_userpass('updatemypolicies', 'mypassword', policies='not_root')
+        self.client.create_userpass('updatemypolicies', 'mypassword', token_policies='not_root')
         self.client.update_userpass_policies('updatemypolicies', policies='somethingelse')
 
         # test that policies have changed
         updated_user = self.client.read_userpass('updatemypolicies')
-        assert 'somethingelse' in updated_user['data']['policies']
+        assert 'somethingelse' in updated_user['data']['token_policies']
 
         # teardown
         self.client.disable_auth_backend('userpass')
@@ -167,7 +167,7 @@ class IntegrationTest(HvacIntegrationTestCase, TestCase):
             self.client.enable_auth_backend('userpass')
 
         # create user and then change its password
-        self.client.create_userpass('changeme', 'mypassword', policies='not_root')
+        self.client.create_userpass('changeme', 'mypassword', token_policies='not_root')
         self.client.update_userpass_password('changeme', 'mynewpassword')
 
         # test that new password authenticates user
@@ -183,7 +183,7 @@ class IntegrationTest(HvacIntegrationTestCase, TestCase):
         if 'userpass/' not in self.client.list_auth_backends()['data']:
             self.client.enable_auth_backend('userpass')
 
-        self.client.create_userpass('testcreateuser', 'testcreateuserpass', policies='not_root')
+        self.client.create_userpass('testcreateuser', 'testcreateuserpass', token_policies='not_root')
 
         result = self.client.auth_userpass('testcreateuser', 'testcreateuserpass')
 
@@ -600,37 +600,37 @@ class IntegrationTest(HvacIntegrationTestCase, TestCase):
         # test binding by AMI ID (the old way, to ensure backward compatibility)
         self.client.create_ec2_role('foo',
                                     'ami-notarealami',
-                                    policies='ec2rolepolicy')
+                                    token_policies='ec2rolepolicy')
 
         # test binding by Account ID
         self.client.create_ec2_role('bar',
                                     bound_account_id='123456789012',
-                                    policies='ec2rolepolicy')
+                                    token_policies='ec2rolepolicy')
 
         # test binding by IAM Role ARN
         self.client.create_ec2_role('baz',
                                     bound_iam_role_arn='arn:aws:iam::123456789012:role/mockec2role',
-                                    policies='ec2rolepolicy')
+                                    token_policies='ec2rolepolicy')
 
         # test binding by instance profile ARN
         self.client.create_ec2_role('qux',
                                     bound_iam_instance_profile_arn='arn:aws:iam::123456789012:instance-profile/mockprofile',
-                                    policies='ec2rolepolicy')
+                                    token_policies='ec2rolepolicy')
 
         # test binding by bound region
         self.client.create_ec2_role('quux',
                                     bound_region='ap-northeast-2',
-                                    policies='ec2rolepolicy')
+                                    token_policies='ec2rolepolicy')
 
         # test binding by bound vpc id
         self.client.create_ec2_role('corge',
                                     bound_vpc_id='vpc-1a123456',
-                                    policies='ec2rolepolicy')
+                                    token_policies='ec2rolepolicy')
 
         # test binding by bound subnet id
         self.client.create_ec2_role('grault',
                                     bound_subnet_id='subnet-123a456',
-                                    policies='ec2rolepolicy')
+                                    token_policies='ec2rolepolicy')
 
         roles = self.client.list_ec2_roles()
 
@@ -644,31 +644,31 @@ class IntegrationTest(HvacIntegrationTestCase, TestCase):
 
         foo_role = self.client.get_ec2_role('foo')
         assert ('ami-notarealami' in foo_role['data']['bound_ami_id'])
-        assert ('ec2rolepolicy' in foo_role['data']['policies'])
+        assert ('ec2rolepolicy' in foo_role['data']['token_policies'])
 
         bar_role = self.client.get_ec2_role('bar')
         assert ('123456789012' in bar_role['data']['bound_account_id'])
-        assert ('ec2rolepolicy' in bar_role['data']['policies'])
+        assert ('ec2rolepolicy' in bar_role['data']['token_policies'])
 
         baz_role = self.client.get_ec2_role('baz')
         assert ('arn:aws:iam::123456789012:role/mockec2role' in baz_role['data']['bound_iam_role_arn'])
-        assert ('ec2rolepolicy' in baz_role['data']['policies'])
+        assert ('ec2rolepolicy' in baz_role['data']['token_policies'])
 
         qux_role = self.client.get_ec2_role('qux')
         assert('arn:aws:iam::123456789012:instance-profile/mockprofile' in qux_role['data']['bound_iam_instance_profile_arn'])
-        assert('ec2rolepolicy' in qux_role['data']['policies'])
+        assert('ec2rolepolicy' in qux_role['data']['token_policies'])
 
         quux_role = self.client.get_ec2_role('quux')
         assert('ap-northeast-2' in quux_role['data']['bound_region'])
-        assert('ec2rolepolicy' in quux_role['data']['policies'])
+        assert('ec2rolepolicy' in quux_role['data']['token_policies'])
 
         corge_role = self.client.get_ec2_role('corge')
         assert('vpc-1a123456' in corge_role['data']['bound_vpc_id'])
-        assert('ec2rolepolicy' in corge_role['data']['policies'])
+        assert('ec2rolepolicy' in corge_role['data']['token_policies'])
 
         grault_role = self.client.get_ec2_role('grault')
         assert('subnet-123a456' in grault_role['data']['bound_subnet_id'])
-        assert('ec2rolepolicy' in grault_role['data']['policies'])
+        assert('ec2rolepolicy' in grault_role['data']['token_policies'])
 
         # teardown
         self.client.delete_ec2_role('foo')
@@ -693,37 +693,37 @@ class IntegrationTest(HvacIntegrationTestCase, TestCase):
         # create a role with no TTL
         self.client.create_ec2_role('foo',
                                     'ami-notarealami',
-                                    policies='ec2rolepolicy')
+                                    token_policies='ec2rolepolicy')
 
         # create a role with a 1hr TTL
         self.client.create_ec2_role('bar',
                                     'ami-notarealami',
-                                    ttl='1h',
-                                    policies='ec2rolepolicy')
+                                    token_ttl='1h',
+                                    token_policies='ec2rolepolicy')
 
         # create a role with a 3-day max TTL
         self.client.create_ec2_role('baz',
                                     'ami-notarealami',
-                                    max_ttl='72h',
-                                    policies='ec2rolepolicy')
+                                    token_max_ttl='72h',
+                                    token_policies='ec2rolepolicy')
 
         # create a role with 1-day period
         self.client.create_ec2_role('qux',
                                     'ami-notarealami',
-                                    period='24h',
-                                    policies='ec2rolepolicy')
+                                    token_period='24h',
+                                    token_policies='ec2rolepolicy')
 
         foo_role = self.client.get_ec2_role('foo')
-        assert (foo_role['data']['ttl'] == 0)
+        assert (foo_role['data']['token_ttl'] == 0)
 
         bar_role = self.client.get_ec2_role('bar')
-        assert (bar_role['data']['ttl'] == 3600)
+        assert (bar_role['data']['token_ttl'] == 3600)
 
         baz_role = self.client.get_ec2_role('baz')
-        assert (baz_role['data']['max_ttl'] == 259200)
+        assert (baz_role['data']['token_max_ttl'] == 259200)
 
         qux_role = self.client.get_ec2_role('qux')
-        assert (qux_role['data']['period'] == 86400)
+        assert (qux_role['data']['token_period'] == 86400)
 
         # teardown
         self.client.delete_ec2_role('foo')


### PR DESCRIPTION
Hello,

This PR adapts HVAC to the Token store changes mentioned here :
https://github.com/hashicorp/vault/blob/master/CHANGELOG.md#120-july-30th-2019 

> Token store roles use new, common token fields for the values that overlap with other auth backends. period, explicit_max_ttl, and bound_cidrs will continue to work, with priority being given to the token_ prefixed versions of those parameters. They will also be returned when doing a read on the role if they were used to provide values initially; however, in Vault 1.4 if period or explicit_max_ttl is zero they will no longer be returned. (explicit_max_ttl was already not returned if empty.)

This include breaking changes as method parameters are renamed to their `token_` prefixed versions.
Kind regards,