### PR TITLE
Extract "renew_self_token" from "renew_token"

### DIFF
--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -6,6 +6,7 @@ from base64 import b64encode
 
 from hvac import aws_utils, exceptions, adapters, utils, api
 from hvac.constants.client import DEPRECATED_PROPERTIES, DEFAULT_URL
+from hvac.utils import generate_property_deprecation_message
 
 try:
     import hcl
@@ -433,6 +434,8 @@ class Client(object):
         :type wrap_ttl:
         :return:
         :rtype:
+
+        For calls expecting to hit the renew-self endpoint please use the "renew_self_token" method instead
         """
         params = {
             'increment': increment,
@@ -442,7 +445,25 @@ class Client(object):
             params['token'] = token
             return self._adapter.post('/v1/auth/token/renew', json=params, wrap_ttl=wrap_ttl)
         else:
-            return self._adapter.post('/v1/auth/token/renew-self', json=params, wrap_ttl=wrap_ttl)
+            generate_property_deprecation_message("1.0.0", "renew_token() without token param", "renew_self_token() without token param", "renew_self_token")
+            return self.renew_self_token(increment=increment, wrap_ttl=wrap_ttl)
+
+    def renew_self_token(self, increment=None, wrap_ttl=None):
+        """
+        POST /auth/token/renew-self
+
+        :param increment:
+        :type increment:
+        :param wrap_ttl:
+        :type wrap_ttl:
+        :return:
+        :rtype:
+        """
+        params = {
+            'increment': increment,
+        }
+
+        return self._adapter.post('/v1/auth/token/renew-self', json=params, wrap_ttl=wrap_ttl)
 
     def create_token_role(self, role,
                           allowed_policies=None, disallowed_policies=None,

--- a/tests/integration_tests/v1/test_integration.py
+++ b/tests/integration_tests/v1/test_integration.py
@@ -78,6 +78,7 @@ class IntegrationTest(HvacIntegrationTestCase, TestCase):
     def test_self_auth_token_manipulation(self):
         result = self.client.create_token(lease='1h', renewable=True)
         assert result['auth']['client_token']
+        self.client.token = result['auth']['client_token']
 
         lookup = self.client.lookup_token(result['auth']['client_token'])
         assert result['auth']['client_token'] == lookup['data']['id']


### PR DESCRIPTION
* Extract call to `renew-self` endpoint into it's own function
* Add deprecation message around calling `renew_token()` without the `token` parameter
---
I had mentioned this in the gitter channel, but I am extracting the `renew-self` endpoint into it's own function. As of now the `renew_token()` function can call either `renew` or `renew-self`. The issue with this comes into play when a client has permissions to renew its own token via the `renew-self` endpoint but passes a token in to the `renew_token()` function and the `renew` endpoint doesn't recognize this permission and fails with `permission denied`. I think that by extracting the `renew-self` endpoint functionality into it's own function will make the library clearer to use, while also having these functions more closely adhere to SRP.