### PR TITLE
Add Raft System Backend Methods

### DIFF
--- a/docs/usage/system_backend/index.rst
+++ b/docs/usage/system_backend/index.rst
@@ -14,5 +14,6 @@ System Backend
    mount
    namespace
    policy
+   raft
    seal
    wrapping

--- a/docs/usage/system_backend/raft.rst
+++ b/docs/usage/system_backend/raft.rst
@@ -1,0 +1,49 @@
+Raft
+====
+
+:py:meth:`hvac.api.system_backend.Raft`
+
+.. contents::
+   :local:
+   :depth: 1
+
+Join Raft Cluster
+-----------------
+
+:py:meth:`hvac.api.system_backend.Raft.join_raft_cluster`
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    client.sys.join_raft_cluster(
+        leader_api_addr='https://some-vault-node',
+    )
+
+Read Raft Configuration
+-----------------------
+
+:py:meth:`hvac.api.system_backend.Raft.read_raft_config`
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    raft_config = c.sys.read_raft_config()
+    num_servers_in_cluster = len(raft_config['data']['config']['servers'])
+
+Remove Raft Node
+----------------
+
+:py:meth:`hvac.api.system_backend.Raft.remove_raft_node`
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    client.sys.remove_raft_node(
+        server_id='i-somenodeid',
+    )

--- a/hvac/api/system_backend/__init__.py
+++ b/hvac/api/system_backend/__init__.py
@@ -12,6 +12,7 @@ from hvac.api.system_backend.lease import Lease
 from hvac.api.system_backend.mount import Mount
 from hvac.api.system_backend.namespace import Namespace
 from hvac.api.system_backend.policy import Policy
+from hvac.api.system_backend.raft import Raft
 from hvac.api.system_backend.seal import Seal
 from hvac.api.system_backend.wrapping import Wrapping
 from hvac.api.system_backend.system_backend_mixin import SystemBackendMixin
@@ -29,6 +30,7 @@ __all__ = (
     'Mount',
     'Namespace',
     'Policy',
+    'Raft',
     'Seal',
     'SystemBackend',
     'SystemBackendMixin',
@@ -40,7 +42,7 @@ logger = logging.getLogger(__name__)
 
 
 class SystemBackend(VaultApiCategory, Audit, Auth, Capabilities, Health, Init, Key, Leader, Lease, Mount, Namespace,
-                    Policy, Seal, Wrapping):
+                    Policy, Raft, Seal, Wrapping):
     implemented_classes = [
         Audit,
         Auth,
@@ -53,6 +55,7 @@ class SystemBackend(VaultApiCategory, Audit, Auth, Capabilities, Health, Init, K
         Mount,
         Namespace,
         Policy,
+        Raft,
         Seal,
         Wrapping,
     ]

--- a/hvac/api/system_backend/raft.py
+++ b/hvac/api/system_backend/raft.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python
+"""Raft methods module."""
+from hvac.api.system_backend.system_backend_mixin import SystemBackendMixin
+from hvac import utils
+
+
+class Raft(SystemBackendMixin):
+    """Raft cluster-related system backend methods.
+
+    When using Shamir seal, as soon as the Vault server is brought up, this API should be invoked
+    instead of sys/init. This API completes in 2 phases. Once this is invoked, the joining node
+    will receive a challenge from the Raft's leader node. This challenge can be answered by the
+    joining node only after a successful unseal. Hence, the joining node should be unsealed using
+    the unseal keys of the Raft's leader node.
+
+    Reference: https://www.vaultproject.io/api-docs/system/storage/raft
+    """
+
+    def join_raft_cluster(self, leader_api_addr, retry=False, leader_ca_cert=None, leader_client_cert=None, leader_client_key=None):
+        """Join a new server node to the Raft cluster.
+
+        When using Shamir seal, as soon as the Vault server is brought up, this API should be invoked
+        instead of sys/init. This API completes in 2 phases. Once this is invoked, the joining node will
+        receive a challenge from the Raft's leader node. This challenge can be answered by the joining
+        node only after a successful unseal. Hence, the joining node should be unsealed using the unseal
+        keys of the Raft's leader node.
+
+        Supported methods:
+            POST: /sys/storage/raft/join.
+
+        :param leader_api_addr: Address of the leader node in the Raft cluster to which this node is trying to join.
+        :type leader_api_addr: str | unicode
+        :param retry: Retry joining the Raft cluster in case of failures.
+        :type retry: bool
+        :param leader_ca_cert: CA certificate used to communicate with Raft's leader node.
+        :type leader_ca_cert: str | unicode
+        :param leader_client_cert: Client certificate used to communicate with Raft's leader node.
+        :type leader_client_cert: str | unicode
+        :param leader_client_key: Client key used to communicate with Raft's leader node.
+        :type leader_client_key: str | unicode
+        :return: The response of the join_raft_cluster request.
+        :rtype: requests.Response
+        """
+        params = utils.remove_nones({
+            'leader_api_addr': leader_api_addr,
+            'retry': retry,
+            'leader_ca_cert': leader_ca_cert,
+            'leader_client_cert': leader_client_cert,
+            'leader_client_key': leader_client_key,
+        })
+        api_path = '/v1/sys/storage/raft/join'
+        return self._adapter.post(
+            url=api_path,
+            json=params,
+        )
+
+    def read_raft_config(self):
+        """Read the details of all the nodes in the raft cluster.
+
+        Supported methods:
+            GET: /sys/storage/raft/configuration.
+
+        :return: The response of the read_raft_config request.
+        :rtype: requests.Response
+        """
+        api_path = '/v1/sys/storage/raft/configuration'
+        return self._adapter.get(
+            url=api_path,
+        )
+
+    def remove_raft_node(self, server_id):
+        """Remove a node from the raft cluster.
+
+        Supported methods:
+            POST: /sys/storage/raft/remove-peer.
+
+        :param server_id: The ID of the node to remove.
+        :type server_id: str
+        :return: The response of the remove_raft_node request.
+        :rtype: requests.Response
+        """
+        params = {
+            'server_id': server_id,
+        }
+        api_path = '/v1/sys/storage/raft/remove-peer'
+        return self._adapter.post(
+            url=api_path,
+            json=params,
+        )
+
+    def take_raft_snapshot(self):
+        """Returns a snapshot of the current state of the raft cluster.
+
+        The snapshot is returned as binary data and should be redirected to a file.
+
+        Supported methods:
+            GET: /sys/storage/raft/snapshot.
+
+        :return: The response of the s request.
+        :rtype: requests.Response
+        """
+        api_path = '/v1/sys/storage/raft/snapshot'
+        return self._adapter.get(
+            url=api_path,
+            stream=True,
+        )
+
+    def restore_raft_snapshot(self, snapshot):
+        """Install the provided snapshot, returning the cluster to the state defined in it.
+
+        Supported methods:
+            POST: /sys/storage/raft/snapshot.
+
+        :param snapshot: Previously created raft snapshot / binary data.
+        :type snapshot: bytes
+        :return: The response of the restore_raft_snapshot request.
+        :rtype: requests.Response
+        """
+        api_path = '/v1/sys/storage/raft/snapshot'
+        return self._adapter.post(
+            url=api_path,
+            data=snapshot,
+        )
+
+    def force_restore_raft_snapshot(self, snapshot):
+        """Installs the provided snapshot, returning the cluster to the state defined in it.
+
+        This is same as writing to /sys/storage/raft/snapshot except that this bypasses checks
+        ensuring the Autounseal or shamir keys are consistent with the snapshot data.
+
+        Supported methods:
+            POST: /sys/storage/raft/snapshot-force.
+
+        :param snapshot: Previously created raft snapshot / binary data.
+        :type snapshot: bytes
+        :return: The response of the force_restore_raft_snapshot request.
+        :rtype: requests.Response
+        """
+        api_path = '/v1/sys/storage/raft/snapshot-force'
+        return self._adapter.post(
+            url=api_path,
+            data=snapshot,
+        )


### PR DESCRIPTION
Full disclosure: I haven't quite been able to figure out how to get the snapshot methods working yet but I'm going to go ahead and commit them for now. I've tried this sort of usage but no dice yet...

```rst
Take Raft Snapshot
------------------

:py:meth:`hvac.api.system_backend.Raft.take_raft_snapshot`

.. code:: python

    import hvac
    client = hvac.Client()

    import hvac
    client = hvac.Client()
    response = client.sys.take_raft_snapshot()

    with open('raft.snap', 'wb') as snapshot_file:
        for chunk in response:
            snapshot_file.write(chunk)


Restore Raft Snapshot
---------------------

:py:meth:`hvac.api.system_backend.Raft.restore_raft_snapshot`

.. code:: python

    import hvac
    client = hvac.Client()

    with open('out.snap', 'rb') as snapshot_file:
        r = client.sys.restore_raft_snapshot(
            snapshot=snapshot_file.read()
        )

Force Restore Raft Snapshot
---------------------------

:py:meth:`hvac.api.system_backend.Raft.force_restore_raft_snapshot`

.. code:: python

    import hvac
    client = hvac.Client()

    with open('out.snap', 'rb') as snapshot_file:
        r = client.sys.force_restore_raft_snapshot(
            snapshot=snapshot_file.read()
        )
```

-->

```python
>>> with open('out.snap', 'rb') as snapshot_file:
...     r = client.sys.restore_raft_snapshot(
...         snapshot=snapshot_file.read()
...     )
...
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
  File "/home/ubuntu/.local/lib/python3.8/site-packages/hvac/api/system_backend/raft.py", line 113, in restore_raft_snapshot
    return self._adapter.post(
  File "/home/ubuntu/.local/lib/python3.8/site-packages/hvac/adapters.py", line 107, in post
    return self.request('post', url, **kwargs)
  File "/home/ubuntu/.local/lib/python3.8/site-packages/hvac/adapters.py", line 342, in request
    response = super(JSONAdapter, self).request(*args, **kwargs)
  File "/home/ubuntu/.local/lib/python3.8/site-packages/hvac/adapters.py", line 304, in request
    utils.raise_for_error(
  File "/home/ubuntu/.local/lib/python3.8/site-packages/hvac/utils.py", line 47, in raise_for_error
    raise exceptions.InternalServerError(message, errors=errors, method=method, url=url)
hvac.exceptions.InternalServerError: 1 error occurred:
	* failed to decompress snapshot: unexpected EOF

, on post http://127.0.0.1:8200/v1/sys/storage/raft/snapshot
```