### PR TITLE
Add Transform Secrets Engine

### DIFF
--- a/docs/usage/secrets_engines/index.rst
+++ b/docs/usage/secrets_engines/index.rst
@@ -12,4 +12,5 @@ Secrets Engines
    kv
    kv_v1
    kv_v2
+   transform
    transit

--- a/docs/usage/secrets_engines/transform.rst
+++ b/docs/usage/secrets_engines/transform.rst
@@ -1,0 +1,480 @@
+Transform Secrets Engine
+========================
+
+.. contents::
+   :local:
+   :depth: 1
+
+.. testsetup:: transform
+    :skipif: test_utils.vault_version_lt('1.4.0') or not test_utils.is_enterprise()
+
+    client.sys.enable_secrets_engine(
+        backend_type='transform',
+    )
+
+Encode/Decode Example
+---------------------
+
+
+.. testcode:: transform
+    :skipif: test_utils.vault_version_lt('1.4.0') or not test_utils.is_enterprise()
+
+    import hvac
+    client = hvac.Client(url='https://127.0.0.1:8200')
+
+    input_value = '1111-1111-1111-1111'
+
+    role_name = 'hvac-role'
+    transformation_name = 'hvac-fpe-credit-card'
+    transformations = [transformation_name]
+
+    # Create a role and a transformation
+    client.secrets.transform.create_or_update_role(
+        name=role_name,
+        transformations=transformations,
+    )
+    client.secrets.transform.create_or_update_transformation(
+        name=transformation_name,
+        transform_type='fpe',
+        template='builtin/creditcardnumber',
+        tweak_source='internal',
+        allowed_roles=[role_name],
+    )
+
+    # Use the role/transformation combination to encode a value
+    encode_response = client.secrets.transform.encode(
+        role_name=role_name,
+        value=input_value,
+        transformation=transformation_name,
+    )
+    print('The encoded value is: %s' % encode_response['data']['encoded_value'])
+
+    # Use the role/transformation combination to decode a value
+    decode_response = client.secrets.transform.decode(
+        role_name=role_name,
+        value=encode_response['data']['encoded_value'],
+        transformation=transformation_name,
+    )
+    print('The decoded value is: %s' % decode_response['data']['decoded_value'])
+
+.. testoutput:: transform
+
+    The encoded value is: ...
+    The decoded value is: 1111-1111-1111-1111
+
+Create/Update Role
+------------------
+
+:py:meth:`hvac.api.auth_methods.Transform.create_or_update_role`
+
+.. testcode:: transform
+    :skipif: test_utils.vault_version_lt('1.4.0') or not test_utils.is_enterprise()
+
+    import hvac
+    client = hvac.Client(url='https://127.0.0.1:8200')
+
+    client.secrets.transform.create_or_update_role(
+        name='hvac-role',
+        transformations=[
+            'hvac-fpe-credit-card',
+        ],
+    )
+
+Read Role
+---------
+
+:py:meth:`hvac.api.auth_methods.Transform.read_role`
+
+.. testcode:: transform
+    :skipif: test_utils.vault_version_lt('1.4.0') or not test_utils.is_enterprise()
+
+    import hvac
+    client = hvac.Client(url='https://127.0.0.1:8200')
+
+    role_name = 'hvac-role'
+    client.secrets.transform.create_or_update_role(
+        name=role_name,
+        transformations=[
+            'hvac-fpe-credit-card',
+        ],
+    )
+    read_response = client.secrets.transform.read_role(
+        name=role_name,
+    )
+    print('Role "{}" has the following transformations configured: {}'.format(
+        role_name,
+        ', '.join(read_response['data']['transformations']),
+    ))
+
+.. testoutput:: transform
+
+    Role "hvac-role" has the following transformations configured: hvac-fpe-credit-card
+
+List Roles
+----------
+
+:py:meth:`hvac.api.auth_methods.Transform.list_roles`
+
+
+.. testcode:: transform
+    :skipif: test_utils.vault_version_lt('1.4.0') or not test_utils.is_enterprise()
+
+    import hvac
+    client = hvac.Client(url='https://127.0.0.1:8200')
+
+    client.secrets.transform.create_or_update_role(
+        name='hvac-role',
+        transformations=[
+            'hvac-fpe-credit-card',
+        ],
+    )
+    list_response = client.secrets.transform.list_roles()
+    print('List of transform role names: {}'.format(
+        ', '.join(list_response['data']['keys']),
+    ))
+
+.. testoutput:: transform
+
+    List of transform role names: hvac-role
+
+Delete Role
+-----------
+
+:py:meth:`hvac.api.auth_methods.Transform.delete_role`
+
+.. testcode:: transform
+    :skipif: test_utils.vault_version_lt('1.4.0') or not test_utils.is_enterprise()
+
+    import hvac
+    client = hvac.Client(url='https://127.0.0.1:8200')
+
+    role_name = 'hvac-role'
+
+    # Create a role
+    client.secrets.transform.create_or_update_role(
+        name=role_name,
+        transformations=[
+            'hvac-fpe-credit-card',
+        ],
+    )
+
+    # Subsequently delete it...
+    client.secrets.transform.delete_role(
+        name=role_name,
+    )
+
+Create/Update Transformation
+----------------------------
+
+:py:meth:`hvac.api.auth_methods.Transform.create_or_update_transformation`
+
+.. testcode:: transform
+    :skipif: test_utils.vault_version_lt('1.4.0') or not test_utils.is_enterprise()
+
+    import hvac
+    client = hvac.Client(url='https://127.0.0.1:8200')
+
+    transformation_name = 'hvac-fpe-credit-card'
+    template = 'builtin/creditcardnumber'
+    client.secrets.transform.create_or_update_transformation(
+        name=transformation_name,
+        transform_type='fpe',
+        template=template,
+        tweak_source='internal',
+        allowed_roles=[
+            'test-role'
+        ],
+    )
+
+Read Transformation
+-------------------
+
+:py:meth:`hvac.api.auth_methods.Transform.read_transformation`
+
+.. testcode:: transform
+    :skipif: test_utils.vault_version_lt('1.4.0') or not test_utils.is_enterprise()
+
+    import hvac
+    client = hvac.Client(url='https://127.0.0.1:8200')
+
+    transformation_name = 'hvac-fpe-credit-card'
+    template = 'builtin/creditcardnumber'
+    client.secrets.transform.create_or_update_transformation(
+        name=transformation_name,
+        transform_type='fpe',
+        template=template,
+        tweak_source='internal',
+        allowed_roles=[
+            'hvac-role'
+        ],
+    )
+    read_response = client.secrets.transform.read_transformation(
+        name=transformation_name,
+    )
+    print('Transformation "{}" has the following type configured: {}'.format(
+        transformation_name,
+        read_response['data']['type'],
+    ))
+
+.. testoutput:: transform
+
+    Transformation "hvac-fpe-credit-card" has the following type configured: fpe
+
+List Transformations
+--------------------
+
+:py:meth:`hvac.api.auth_methods.Transform.list_transformations`
+
+.. testcode:: transform
+    :skipif: test_utils.vault_version_lt('1.4.0') or not test_utils.is_enterprise()
+
+    import hvac
+    client = hvac.Client(url='https://127.0.0.1:8200')
+
+    transformation_name = 'hvac-fpe-credit-card'
+    template = 'builtin/creditcardnumber'
+    client.secrets.transform.create_or_update_transformation(
+        name=transformation_name,
+        transform_type='fpe',
+        template=template,
+        tweak_source='internal',
+        allowed_roles=[
+            'hvac-role'
+        ],
+    )
+    list_response = client.secrets.transform.list_transformations()
+    print('List of transformations: {}'.format(
+        ', '.join(list_response['data']['keys']),
+    ))
+
+.. testoutput:: transform
+
+    List of transformations: hvac-fpe-credit-card
+
+Delete Transformation
+---------------------
+
+:py:meth:`hvac.api.auth_methods.Transform.delete_transformation`
+
+.. testcode:: transform
+    :skipif: test_utils.vault_version_lt('1.4.0') or not test_utils.is_enterprise()
+
+    import hvac
+    client = hvac.Client(url='https://127.0.0.1:8200')
+
+    transformation_name = 'hvac-fpe-credit-card'
+    template = 'builtin/creditcardnumber'
+
+    # Create a transformation
+    client.secrets.transform.create_or_update_transformation(
+        name=transformation_name,
+        transform_type='fpe',
+        template=template,
+        tweak_source='internal',
+        allowed_roles=[
+            'hvac-role'
+        ],
+    )
+
+    # Subsequently delete it...
+    client.secrets.transform.delete_role(
+        name=role_name,
+    )
+
+Create/Update Template
+----------------------
+
+:py:meth:`hvac.api.auth_methods.Transform.create_or_update_template`
+
+.. testcode:: transform
+    :skipif: test_utils.vault_version_lt('1.4.0') or not test_utils.is_enterprise()
+
+    import hvac
+    client = hvac.Client(url='https://127.0.0.1:8200')
+
+    template_name = 'hvac-template'
+    create_response = client.secrets.transform.create_or_update_template(
+        name=template_name,
+        template_type='regex',
+        pattern='(\\d{9})',
+        alphabet='builtin/numeric',
+    )
+
+Read Template
+-------------
+
+:py:meth:`hvac.api.auth_methods.Transform.read_template`
+
+.. testcode:: transform
+    :skipif: test_utils.vault_version_lt('1.4.0') or not test_utils.is_enterprise()
+
+    import hvac
+    client = hvac.Client(url='https://127.0.0.1:8200')
+
+    template_name = 'hvac-template'
+    client.secrets.transform.create_or_update_template(
+        name=template_name,
+        template_type='regex',
+        pattern='(\\d{9})',
+        alphabet='builtin/numeric',
+    )
+    read_response = client.secrets.transform.read_template(
+        name=template_name,
+    )
+    print('Template "{}" has the following type configured: {}'.format(
+        template_name,
+        read_response['data']['type'],
+    ))
+
+.. testoutput:: transform
+
+    Template "hvac-template" has the following type configured: regex
+
+List Templates
+--------------
+
+:py:meth:`hvac.api.auth_methods.Transform.list_templates`
+
+.. testcode:: transform
+    :skipif: test_utils.vault_version_lt('1.4.0') or not test_utils.is_enterprise()
+
+    import hvac
+    client = hvac.Client(url='https://127.0.0.1:8200')
+
+    template_name = 'hvac-template'
+    client.secrets.transform.create_or_update_template(
+        name=template_name,
+        template_type='regex',
+        pattern='(\\d{9})',
+        alphabet='builtin/numeric',
+    )
+    list_response = client.secrets.transform.list_templates()
+    print('List of templates: {}'.format(
+        ', '.join(list_response['data']['keys']),
+    ))
+
+.. testoutput:: transform
+
+    List of templates: builtin/creditcardnumber, builtin/socialsecuritynumber, hvac-template
+
+Delete Template
+-------------------------------
+
+:py:meth:`hvac.api.auth_methods.Transform.delete_template`
+
+.. testcode:: transform
+    :skipif: test_utils.vault_version_lt('1.4.0') or not test_utils.is_enterprise()
+
+    import hvac
+    client = hvac.Client(url='https://127.0.0.1:8200')
+
+    template_name = 'hvac-template'
+    client.secrets.transform.create_or_update_template(
+        name=template_name,
+        template_type='regex',
+        pattern='(\\d{9})',
+        alphabet='builtin/numeric',
+    )
+
+    # Subsequently delete it...
+    client.secrets.transform.delete_template(
+        name=template_name,
+    )
+
+Create/Update Alphabet
+----------------------
+
+:py:meth:`hvac.api.auth_methods.Transform.create_or_update_alphabet`
+
+.. testcode:: transform
+    :skipif: test_utils.vault_version_lt('1.4.0') or not test_utils.is_enterprise()
+
+    import hvac
+    client = hvac.Client(url='https://127.0.0.1:8200')
+
+    alphabet_name = 'hvac-alphabet'
+    alphabet_value = 'abc'
+    client.secrets.transform.create_or_update_alphabet(
+        name=alphabet_name,
+        alphabet=alphabet_value,
+    )
+
+Read Alphabet
+-------------
+
+:py:meth:`hvac.api.auth_methods.Transform.read_alphabet`
+
+.. testcode:: transform
+    :skipif: test_utils.vault_version_lt('1.4.0') or not test_utils.is_enterprise()
+
+    import hvac
+    client = hvac.Client(url='https://127.0.0.1:8200')
+
+    alphabet_name = 'hvac-alphabet'
+    alphabet_value = 'abc'
+    client.secrets.transform.create_or_update_alphabet(
+        name=alphabet_name,
+        alphabet=alphabet_value,
+    )
+    read_response = client.secrets.transform.read_alphabet(
+        name=alphabet_name,
+    )
+    print('Alphabet "{}" has this jazz: {}'.format(
+        alphabet_name,
+        read_response['data']['alphabet'],
+    ))
+
+.. testoutput:: transform
+
+    Alphabet "hvac-alphabet" has this jazz: abc
+
+List Alphabets
+--------------
+
+:py:meth:`hvac.api.auth_methods.Transform.list_alphabets`
+
+.. testcode:: transform
+    :skipif: test_utils.vault_version_lt('1.4.0') or not test_utils.is_enterprise()
+
+    import hvac
+    client = hvac.Client(url='https://127.0.0.1:8200')
+
+    alphabet_name = 'hvac-alphabet'
+    alphabet_value = 'abc'
+    client.secrets.transform.create_or_update_alphabet(
+        name=alphabet_name,
+        alphabet=alphabet_value,
+    )
+    list_response = client.secrets.transform.list_alphabets()
+    print('List of alphabets: {}'.format(
+        ', '.join(list_response['data']['keys']),
+    ))
+
+.. testoutput:: transform
+
+   List of alphabets: builtin/alphalower, ..., hvac-alphabet
+
+Delete Alphabet
+---------------
+
+:py:meth:`hvac.api.auth_methods.Transform.delete_alphabet`
+
+.. testcode:: transform
+    :skipif: test_utils.vault_version_lt('1.4.0') or not test_utils.is_enterprise()
+
+    import hvac
+    client = hvac.Client(url='https://127.0.0.1:8200')
+
+    alphabet_name = 'hvac-alphabet'
+    alphabet_value = 'abc'
+
+    # Create an alphabet
+    client.secrets.transform.create_or_update_alphabet(
+        name=alphabet_name,
+        alphabet=alphabet_value,
+    )
+
+    # Subsequently delete it...
+    client.secrets.transform.delete_alphabet(
+        name=alphabet_name,
+    )

--- a/docs/usage/secrets_engines/transform.rst
+++ b/docs/usage/secrets_engines/transform.rst
@@ -15,6 +15,8 @@ Transform Secrets Engine
 Encode/Decode Example
 ---------------------
 
+:py:meth:`hvac.api.secrets_engines.Transform.encode`
+:py:meth:`hvac.api.secrets_engines.Transform.decode`
 
 .. testcode:: transform
     :skipif: test_utils.vault_version_lt('1.4.0') or not test_utils.is_enterprise()
@@ -65,7 +67,7 @@ Encode/Decode Example
 Create/Update Role
 ------------------
 
-:py:meth:`hvac.api.auth_methods.Transform.create_or_update_role`
+:py:meth:`hvac.api.secrets_engines.Transform.create_or_update_role`
 
 .. testcode:: transform
     :skipif: test_utils.vault_version_lt('1.4.0') or not test_utils.is_enterprise()
@@ -83,7 +85,7 @@ Create/Update Role
 Read Role
 ---------
 
-:py:meth:`hvac.api.auth_methods.Transform.read_role`
+:py:meth:`hvac.api.secrets_engines.Transform.read_role`
 
 .. testcode:: transform
     :skipif: test_utils.vault_version_lt('1.4.0') or not test_utils.is_enterprise()
@@ -113,7 +115,7 @@ Read Role
 List Roles
 ----------
 
-:py:meth:`hvac.api.auth_methods.Transform.list_roles`
+:py:meth:`hvac.api.secrets_engines.Transform.list_roles`
 
 
 .. testcode:: transform
@@ -140,7 +142,7 @@ List Roles
 Delete Role
 -----------
 
-:py:meth:`hvac.api.auth_methods.Transform.delete_role`
+:py:meth:`hvac.api.secrets_engines.Transform.delete_role`
 
 .. testcode:: transform
     :skipif: test_utils.vault_version_lt('1.4.0') or not test_utils.is_enterprise()
@@ -166,7 +168,7 @@ Delete Role
 Create/Update Transformation
 ----------------------------
 
-:py:meth:`hvac.api.auth_methods.Transform.create_or_update_transformation`
+:py:meth:`hvac.api.secrets_engines.Transform.create_or_update_transformation`
 
 .. testcode:: transform
     :skipif: test_utils.vault_version_lt('1.4.0') or not test_utils.is_enterprise()
@@ -189,7 +191,7 @@ Create/Update Transformation
 Read Transformation
 -------------------
 
-:py:meth:`hvac.api.auth_methods.Transform.read_transformation`
+:py:meth:`hvac.api.secrets_engines.Transform.read_transformation`
 
 .. testcode:: transform
     :skipif: test_utils.vault_version_lt('1.4.0') or not test_utils.is_enterprise()
@@ -223,7 +225,7 @@ Read Transformation
 List Transformations
 --------------------
 
-:py:meth:`hvac.api.auth_methods.Transform.list_transformations`
+:py:meth:`hvac.api.secrets_engines.Transform.list_transformations`
 
 .. testcode:: transform
     :skipif: test_utils.vault_version_lt('1.4.0') or not test_utils.is_enterprise()
@@ -254,7 +256,7 @@ List Transformations
 Delete Transformation
 ---------------------
 
-:py:meth:`hvac.api.auth_methods.Transform.delete_transformation`
+:py:meth:`hvac.api.secrets_engines.Transform.delete_transformation`
 
 .. testcode:: transform
     :skipif: test_utils.vault_version_lt('1.4.0') or not test_utils.is_enterprise()
@@ -284,7 +286,7 @@ Delete Transformation
 Create/Update Template
 ----------------------
 
-:py:meth:`hvac.api.auth_methods.Transform.create_or_update_template`
+:py:meth:`hvac.api.secrets_engines.Transform.create_or_update_template`
 
 .. testcode:: transform
     :skipif: test_utils.vault_version_lt('1.4.0') or not test_utils.is_enterprise()
@@ -303,7 +305,7 @@ Create/Update Template
 Read Template
 -------------
 
-:py:meth:`hvac.api.auth_methods.Transform.read_template`
+:py:meth:`hvac.api.secrets_engines.Transform.read_template`
 
 .. testcode:: transform
     :skipif: test_utils.vault_version_lt('1.4.0') or not test_utils.is_enterprise()
@@ -333,7 +335,7 @@ Read Template
 List Templates
 --------------
 
-:py:meth:`hvac.api.auth_methods.Transform.list_templates`
+:py:meth:`hvac.api.secrets_engines.Transform.list_templates`
 
 .. testcode:: transform
     :skipif: test_utils.vault_version_lt('1.4.0') or not test_utils.is_enterprise()
@@ -360,7 +362,7 @@ List Templates
 Delete Template
 -------------------------------
 
-:py:meth:`hvac.api.auth_methods.Transform.delete_template`
+:py:meth:`hvac.api.secrets_engines.Transform.delete_template`
 
 .. testcode:: transform
     :skipif: test_utils.vault_version_lt('1.4.0') or not test_utils.is_enterprise()
@@ -384,7 +386,7 @@ Delete Template
 Create/Update Alphabet
 ----------------------
 
-:py:meth:`hvac.api.auth_methods.Transform.create_or_update_alphabet`
+:py:meth:`hvac.api.secrets_engines.Transform.create_or_update_alphabet`
 
 .. testcode:: transform
     :skipif: test_utils.vault_version_lt('1.4.0') or not test_utils.is_enterprise()
@@ -402,7 +404,7 @@ Create/Update Alphabet
 Read Alphabet
 -------------
 
-:py:meth:`hvac.api.auth_methods.Transform.read_alphabet`
+:py:meth:`hvac.api.secrets_engines.Transform.read_alphabet`
 
 .. testcode:: transform
     :skipif: test_utils.vault_version_lt('1.4.0') or not test_utils.is_enterprise()
@@ -431,7 +433,7 @@ Read Alphabet
 List Alphabets
 --------------
 
-:py:meth:`hvac.api.auth_methods.Transform.list_alphabets`
+:py:meth:`hvac.api.secrets_engines.Transform.list_alphabets`
 
 .. testcode:: transform
     :skipif: test_utils.vault_version_lt('1.4.0') or not test_utils.is_enterprise()
@@ -457,7 +459,7 @@ List Alphabets
 Delete Alphabet
 ---------------
 
-:py:meth:`hvac.api.auth_methods.Transform.delete_alphabet`
+:py:meth:`hvac.api.secrets_engines.Transform.delete_alphabet`
 
 .. testcode:: transform
     :skipif: test_utils.vault_version_lt('1.4.0') or not test_utils.is_enterprise()

--- a/hvac/api/secrets_engines/__init__.py
+++ b/hvac/api/secrets_engines/__init__.py
@@ -11,6 +11,7 @@ from hvac.api.secrets_engines.kv_v1 import KvV1
 from hvac.api.secrets_engines.kv_v2 import KvV2
 from hvac.api.secrets_engines.pki import Pki
 from hvac.api.secrets_engines.rabbitmq import RabbitMQ
+from hvac.api.secrets_engines.transform import Transform
 from hvac.api.secrets_engines.transit import Transit
 from hvac.api.vault_api_category import VaultApiCategory
 
@@ -24,6 +25,7 @@ __all__ = (
     'KvV1',
     'KvV2',
     'Pki',
+    'Transform',
     'Transit',
     'SecretsEngines',
     'Database',
@@ -42,6 +44,7 @@ class SecretsEngines(VaultApiCategory):
         Identity,
         Kv,
         Pki,
+        Transform,
         Transit,
         Database,
         Consul,

--- a/hvac/api/secrets_engines/transform.py
+++ b/hvac/api/secrets_engines/transform.py
@@ -1,0 +1,495 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Transform secrets engine methods module."""
+from hvac import utils
+from hvac.api.vault_api_base import VaultApiBase
+
+DEFAULT_MOUNT_POINT = 'transform'
+
+
+class Transform(VaultApiBase):
+    """Transform Secrets Engine (API).
+
+    Reference: https://www.vaultproject.io/api-docs/secret/transform
+    """
+
+    def create_or_update_role(self, name, transformations, mount_point=DEFAULT_MOUNT_POINT):
+        """Creates or update the role with the given name.
+
+        If a role with the name does not exist, it will be created. If the role exists, it will be
+        updated with the new attributes.
+
+        Supported methods:
+            POST: /{mount_point}/role/:name.
+
+        :param name: the name of the role to create. This is part of the request URL.
+        :type name: str | unicode
+        :param transformations: Specifies the transformations that can be used with this role.
+            At least one transformation is required.
+        :type transformations: list
+        :param mount_point: The "path" the secrets engine was mounted on.
+        :type mount_point: str | unicode
+        :return: The response of the create_or_update_role request.
+        :rtype: requests.Response
+        """
+        params = {
+            'transformations': transformations,
+        }
+        api_path = '/v1/{mount_point}/role/{name}'.format(
+            mount_point=mount_point,
+            name=name,
+        )
+        return self._adapter.post(
+            url=api_path,
+            json=params,
+        )
+
+    def read_role(self, name, mount_point=DEFAULT_MOUNT_POINT):
+        """Query an existing role by the given name.
+
+        Supported methods:
+            GET: /{mount_point}/role/:name.
+
+        :param name: the name of the role to read. This is part of the request URL.
+        :type name: str | unicode
+        :param mount_point: The "path" the secrets engine was mounted on.
+        :type mount_point: str | unicode
+        :return: The response of the read_role request.
+        :rtype: requests.Response
+        """
+        api_path = '/v1/{mount_point}/role/{name}'.format(
+            mount_point=mount_point,
+            name=name,
+        )
+        return self._adapter.get(
+            url=api_path,
+        )
+
+    def list_roles(self, mount_point=DEFAULT_MOUNT_POINT):
+        """List all existing roles in the secrets engine.
+
+        Supported methods:
+            LIST: /{mount_point}/role.
+
+        :param mount_point: The "path" the secrets engine was mounted on.
+        :type mount_point: str | unicode
+        :return: The response of the list_roles request.
+        :rtype: requests.Response
+        """
+        api_path = '/v1/{mount_point}/role'.format(mount_point=mount_point)
+        return self._adapter.list(
+            url=api_path,
+        )
+
+    def delete_role(self, name, mount_point=DEFAULT_MOUNT_POINT):
+        """Delete an existing role by the given name.
+
+        Supported methods:
+            DELETE: /{mount_point}/role/:name.
+
+        :param name: the name of the role to delete. This is part of the request URL.
+        :type name: str | unicode
+        :param mount_point: The "path" the secrets engine was mounted on.
+        :type mount_point: str | unicode
+        :return: The response of the delete_role request.
+        :rtype: requests.Response
+        """
+        api_path = '/v1/{mount_point}/role/{name}'.format(
+            mount_point=mount_point,
+            name=name,
+        )
+        return self._adapter.delete(
+            url=api_path,
+        )
+
+    def create_or_update_transformation(self, name, transform_type, template, tweak_source="supplied",
+                                        masking_character="*", allowed_roles=None, mount_point=DEFAULT_MOUNT_POINT):
+        """Create or update a transformation with the given name.
+
+        If a transformation with the name does not exist, it will be created. If the
+        transformation exists, it will be updated with the new attributes.
+
+        Supported methods:
+            POST: /{mount_point}/transformation/:name.
+
+        :param name: the name of the transformation to create or update. This is part of
+            the request URL.
+        :type name: str | unicode
+        :param transform_type: Specifies the type of transformation to perform.
+            The types currently supported by this backend are fpe and masking.
+            This value cannot be modified by an update operation after creation.
+        :type transform_type: str | unicode
+        :param template: the template name to use for matching value on encode and decode
+            operations when using this transformation.
+        :type template: str | unicode
+        :param tweak_source: Only used when the type is FPE.
+        :type tweak_source: str | unicode
+        :param masking_character: the character to use for masking. If multiple characters are
+            provided, only the first one is used and the rest is ignored. Only used when
+            the type is masking.
+        :type masking_character: str | unicode
+        :param allowed_roles: a list of allowed roles that this transformation can be assigned to.
+            A role using this transformation must exist in this list in order for
+            encode and decode operations to properly function.
+        :type allowed_roles: list
+        :param mount_point: The "path" the secrets engine was mounted on.
+        :type mount_point: str | unicode
+        :return: The response of the create_or_update_ation request.
+        :rtype: requests.Response
+        """
+        params = {
+            'type': transform_type,
+            'template': template,
+            'tweak_source': tweak_source,
+            'masking_character': masking_character,
+        }
+        params.update(utils.remove_nones({
+            'allowed_roles': allowed_roles,
+        }))
+        api_path = '/v1/{mount_point}/transformation/{name}'.format(
+            mount_point=mount_point,
+            name=name,
+        )
+        return self._adapter.post(
+            url=api_path,
+            json=params,
+        )
+
+    def read_transformation(self, name, mount_point=DEFAULT_MOUNT_POINT):
+        """Query an existing transformation by the given name.
+
+        Supported methods:
+            GET: /{mount_point}/transformation/:name.
+
+        :param name: Specifies the name of the role to read.
+        :type name: str | unicode
+        :param mount_point: The "path" the secrets engine was mounted on.
+        :type mount_point: str | unicode
+        :return: The response of the read_ation request.
+        :rtype: requests.Response
+        """
+        api_path = '/v1/{mount_point}/transformation/{name}'.format(
+            mount_point=mount_point,
+            name=name,
+        )
+        return self._adapter.get(
+            url=api_path,
+        )
+
+    def list_transformations(self, mount_point=DEFAULT_MOUNT_POINT):
+        """List all existing transformations in the secrets engine.
+
+        Supported methods:
+            LIST: /{mount_point}/transformation.
+
+        :param mount_point: The "path" the secrets engine was mounted on.
+        :type mount_point: str | unicode
+        :return: The response of the list_ation request.
+        :rtype: requests.Response
+        """
+        api_path = '/v1/{mount_point}/transformation'.format(mount_point=mount_point)
+        return self._adapter.list(
+            url=api_path,
+        )
+
+    def delete_transformation(self, name, mount_point=DEFAULT_MOUNT_POINT):
+        """Delete an existing transformation by the given name.
+
+        Supported methods:
+            DELETE: /{mount_point}/transformation/:name.
+
+        :param name: the name of the transformation to delete. This is part of the
+            request URL.
+        :type name: str | unicode
+        :param mount_point: The "path" the secrets engine was mounted on.
+        :type mount_point: str | unicode
+        :return: The response of the delete_ation request.
+        :rtype: requests.Response
+        """
+        api_path = '/v1/{mount_point}/transformation/{name}'.format(
+            mount_point=mount_point,
+            name=name,
+        )
+        return self._adapter.delete(
+            url=api_path,
+        )
+
+    def create_or_update_template(self, name, template_type, pattern, alphabet, mount_point=DEFAULT_MOUNT_POINT):
+        """Creates or update a template with the given name.
+
+        If a template with the name does not exist, it will be created. If the
+        template exists, it will be updated with the new attributes.
+
+        Supported methods:
+            POST: /{mount_point}/template/:name.
+
+        :param name: the name of the template to create.
+        :type name: str | unicode
+        :param template_type: Specifies the type of pattern matching to perform.
+            The ony type currently supported by this backend is regex.
+        :type template_type: str | unicode
+        :param pattern: the pattern used to match a particular value. For regex type
+            matching, capture group determines the set of character that should be matched
+            against. Any matches outside of capture groups are retained
+            post-transformation.
+        :type pattern: str | unicode
+        :param alphabet: the name of the alphabet to use when this template is used for FPE
+            encoding and decoding operations.
+        :type alphabet: str | unicode
+        :param mount_point: The "path" the secrets engine was mounted on.
+        :type mount_point: str | unicode
+        :return: The response of the create_or_update_template request.
+        :rtype: requests.Response
+        """
+        params = {
+            'type': template_type,
+            'pattern': pattern,
+            'alphabet': alphabet,
+        }
+        api_path = '/v1/{mount_point}/template/{name}'.format(
+            mount_point=mount_point,
+            name=name,
+        )
+        return self._adapter.post(
+            url=api_path,
+            json=params,
+        )
+
+    def read_template(self, name, mount_point=DEFAULT_MOUNT_POINT):
+        """Query an existing template by the given name.
+
+        Supported methods:
+            GET: /{mount_point}/template/:name.
+
+        :param name: Specifies the name of the role to read.
+        :type name: str | unicode
+        :param mount_point: The "path" the secrets engine was mounted on.
+        :type mount_point: str | unicode
+        :return: The response of the read_template request.
+        :rtype: requests.Response
+        """
+        api_path = '/v1/{mount_point}/template/{name}'.format(
+            mount_point=mount_point,
+            name=name,
+        )
+        return self._adapter.get(
+            url=api_path,
+        )
+
+    def list_templates(self, mount_point=DEFAULT_MOUNT_POINT):
+        """List all existing templates in the secrets engine.
+
+        Supported methods:
+            LIST: /{mount_point}/transformation.
+
+        :param mount_point: The "path" the secrets engine was mounted on.
+        :type mount_point: str | unicode
+        :return: The response of the list_template request.
+        :rtype: requests.Response
+        """
+        api_path = '/v1/{mount_point}/template'.format(mount_point=mount_point)
+        return self._adapter.list(
+            url=api_path,
+        )
+
+    def delete_template(self, name, mount_point=DEFAULT_MOUNT_POINT):
+        """Delete an existing template by the given name.
+
+        Supported methods:
+            DELETE: /{mount_point}/template/:name.
+
+        :param name: the name of the template to delete. This is part of the
+            request URL.
+        :type name: str | unicode
+        :param mount_point: The "path" the secrets engine was mounted on.
+        :type mount_point: str | unicode
+        :return: The response of the delete_template request.
+        :rtype: requests.Response
+        """
+        params = {
+            'name': name,
+        }
+        api_path = '/v1/{mount_point}/template/{name}'.format(
+            mount_point=mount_point,
+            name=name,
+        )
+        return self._adapter.delete(
+            url=api_path,
+            json=params,
+        )
+
+    def create_or_update_alphabet(self, name, alphabet, mount_point=DEFAULT_MOUNT_POINT):
+        """Create or update an alphabet with the given name.
+
+        If an alphabet with the name does not exist, it will be created. If the
+        alphabet exists, it will be updated with the new attributes.
+
+        Supported methods:
+            POST: /{mount_point}/alphabet/:name.
+
+        :param name: Specifies the name of the transformation alphabet to create.
+        :type name: str | unicode
+        :param alphabet: the set of characters that can exist within the provided value
+            and the encoded or decoded value for a FPE transformation.
+        :type alphabet: str | unicode
+        :param mount_point: The "path" the secrets engine was mounted on.
+        :type mount_point: str | unicode
+        :return: The response of the create_or_update_alphabet request.
+        :rtype: requests.Response
+        """
+        params = {
+            'alphabet': alphabet,
+        }
+        api_path = '/v1/{mount_point}/alphabet/{name}'.format(
+            mount_point=mount_point,
+            name=name,
+        )
+        return self._adapter.post(
+            url=api_path,
+            json=params,
+        )
+
+    def read_alphabet(self, name, mount_point=DEFAULT_MOUNT_POINT):
+        """Queries an existing alphabet by the given name.
+
+        Supported methods:
+            GET: /{mount_point}/alphabet/:name.
+
+
+        :param name: the name of the alphabet to delete. This is part of the request URL.
+        :type name: str | unicode
+        :param mount_point: The "path" the secrets engine was mounted on.
+        :type mount_point: str | unicode
+        :return: The response of the read_alphabet request.
+        :rtype: requests.Response
+        """
+        api_path = '/v1/{mount_point}/alphabet/{name}'.format(
+            mount_point=mount_point,
+            name=name,
+        )
+        return self._adapter.get(
+            url=api_path,
+        )
+
+    def list_alphabets(self, mount_point=DEFAULT_MOUNT_POINT):
+        """List all existing alphabets in the secrets engine.
+
+        Supported methods:
+            LIST: /{mount_point}/alphabet.
+
+        :param mount_point: The "path" the secrets engine was mounted on.
+        :type mount_point: str | unicode
+        :return: The response of the list_alphabets request.
+        :rtype: requests.Response
+        """
+        api_path = '/v1/{mount_point}/alphabet'.format(mount_point=mount_point)
+        return self._adapter.list(
+            url=api_path,
+        )
+
+    def delete_alphabet(self, name, mount_point=DEFAULT_MOUNT_POINT):
+        """Delete an existing alphabet by the given name.
+
+        Supported methods:
+            DELETE: /{mount_point}/alphabet/:name.
+
+        :param name: the name of the alphabet to delete. This is part of the request URL.
+        :type name: str | unicode
+        :param mount_point: The "path" the secrets engine was mounted on.
+        :type mount_point: str | unicode
+        :return: The response of the delete_alphabet request.
+        :rtype: requests.Response
+        """
+        api_path = '/v1/{mount_point}/alphabet/{name}'.format(
+            mount_point=mount_point,
+            name=name,
+        )
+        return self._adapter.delete(
+            url=api_path,
+        )
+
+    def encode(self, role_name, value=None, transformation=None, tweak=None, batch_input=None, mount_point=DEFAULT_MOUNT_POINT):
+        """Encode the provided value using a named role.
+
+        Supported methods:
+            POST: /{mount_point}/encode/:role_name.
+
+        :param role_name: the role name to use for this operation. This is specified as part
+            of the URL.
+        :type role_name: str | unicode
+        :param value: the value to be encoded.
+        :type value: str | unicode
+        :param transformation: the transformation within the role that should be used for this
+            encode operation. If a single transformation exists for role, this parameter
+            may be skipped and will be inferred. If multiple transformations exist, one
+            must be specified.
+        :type transformation: str | unicode
+        :param tweak: the tweak source.
+        :type tweak: str | unicode
+        :param batch_input: a list of items to be encoded in a single batch. When this
+            parameter is set, the 'value', 'transformation' and 'tweak' parameters are
+            ignored. Instead, the aforementioned parameters should be provided within
+            each object in the list.
+        :type batch_input: list
+        :param mount_point: The "path" the secrets engine was mounted on.
+        :type mount_point: str | unicode
+        :return: The response of the encode request.
+        :rtype: requests.Response
+        """
+        params = utils.remove_nones({
+            'value': value,
+            'transformation': transformation,
+            'tweak': tweak,
+            'batch_input': batch_input,
+        })
+        api_path = '/v1/{mount_point}/encode/{role_name}'.format(
+            mount_point=mount_point,
+            role_name=role_name,
+        )
+        return self._adapter.post(
+            url=api_path,
+            json=params,
+        )
+
+    def decode(self, role_name, value=None, transformation=None, tweak=None, batch_input=None, mount_point=DEFAULT_MOUNT_POINT):
+        """Decode the provided value using a named role.
+
+        Supported methods:
+            POST: /{mount_point}/decode/:role_name.
+
+        :param role_name: the role name to use for this operation. This is specified as part
+            of the URL.
+        :type role_name: str | unicode
+        :param value: the value to be decoded.
+        :type value: str | unicode
+        :param transformation: the transformation within the role that should be used for this
+            decode operation. If a single transformation exists for role, this parameter
+            may be skipped and will be inferred. If multiple transformations exist, one
+            must be specified.
+        :type transformation: str | unicode
+        :param tweak: the tweak source.
+        :type tweak: str | unicode
+        :param batch_input: a list of items to be decoded in a single batch. When this
+            parameter is set, the 'value', 'transformation' and 'tweak' parameters are
+            ignored. Instead, the aforementioned parameters should be provided within
+            each object in the list.
+        :type batch_input: array<object>
+        :param mount_point: The "path" the secrets engine was mounted on.
+        :type mount_point: str | unicode
+        :return: The response of the decode request.
+        :rtype: requests.Response
+        """
+        params = utils.remove_nones({
+            'value': value,
+            'transformation': transformation,
+            'tweak': tweak,
+            'batch_input': batch_input,
+        })
+        api_path = '/v1/{mount_point}/decode/{role_name}'.format(
+            mount_point=mount_point,
+            role_name=role_name,
+        )
+        return self._adapter.post(
+            url=api_path,
+            json=params,
+        )

--- a/tests/integration_tests/api/secrets_engines/test_transform.py
+++ b/tests/integration_tests/api/secrets_engines/test_transform.py
@@ -1,0 +1,432 @@
+import logging
+from unittest import TestCase, skipIf
+
+from tests import utils
+from tests.utils.hvac_integration_test_case import HvacIntegrationTestCase
+
+
+@skipIf(
+    utils.vault_version_lt('1.4.0') or not utils.is_enterprise(),
+    'Transform secrets engine only supported with Enterprise Vault',
+)
+class TestTransform(HvacIntegrationTestCase, TestCase):
+    TEST_MOUNT_POINT = 'transform-integration-test'
+
+    def setUp(self):
+        super(TestTransform, self).setUp()
+        self.client.sys.enable_secrets_engine(
+            backend_type='transform',
+            path=self.TEST_MOUNT_POINT,
+        )
+
+    def tearDown(self):
+        self.client.sys.disable_secrets_engine(path=self.TEST_MOUNT_POINT)
+        super(TestTransform, self).tearDown()
+
+    def test_create_or_update_role(self):
+        create_response = self.client.secrets.transform.create_or_update_role(
+            name='test_role',
+            transformations=[
+                'creditcard-fpe',
+                'creditcard-masking',
+            ],
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('create_response: {}'.format(create_response))
+        self.assertEquals(
+            first=create_response.status_code,
+            second=204,
+        )
+
+    def test_read_role(self):
+        transformations = [
+            'creditcard-fpe',
+            'creditcard-masking',
+        ]
+        create_response = self.client.secrets.transform.create_or_update_role(
+            name='test_role',
+            transformations=transformations,
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('create_response: {}'.format(create_response))
+        read_response = self.client.secrets.transform.read_role(
+            name='test_role',
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('read_response: {}'.format(read_response))
+        self.assertEquals(
+            first=read_response['data']['transformations'],
+            second=transformations,
+        )
+
+    def test_list_roles(self):
+        role_name = 'test_role'
+        transformations = [
+            'creditcard-fpe',
+            'creditcard-masking',
+        ]
+        create_response = self.client.secrets.transform.create_or_update_role(
+            name=role_name,
+            transformations=transformations,
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('create_response: {}'.format(create_response))
+        list_roles_response = self.client.secrets.transform.list_roles(
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('list_roles_response: {}'.format(list_roles_response))
+        self.assertEquals(
+            first=list_roles_response['data']['keys'],
+            second=[role_name],
+        )
+
+    def test_delete_role(self):
+        role_name = 'test_role'
+        transformations = [
+            'creditcard-fpe',
+            'creditcard-masking',
+        ]
+        create_response = self.client.secrets.transform.create_or_update_role(
+            name=role_name,
+            transformations=transformations,
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('create_response: {}'.format(create_response))
+        create_response = self.client.secrets.transform.create_or_update_role(
+            name='other-role',
+            transformations=transformations,
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('create_response: {}'.format(create_response))
+        list_roles_response = self.client.secrets.transform.list_roles(
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('list_roles_response: {}'.format(list_roles_response))
+        self.assertIn(
+            member=role_name,
+            container=list_roles_response['data']['keys'],
+        )
+        delete_role_response = self.client.secrets.transform.delete_role(
+            name=role_name,
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('delete_role_response: {}'.format(delete_role_response))
+        self.assertEquals(
+            first=delete_role_response.status_code,
+            second=204,
+        )
+        list_roles_response = self.client.secrets.transform.list_roles(
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('list_roles_response: {}'.format(list_roles_response))
+        self.assertNotIn(
+            member=role_name,
+            container=list_roles_response['data']['keys'],
+        )
+
+    def test_create_or_update_transformation(self):
+        create_response = self.client.secrets.transform.create_or_update_transformation(
+            name='test-transformation',
+            transform_type='fpe',
+            template='builtin/creditcardnumber',
+            tweak_source='internal',
+            allowed_roles=[
+                'test-role'
+            ],
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('create_response: {}'.format(create_response))
+        self.assertEquals(
+            first=create_response.status_code,
+            second=204,
+        )
+
+    def test_read_transformation(self):
+        test_name = 'test-transformation'
+        template = 'builtin/creditcardnumber'
+        create_response = self.client.secrets.transform.create_or_update_transformation(
+            name=test_name,
+            transform_type='fpe',
+            template=template,
+            tweak_source='internal',
+            allowed_roles=[
+                'test-role'
+            ],
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('create_response: {}'.format(create_response))
+        read_response = self.client.secrets.transform.read_transformation(
+            name=test_name,
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('read_response: {}'.format(read_response))
+        self.assertIn(
+            member=template,
+            container=read_response['data']['templates'],
+        )
+
+    def test_list_transformations(self):
+        test_name = 'test-transformation'
+        template = 'builtin/creditcardnumber'
+        create_response = self.client.secrets.transform.create_or_update_transformation(
+            name=test_name,
+            transform_type='fpe',
+            template=template,
+            tweak_source='internal',
+            allowed_roles=[
+                'test-role'
+            ],
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('create_response: {}'.format(create_response))
+        list_response = self.client.secrets.transform.list_transformations(
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('list_response: {}'.format(list_response))
+        self.assertIn(
+            member=test_name,
+            container=list_response['data']['keys'],
+        )
+
+    def test_delete_transformation(self):
+        test_name = 'test-transformation'
+        template = 'builtin/creditcardnumber'
+        create_response = self.client.secrets.transform.create_or_update_transformation(
+            name=test_name,
+            transform_type='fpe',
+            template=template,
+            tweak_source='internal',
+            allowed_roles=[
+                'test-role'
+            ],
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('create_response: {}'.format(create_response))
+        delete_response = self.client.secrets.transform.delete_transformation(
+            name=test_name,
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('delete_response: {}'.format(delete_response))
+        self.assertEquals(
+            first=delete_response.status_code,
+            second=204,
+        )
+
+    def test_create_or_update_template(self):
+        test_name = 'test-template'
+        create_response = self.client.secrets.transform.create_or_update_template(
+            name=test_name,
+            template_type='regex',
+            pattern='(\\d{9})',
+            alphabet='builtin/numeric',
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('create_response: {}'.format(create_response))
+        self.assertEquals(
+            first=create_response.status_code,
+            second=204,
+        )
+
+    def test_read_template(self):
+        test_name = 'test-template'
+        test_pattern = '(\\d{9})'
+        create_response = self.client.secrets.transform.create_or_update_template(
+            name=test_name,
+            template_type='regex',
+            pattern=test_pattern,
+            alphabet='builtin/numeric',
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('create_response: {}'.format(create_response))
+        read_response = self.client.secrets.transform.read_template(
+            name=test_name,
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('read_response: {}'.format(read_response))
+        self.assertIn(
+            member=test_pattern,
+            container=read_response['data']['pattern'],
+        )
+
+    def test_list_templates(self):
+        test_name = 'test-template'
+        test_pattern = '(\\d{9})'
+        create_response = self.client.secrets.transform.create_or_update_template(
+            name=test_name,
+            template_type='regex',
+            pattern=test_pattern,
+            alphabet='builtin/numeric',
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('create_response: {}'.format(create_response))
+        list_response = self.client.secrets.transform.list_templates(
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('list_response: {}'.format(list_response))
+        self.assertIn(
+            member=test_name,
+            container=list_response['data']['keys'],
+        )
+
+    def test_delete_template(self):
+        test_name = 'test-template'
+        test_pattern = '(\\d{9})'
+        create_response = self.client.secrets.transform.create_or_update_template(
+            name=test_name,
+            template_type='regex',
+            pattern=test_pattern,
+            alphabet='builtin/numeric',
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('create_response: {}'.format(create_response))
+        delete_response = self.client.secrets.transform.delete_template(
+            name=test_name,
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('delete_response: {}'.format(delete_response))
+        self.assertEquals(
+            first=delete_response.status_code,
+            second=204,
+        )
+
+    def test_create_or_update_alphabet(self):
+        test_name = 'test-alphabet'
+        test_alphabet = 'abc'
+        create_response = self.client.secrets.transform.create_or_update_alphabet(
+            name=test_name,
+            alphabet=test_alphabet,
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('create_response: {}'.format(create_response))
+        self.assertEquals(
+            first=create_response.status_code,
+            second=204,
+        )
+
+    def test_read_alphabet(self):
+        test_name = 'test-alphabet'
+        test_alphabet = 'abc'
+        create_response = self.client.secrets.transform.create_or_update_alphabet(
+            name=test_name,
+            alphabet=test_alphabet,
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('create_response: {}'.format(create_response))
+        read_response = self.client.secrets.transform.read_alphabet(
+            name=test_name,
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('read_response: {}'.format(read_response))
+        self.assertEquals(
+            first=test_alphabet,
+            second=read_response['data']['alphabet'],
+        )
+
+    def test_list_alphabets(self):
+        test_name = 'test-alphabet'
+        test_alphabet = 'abc'
+        create_response = self.client.secrets.transform.create_or_update_alphabet(
+            name=test_name,
+            alphabet=test_alphabet,
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('create_response: {}'.format(create_response))
+        list_response = self.client.secrets.transform.list_alphabets(
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('list_response: {}'.format(list_response))
+        self.assertIn(
+            member=test_name,
+            container=list_response['data']['keys'],
+        )
+
+    def test_delete_alphabet(self):
+        test_name = 'test-alphabet'
+        test_alphabet = 'abc'
+        create_response = self.client.secrets.transform.create_or_update_alphabet(
+            name=test_name,
+            alphabet=test_alphabet,
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('create_response: {}'.format(create_response))
+        delete_response = self.client.secrets.transform.delete_alphabet(
+            name=test_name,
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('delete_response: {}'.format(delete_response))
+        self.assertEquals(
+            first=delete_response.status_code,
+            second=204,
+        )
+
+    def test_encode(self):
+        role_name = 'test-role'
+        transformation_name = 'test-transformation'
+        transformations = [transformation_name]
+        test_input_value = '1111-1111-1111-1111'
+        expected_output = '****-****-****-****'
+        create_role_response = self.client.secrets.transform.create_or_update_role(
+            name=role_name,
+            transformations=transformations,
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('create_role_response: {}'.format(create_role_response))
+        create_transform_response = self.client.secrets.transform.create_or_update_transformation(
+            name=transformation_name,
+            transform_type='masking',
+            template='builtin/creditcardnumber',
+            tweak_source='internal',
+            allowed_roles=[role_name],
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('create_transform_response: {}'.format(create_transform_response))
+        encode_response = self.client.secrets.transform.encode(
+            role_name=role_name,
+            value=test_input_value,
+            transformation=transformation_name,
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('encode_response: {}'.format(encode_response))
+        self.assertEquals(
+            first=encode_response['data']['encoded_value'],
+            second=expected_output,
+        )
+
+    def test_decode(self):
+        role_name = 'test-role'
+        transformation_name = 'test-transformation'
+        transformations = [transformation_name]
+        test_input_value = '1111-1111-1111-1111'
+        create_role_response = self.client.secrets.transform.create_or_update_role(
+            name=role_name,
+            transformations=transformations,
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('create_role_response: {}'.format(create_role_response))
+        create_transform_response = self.client.secrets.transform.create_or_update_transformation(
+            name=transformation_name,
+            transform_type='fpe',
+            template='builtin/creditcardnumber',
+            tweak_source='internal',
+            allowed_roles=[role_name],
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('create_transform_response: {}'.format(create_transform_response))
+        encode_response = self.client.secrets.transform.encode(
+            role_name=role_name,
+            value=test_input_value,
+            transformation=transformation_name,
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('encode_response: {}'.format(encode_response))
+        decode_response = self.client.secrets.transform.decode(
+            role_name=role_name,
+            value=encode_response['data']['encoded_value'],
+            transformation=transformation_name,
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug('decode_response: {}'.format(decode_response))
+        self.assertEquals(
+            first=decode_response['data']['decoded_value'],
+            second=test_input_value,
+        )


### PR DESCRIPTION
With the release of Vault 1.4.0, the [transform secrets engine](https://www.hashicorp.com/blog/transform-secrets-engine/) is now available for Vault enterprise. Adding a class to support this secrets engine, with associated docs, in this PR.