### PR TITLE
Fix transit constants for "generate_data_key"

### DIFF
--- a/hvac/constants/transit.py
+++ b/hvac/constants/transit.py
@@ -22,7 +22,7 @@ ALLOWED_EXPORT_KEY_TYPES = [
 
 ALLOWED_DATA_KEY_TYPES = [
     'plaintext',
-    'ciphertext',
+    'wrapped',
 ]
 
 ALLOWED_DATA_KEY_BITS = [


### PR DESCRIPTION
For transit "generate_data_key" function, the [official documentation](https://www.vaultproject.io/api-docs/secret/transit#generate-data-key) and your [own documentation](https://hvac.readthedocs.io/en/stable/usage/secrets_engines/transit.html#generate-data-key) only mentions "plaintext" and "wrapped" as valid value for the key type.
The problem is that "ciphertext" seems to replace "wrapped" in your constant.
Moreover, "ciphertext" is not valid and results in the following traceback : 

```
Traceback (most recent call last):
  File "[...]", line 91, in runcode
    exec(code, self.locals)
  File "<input>", line 4, in <module>
  File "[...]/hvac/api/secrets_engines/transit.py", line 504, in generate_data_key
    json=params,
  File "[...]/hvac/adapters.py", line 107, in post
    return self.request('post', url, **kwargs)
  File "[...]/hvac/adapters.py", line 342, in request
    response = super(JSONAdapter, self).request(*args, **kwargs)
  File "[...]/hvac/adapters.py", line 309, in request
    errors=errors
  File "[...]/hvac/utils.py", line 37, in raise_for_error
    raise exceptions.InvalidRequest(message, errors=errors, method=method, url=url)
hvac.exceptions.InvalidRequest: Invalid path, must be 'plaintext' or 'wrapped', on post https://[...]
```