### PR TITLE
Add Support For use_token_groups In LDAP Auth Method

### DIFF
--- a/hvac/api/auth_methods/ldap.py
+++ b/hvac/api/auth_methods/ldap.py
@@ -16,7 +16,7 @@ class Ldap(VaultApiBase):
     def configure(self, user_dn=None, group_dn=None, url=None, case_sensitive_names=None, starttls=None,
                   tls_min_version=None, tls_max_version=None, insecure_tls=None, certificate=None, bind_dn=None,
                   bind_pass=None, user_attr=None, discover_dn=None, deny_null_bind=True, upn_domain=None,
-                  group_filter=None, group_attr=None, mount_point=DEFAULT_MOUNT_POINT):
+                  group_filter=None, group_attr=None, use_token_groups=None, mount_point=DEFAULT_MOUNT_POINT):
         """
         Configure the LDAP auth method.
 
@@ -72,6 +72,9 @@ class Ldap(VaultApiBase):
             membership. Examples: for groupfilter queries returning group objects, use: cn. For queries returning user
             objects, use: memberOf. The default is cn.
         :type group_attr: str | unicode
+        :param use_token_groups: If true, groups are resolved through Active Directory tokens. This may speed up nested
+            group membership resolution in large directories.
+        :type use_token_groups: bool
         :param mount_point: The "path" the method/backend was mounted on.
         :type mount_point: str | unicode
         :return: The response of the configure request.
@@ -96,6 +99,7 @@ class Ldap(VaultApiBase):
             'binddn': bind_dn,
             'bindpass': bind_pass,
             'certificate': certificate,
+            'use_token_groups': use_token_groups,
         })
 
         api_path = utils.format_url('/v1/auth/{mount_point}/config', mount_point=mount_point)


### PR DESCRIPTION
Hashicorp [added support for use_token_groups for LDAP backend back in 2018](https://github.com/hashicorp/vault/pull/4936) . This parameter is not in [the documentation](https://www.vaultproject.io/api-docs/auth/ldap) but it is available on the [Terraform provider](https://www.terraform.io/docs/providers/vault/r/ldap_auth_backend.html#use_token_groups).

It is only applicable to Active Directory and greatly improves the performance of group resolution on large directories.

This pull request adds support for that parameter. 

I have not added any tests because I am not sure how I can test this. Please let me know if you have any suggestions I will add the tests. I tested it on my Vault cluster against my AD environment. 
