### PR TITLE
remove legacy policy type check

### DIFF
--- a/hvac/api/secrets_engines/consul.py
+++ b/hvac/api/secrets_engines/consul.py
@@ -80,10 +80,6 @@ class Consul(VaultApiBase):
         """
         api_path = utils.format_url("/v1/{}/roles/{}", mount_point, name)
 
-        if not policy and token_type != "management":
-            error_msg = 'policy must be specified unless token_type is management'
-            raise exceptions.ParamValidationError(error_msg)
-
         params = utils.remove_nones({
             "token_type": token_type,
             "policy": policy,


### PR DESCRIPTION
The below change allows any version of consul newer than 1.4 to create tokens with the new policy system. 

Current release of hvac means I can only create a token that maps to an existing policy if it's a management type token, which is not ideal as newer versions will warn that you are using 'legacy type tokens' and suggest going to documentation to upgrade your tokens.
A management token has global rights within the system, so this is expressly not wanted most of the time for generating tokens.
