### PR TITLE
bugfix: options not read by tune_mount_configuration

### DIFF
--- a/hvac/api/system_backend/mount.py
+++ b/hvac/api/system_backend/mount.py
@@ -179,7 +179,7 @@ class Mount(SystemBackendMixin):
             'audit_non_hmac_response_keys',
             'listing_visibility',
             'passthrough_request_headers',
-            'force_no_cache'
+            'force_no_cache',
             'options',
         ]
         params = {}


### PR DESCRIPTION
Was pulling my hair out trying to workout why my kv wouldn't update to kv2!
