### PR TITLE
Support for Google IAP proxy authentication

### DIFF
--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -88,3 +88,24 @@ hvac does not currently offer direct support of requests to a `Vault agent proce
 		session=socket_session,
 	)
 	print(client.secrets.kv.read_secret_version(path='some-secret'))
+
+
+
+Using Vault behind Google IAP
+--------------------------------
+
+Vault instances secured behind Google IAP enjoy an extra level of protection due to the Google Cloud Platform role required to access the web application. In order to access your vault instance each request must contain a valid Google-issued OpenID Connect token in the authorization header.
+.. code:: python
+
+    advanced_proxy = {
+        "provider": "google",
+        "payload": {
+            "client_id": "your_google_client_id.apps.googleusercontent.com"
+        }
+    }
+
+    self.client = hvac.Client(url=vault_url, namespace='your_vault_namespace', advanced_proxies=advanced_proxy)
+
+
+ttt
+

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -99,6 +99,13 @@ Vault instances secured behind Google IAP enjoy an extra level of protection due
 
 Rather than build a static feature to allow only Google IAP it was decided to build an advanced_function parameter that could support a plugable proxy backend.  This was accomplished via passing in a dictionary container a string with the provider name which will need to match a valid key in `ProxyRouter.ADVANCED_PROXIES`
 
+In order to leverage the advanced proxy simply pass a kwarg when instantiating your hvac.Client() object. This parameter MUST contain a dictionary with two keys as shown below.
+
+- provider
+    - String: Name of the provider
+- payload
+    - Dictonary: Must contain the values for any required variables your plugin requires. For Google IAP this is "client_id" for the IAP instance you want to access
+
 .. code:: python
 
     advanced_proxy = {

--- a/hvac/proxy.py
+++ b/hvac/proxy.py
@@ -27,7 +27,7 @@ class GoogleIAP:
             print("A required payload K/V pair is missing: client_id\n"
                   "This KV pair is used to generates the Google-issued OpenID Connect token")
     @staticmethod
-    def print_modules_note_installed(e):
+    def print_modules_not_installed(e):
         print_statement = f"""
         Looks like there was an error importing google.oauth2 library. Versions in print statements were captured at time of development
         To install google.oauth2 library use the following command:
@@ -53,7 +53,7 @@ class GoogleIAP:
             self.proxy_id_token = id_token.fetch_id_token(Request(), self.client_id)
             return f"Bearer {self.proxy_id_token}"
         except Exception as e:
-            self.print_modules_note_installed(e=e)
+            self.print_modules_not_installed(e=e)
             return None
 
 

--- a/hvac/proxy.py
+++ b/hvac/proxy.py
@@ -1,0 +1,124 @@
+class GoogleIAP:
+    """
+    This class contains all of the code to authentication against a vault instance secured by Google IAP.
+    NOTE: This authentication method works when leveraging a service account
+    Requirements:
+    1. Have your GOOGLE_APPLICATION_CREDENTAILS varaible configured with the service account you will be authenticating with
+    2. The service account must have the following permission: roles/iam.serviceAccountTokenCreator
+        This is required to create the JWT that is returned
+
+    Currently supports authentication via service accounts
+    """
+    def __init__(self):
+        self.proxy_id_token = None
+        self.client_id = None
+
+    def add_payload(self, payload):
+        """
+        Standard function for all plugins to add the content of the advanced_proxy["payload"] into plugin.
+
+        This function will crape thr content os the payload for the values we require
+        :param payload:
+        :return:
+        """
+        try:
+            self.client_id = payload["client_id"]
+        except KeyError:
+            print("A required payload K/V pair is missing: client_id\n"
+                  "This KV pair is used to generates the Google-issued OpenID Connect token")
+    @staticmethod
+    def print_modules_note_installed(e):
+        print_statement = f"""
+        Looks like there was an error importing google.oauth2 library. Versions in print statements were captured at time of development
+        To install google.oauth2 library use the following command:
+        pip install google-auth-oauthlib==0.4.1
+
+        To install the base google.auth package please use the following command
+        pip install google-auth==1.20.1
+        Exception: {e}
+        """
+        print(print_statement)
+
+    def generate_auth_token(self):
+        """
+        Generate a valid Google-issued OpenID Connect token for the service account
+        :return:
+        """
+        if self.client_id is None:
+            print("No client_id was passed in the payload during client instantiation. Unable to generate Google-issued OpenID Connect token")
+            return None
+        try:
+            from google.oauth2 import id_token
+            from google.auth.transport.requests import Request
+            self.proxy_id_token = id_token.fetch_id_token(Request(), self.client_id)
+            return f"Bearer {self.proxy_id_token}"
+        except Exception as e:
+            self.print_modules_note_installed(e=e)
+            return None
+
+
+class ProxyRouter:
+    def __init__(self, advanced_proxy):
+        """
+        The proxy router will provide a plugable advanced proxy mechanism for Vault.
+
+        :param advanced_proxy: Type: Dict
+        :param advanced_proxy:  a dictionary with two keys needs to be passed
+        Example:
+        {
+            "provider":"google", # The name of the plugin you wish to use
+            "payload": {"client_id":"my-gcp-iap-client-id-545435345345345345345"}  # Custom dict to pass to your plugin
+        }
+
+
+        Usage:
+                advanced_proxy = {
+            "provider": "google",
+            "payload": {
+                "client_id": "my-gcp-iap-client-id-545435345345345345345"
+            }
+        }
+        self.client = hvac.Client(url=self.VAULT_URL, namespace='myco', advanced_proxies=advanced_proxy)
+        """
+        self.selected_proxy_configuration = None
+
+        # This will need to be modified as more advanced proxy plugins become available
+        self.ADVANCED_PROXIES = {
+            "google": GoogleIAP,
+        }
+
+        try:
+            provider = advanced_proxy.get("provider", None)
+            self.get_proxy_configuration(advanced_proxy=provider)
+        except AttributeError:
+            print("No provider key was passed into advanced_proxy dict")
+            self.get_proxy_configuration(advanced_proxy=None)
+
+        try:
+            payload = advanced_proxy.get("payload", None)
+            self.add_payload_to_plugin(payload)
+        except AttributeError:
+            print("No payload key was passed into advanced_proxy dict")
+
+    def get_proxy_configuration(self, advanced_proxy):
+        """
+        Instantiates the advanced proxy object
+        :param advanced_proxy: key for self.ADVANCED_PROXIES
+        :return:
+        """
+        if advanced_proxy is None:
+            self.selected_proxy_configuration = None
+        else:
+            self.selected_proxy_configuration = self.ADVANCED_PROXIES.get(advanced_proxy, None)()
+
+    def add_payload_to_plugin(self, payload):
+        self.selected_proxy_configuration.add_payload(payload)
+
+    def get_request_authorization_header(self):
+        """
+        :return: Returns a valid Bearer header for advance proxy
+        """
+        if self.selected_proxy_configuration is not None:
+            return self.selected_proxy_configuration.generate_auth_token()
+        else:
+            return None

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -21,7 +21,7 @@ class Client(object):
     def __init__(self, url=None, token=None,
                  cert=None, verify=True, timeout=30, proxies=None,
                  allow_redirects=True, session=None, adapter=adapters.JSONAdapter,
-                 namespace=None, **kwargs, advanced_proxies=None):
+                 namespace=None, advanced_proxies=None, **kwargs ):
         """Creates a new hvac client instance.
 
         :param url: Base URL for the Vault instance being addressed.

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -21,7 +21,7 @@ class Client(object):
     def __init__(self, url=None, token=None,
                  cert=None, verify=True, timeout=30, proxies=None,
                  allow_redirects=True, session=None, adapter=adapters.JSONAdapter,
-                 namespace=None, advanced_proxies=None, **kwargs ):
+                 namespace=None, advanced_proxies=None, **kwargs):
         """Creates a new hvac client instance.
 
         :param url: Base URL for the Vault instance being addressed.

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -21,7 +21,7 @@ class Client(object):
     def __init__(self, url=None, token=None,
                  cert=None, verify=True, timeout=30, proxies=None,
                  allow_redirects=True, session=None, adapter=adapters.JSONAdapter,
-                 namespace=None, **kwargs):
+                 namespace=None, **kwargs, advanced_proxies=None):
         """Creates a new hvac client instance.
 
         :param url: Base URL for the Vault instance being addressed.


### PR DESCRIPTION
This proposed changed will allow services accounts that leverage a Google IAP secured Vault instanced to authenticate to the proxy prior to hitting the Vault API.

I designed it as a plug able mechanism for different advanced proxies. 