### PR TITLE
Add auth_methods module to support AppRole

### DIFF
--- a/hvac/api/auth_methods/__init__.py
+++ b/hvac/api/auth_methods/__init__.py
@@ -2,6 +2,7 @@
 
 import warnings
 
+from hvac.api.auth_methods.approle import AppRole
 from hvac.api.auth_methods.azure import Azure
 from hvac.api.auth_methods.gcp import Gcp
 from hvac.api.auth_methods.github import Github
@@ -19,6 +20,7 @@ from hvac.utils import generate_method_deprecation_message
 
 __all__ = (
     'AuthMethods',
+    'AppRole',
     'Azure',
     'Gcp',
     'Github',
@@ -37,6 +39,7 @@ __all__ = (
 class AuthMethods(VaultApiCategory):
     """Auth Methods."""
     implemented_classes = [
+        AppRole,
         Azure,
         Github,
         Gcp,
@@ -52,7 +55,6 @@ class AuthMethods(VaultApiCategory):
     ]
     unimplemented_classes = [
         'AppId',
-        'AppRole',
         'AliCloud',
         'Cert',
         'Token',

--- a/hvac/api/auth_methods/approle.py
+++ b/hvac/api/auth_methods/approle.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""APPROLE methods module."""
+from hvac import exceptions, utils
+from hvac.api.vault_api_base import VaultApiBase
+from hvac.constants.approle import DEFAULT_MOUNT_POINT, ALLOWED_TOKEN_TYPES
+from hvac.utils import validate_list_of_strings_param, list_to_comma_delimited
+
+
+class AppRole(VaultApiBase):
+    """USERPASS Auth Method (API).
+    Reference: https://www.vaultproject.io/api-docs/auth/approle/index.html
+    """
+
+    def create_or_update_approle(self, role_name, bind_secret_id=None, secret_id_bound_cidrs=None,
+                                 secret_id_num_uses=None, secret_id_ttl=None, enable_local_secret_ids=None,
+                                 token_ttl=None, token_max_ttl=None, token_policies=None,
+                                 token_bound_cidrs=None, token_explicit_max_ttl=None,
+                                 token_no_default_policy=None, token_num_uses=None, token_period=None,
+                                 token_type=None, mount_point=DEFAULT_MOUNT_POINT):
+        """
+        Create/update approle.
+
+        Supported methods:
+            POST: /auth/{mount_point}/role/{role_name}. Produces: 204 (empty body)
+
+        :param role_name: The name for the approle.
+        :type role_name: str | unicode
+        :param bind_secret_id: Require secret_id to be presented when logging in using this approle.
+        :type bind_secret_id: bool
+        :param secret_id_bound_cidrs: Blocks of IP addresses which can perform login operations.
+        :type secret_id_bound_cidrs: list
+        :param secret_id_num_uses: Number of times any secret_id can be used to fetch a token.
+            A value of zero allows unlimited uses.
+        :type secret_id_num_uses: int
+        :param secret_id_ttl: Duration after which a secret_id expires. This can be specified
+            as an integer number of seconds or as a duration value like "5m".
+        :type secret_id_ttl: str | unicode
+        :param enable_local_secret_ids: Secret IDs generated using role will be cluster local.
+        :type enable_local_secret_ids: bool
+        :param token_ttl: Incremental lifetime for generated tokens. This can be specified
+            as an integer number of seconds or as a duration value like "5m".
+        :type token_ttl: str | unicode
+        :param token_max_ttl: Maximum lifetime for generated tokens: This can be specified
+            as an integer number of seconds or as a duration value like "5m".
+        :type token_max_ttl: str | unicode
+        :param token_policies: List of policies to encode onto generated tokens.
+        :type token_policies: list
+        :param token_bound_cidrs: Blocks of IP addresses which can authenticate successfully.
+        :type token_bound_cidrs: list
+        :param token_explicit_max_ttl: If set, will encode an explicit max TTL onto the token. This can be specified
+            as an integer number of seconds or as a duration value like "5m".
+        :type token_explicit_max_ttl: str | unicode
+        :param token_no_default_policy: Do not add the default policy to generated tokens, use only tokens
+            specified in token_policies.
+        :type token_no_default_policy: bool
+        :param token_num_uses: Maximum number of times a generated token may be used. A value of zero
+            allows unlimited uses.
+        :type token_num_uses: int
+        :param token_period: The period, if any, to set on the token. This can be specified
+            as an integer number of seconds or as a duration value like "5m".
+        :type token_period: str | unicode
+        :param token_type: The type of token that should be generated, can be "service", "batch", or "default".
+        :type token_type: str | unicode
+        :param mount_point: The "path" the method/backend was mounted on.
+        :type mount_point: str | unicode
+        """
+        list_of_strings_params = {
+            'secret_id_bound_cidrs': secret_id_bound_cidrs,
+            'token_policies': token_policies,
+            'token_bound_cidrs': token_bound_cidrs
+        }
+
+        if token_type is not None and token_type not in ALLOWED_TOKEN_TYPES:
+            error_msg = 'unsupported token_type argument provided "{arg}", supported types: "{token_types}"'
+            raise exceptions.ParamValidationError(error_msg.format(
+                arg=token_type,
+                token_types=','.join(ALLOWED_TOKEN_TYPES),
+            ))
+
+        params = dict()
+
+        for param_name, param_argument in list_of_strings_params.items():
+            validate_list_of_strings_param(
+                param_name=param_name,
+                param_argument=param_argument,
+            )
+            if param_argument is not None:
+                params[param_name] = list_to_comma_delimited(param_argument)
+
+        params.update(
+            utils.remove_nones({
+                'bind_secret_id': bind_secret_id,
+                'secret_id_num_uses': secret_id_num_uses,
+                'secret_id_ttl': secret_id_ttl,
+                'enable_local_secret_ids': enable_local_secret_ids,
+                'token_ttl': token_ttl,
+                'token_max_ttl': token_max_ttl,
+                'token_explicit_max_ttl': token_explicit_max_ttl,
+                'token_no_default_policy': token_no_default_policy,
+                'token_num_uses': token_num_uses,
+                'token_period': token_period,
+                'token_type': token_type
+            })
+        )
+
+        api_path = utils.format_url(
+            '/v1/auth/{mount_point}/role/{name}',
+            mount_point=mount_point,
+            name=role_name
+        )
+        return self._adapter.post(url=api_path, json=params)
+
+    def list_roles(self, mount_point=DEFAULT_MOUNT_POINT):
+        """
+        List existing roles created in the auth method.
+
+        Supported methods:
+            LIST: /auth/{mount_point}/role. Produces: 200 application/json
+
+        :param mount_point: The "path" the method/backend was mounted on.
+        :type mount_point: str | unicode
+        :return: The JSON response of the list_roles request.
+        :rtype: dict
+        """
+        api_path = utils.format_url(
+            '/v1/auth/{mount_point}/role',
+            mount_point=mount_point
+        )
+        return self._adapter.list(url=api_path)
+
+    def read_role(self, role_name, mount_point=DEFAULT_MOUNT_POINT):
+        """
+        Read role in the auth method.
+
+        Supported methods:
+            GET: /auth/{mount_point}/role/{role_name}. Produces: 200 application/json
+
+        :param role_name: The name for the role.
+        :type role_name: str | unicode
+        :param mount_point: The "path" the method/backend was mounted on.
+        :type mount_point: str | unicode
+        :return: The JSON response of the read_role request.
+        :rtype: dict
+        """
+        api_path = utils.format_url(
+            '/v1/auth/{mount_point}/role/{role_name}',
+            mount_point=mount_point,
+            role_name=role_name
+        )
+        return self._adapter.get(url=api_path)
+
+    def delete_role(self, role_name, mount_point=DEFAULT_MOUNT_POINT):
+        """
+        Delete role in the auth method.
+
+        Supported methods:
+            DELETE: /auth/{mount_point}/role/{role_name}. Produces: 204 (empty body)
+
+        :param role_name: The name for the role.
+        :type role_name: str | unicode
+        :param mount_point: The "path" the method/backend was mounted on.
+        :type mount_point: str | unicode
+        """
+        api_path = utils.format_url(
+            '/v1/auth/{mount_point}/role/{role_name}',
+            mount_point=mount_point,
+            role_name=role_name
+        )
+        return self._adapter.delete(url=api_path)
+
+    def read_role_id(self, role_name, mount_point=DEFAULT_MOUNT_POINT):
+        """
+        Reads the Role ID of a role in the auth method.
+
+        Supported methods:
+            GET: /auth/{mount_point}/role/{role_name}/role-id. Produces: 200 application/json
+
+        :param role_name: The name for the role.
+        :type role_name: str | unicode
+        :param mount_point: The "path" the method/backend was mounted on.
+        :type mount_point: str | unicode
+        :return: The JSON response of the read_role_id request.
+        :rtype: dict
+        """
+        api_path = utils.format_url(
+            '/v1/auth/{mount_point}/role/{role_name}/role-id',
+            mount_point=mount_point,
+            role_name=role_name
+        )
+        return self._adapter.get(url=api_path)
+
+    def update_role_id(self, role_name, role_id, mount_point=DEFAULT_MOUNT_POINT):
+        """
+        Updates the Role ID of a role in the auth method.
+
+        Supported methods:
+            POST: /auth/{mount_point}/role/{role_name}/role-id. Produces: 200 application/json
+
+        :param role_name: The name for the role.
+        :type role_name: str | unicode
+        :param role_id: New value for the Role ID.
+        :type role_id: str | unicode
+        :param mount_point: The "path" the method/backend was mounted on.
+        :type mount_point: str | unicode
+        :return: The JSON response of the read_role_id request.
+        :rtype: dict
+        """
+        params = {
+            'role_id': role_id
+        }
+
+        api_path = utils.format_url(
+            '/v1/auth/{mount_point}/role/{role_name}/role-id',
+            mount_point=mount_point,
+            role_name=role_name
+        )
+        return self._adapter.post(url=api_path, json=params)
+
+    def generate_secret_id(self, role_name, metadata=None, cidr_list=None, token_bound_cidrs=None, mount_point=DEFAULT_MOUNT_POINT):
+        """
+        Generates and issues a new Secret ID on a role in the auth method.
+
+        Supported methods:
+            POST: /auth/{mount_point}/role/{role_name}/secret-id. Produces: 200 application/json
+
+        :param role_name: The name for the role.
+        :type role_name: str | unicode
+        :param metadata: Metadata to be tied to the Secret ID.
+        :type metadata: dict
+        :param cidr_list: Blocks of IP addresses which can perform login operations.
+        :type cidr_list: list
+        :param token_bound_cidrs: Blocks of IP addresses which can authenticate successfully.
+        :type token_bound_cidrs: list
+        :param mount_point: The "path" the method/backend was mounted on.
+        :type mount_point: str | unicode
+        :return: The JSON response of the read_role_id request.
+        :rtype: dict
+        """
+        if metadata is not None and not isinstance(metadata, dict):
+            error_msg = 'unsupported metadata argument provided "{arg}" ({arg_type}), required type: dict"'
+            raise exceptions.ParamValidationError(error_msg.format(
+                arg=metadata,
+                arg_type=type(metadata),
+            ))
+
+        params = {
+            'metadata': metadata
+        }
+
+        list_of_strings_params = {
+            'cidr_list': cidr_list,
+            'token_bound_cidrs': token_bound_cidrs
+        }
+        for param_name, param_argument in list_of_strings_params.items():
+            validate_list_of_strings_param(
+                param_name=param_name,
+                param_argument=param_argument,
+            )
+            if param_argument is not None:
+                params[param_name] = list_to_comma_delimited(param_argument)
+
+        api_path = utils.format_url(
+            '/v1/auth/{mount_point}/role/{role_name}/secret-id',
+            mount_point=mount_point,
+            role_name=role_name
+        )
+        return self._adapter.post(url=api_path, json=params)
+
+    def create_custom_secret_id(self, role_name, secret_id, metadata=None, cidr_list=None, token_bound_cidrs=None,
+                                mount_point=DEFAULT_MOUNT_POINT):
+        """
+        Generates and issues a new Secret ID on a role in the auth method.
+
+        Supported methods:
+            POST: /auth/{mount_point}/role/{role_name}/custom-secret-id. Produces: 200 application/json
+
+        :param role_name: The name for the role.
+        :type role_name: str | unicode
+        :param secret_id: The Secret ID to read.
+        :type secret_id: str | unicode
+        :param metadata: Metadata to be tied to the Secret ID.
+        :type metadata: dict
+        :param cidr_list: Blocks of IP addresses which can perform login operations.
+        :type cidr_list: list
+        :param token_bound_cidrs: Blocks of IP addresses which can authenticate successfully.
+        :type token_bound_cidrs: list
+        :param mount_point: The "path" the method/backend was mounted on.
+        :type mount_point: str | unicode
+        :return: The JSON response of the read_role_id request.
+        :rtype: dict
+        """
+        if metadata is not None and not isinstance(metadata, dict):
+            error_msg = 'unsupported metadata argument provided "{arg}" ({arg_type}), required type: dict"'
+            raise exceptions.ParamValidationError(error_msg.format(
+                arg=metadata,
+                arg_type=type(metadata),
+            ))
+
+        params = {
+            'secret_id': secret_id,
+            'metadata': metadata
+        }
+
+        list_of_strings_params = {
+            'cidr_list': cidr_list,
+            'token_bound_cidrs': token_bound_cidrs
+        }
+        for param_name, param_argument in list_of_strings_params.items():
+            validate_list_of_strings_param(
+                param_name=param_name,
+                param_argument=param_argument,
+            )
+            if param_argument is not None:
+                params[param_name] = list_to_comma_delimited(param_argument)
+
+        api_path = utils.format_url(
+            '/v1/auth/{mount_point}/role/{role_name}/custom-secret-id',
+            mount_point=mount_point,
+            role_name=role_name
+        )
+        return self._adapter.post(url=api_path, json=params)
+
+    def read_secret_id(self, role_name, secret_id, mount_point=DEFAULT_MOUNT_POINT):
+        """
+        Read the properties of a Secret ID for a role in the auth method.
+
+        Supported methods:
+            POST: /auth/{mount_point}/role/{role_name}/secret-id/lookup. Produces: 200 application/json
+
+        :param role_name: The name for the role
+        :type role_name: str | unicode
+        :param secret_id: The Secret ID to read.
+        :type secret_id: str | unicode
+        :param mount_point: The "path" the method/backend was mounted on.
+        :type mount_point: str | unicode
+        :return: The JSON response of the read_role_id request.
+        :rtype: dict
+        """
+        params = {
+            'secret_id': secret_id
+        }
+        api_path = utils.format_url(
+            '/v1/auth/{mount_point}/role/{role_name}/secret-id/lookup',
+            mount_point=mount_point,
+            role_name=role_name
+        )
+        return self._adapter.post(url=api_path, json=params)
+
+    def destroy_secret_id(self, role_name, secret_id, mount_point=DEFAULT_MOUNT_POINT):
+        """
+        Destroys a Secret ID for a role in the auth method.
+
+        Supported methods:
+            POST: /auth/{mount_point}/role/{role_name}/secret-id/destroy. Produces 204 (empty body)
+
+        :param role_name: The name for the role
+        :type role_name: str | unicode
+        :param secret_id: The Secret ID to read.
+        :type secret_id: str | unicode
+        :param mount_point: The "path" the method/backend was mounted on.
+        :type mount_point: str | unicode
+        """
+        params = {
+            'secret_id': secret_id
+        }
+        api_path = utils.format_url(
+            '/v1/auth/{mount_point}/role/{role_name}/secret-id/destroy',
+            mount_point=mount_point,
+            role_name=role_name
+        )
+        return self._adapter.post(url=api_path, json=params)
+
+    def list_secret_id_accessors(self, role_name, mount_point=DEFAULT_MOUNT_POINT):
+        """
+        Lists accessors of all issued Secret IDs for a role in the auth method.
+
+        Supported methods:
+            LIST: /auth/{mount_point}/role/{role_name}/secret-id. Produces: 200 application/json
+
+        :param role_name: The name for the role
+        :type role_name: str | unicode
+        :param mount_point: The "path" the method/backend was mounted on.
+        :type mount_point: str | unicode
+        :return: The JSON response of the read_role_id request.
+        :rtype: dict
+        """
+        api_path = utils.format_url(
+            '/v1/auth/{mount_point}/role/{role_name}/secret-id',
+            mount_point=mount_point,
+            role_name=role_name
+        )
+        return self._adapter.list(url=api_path)
+
+    def read_secret_id_accessor(self, role_name, secret_id_accessor, mount_point=DEFAULT_MOUNT_POINT):
+        """
+        Read the properties of a Secret ID for a role in the auth method.
+
+        Supported methods:
+            POST: /auth/{mount_point}/role/{role_name}/secret-id-accessor/lookup. Produces: 200 application/json
+
+        :param role_name: The name for the role
+        :type role_name: str | unicode
+        :param secret_id_accessor: The accessor for the Secret ID to read.
+        :type secret_id_accessor: str | unicode
+        :param mount_point: The "path" the method/backend was mounted on.
+        :type mount_point: str | unicode
+        :return: The JSON response of the read_role_id request.
+        :rtype: dict
+        """
+        params = {
+            'secret_id_accessor': secret_id_accessor
+        }
+        api_path = utils.format_url(
+            '/v1/auth/{mount_point}/role/{role_name}/secret-id-accessor/lookup',
+            mount_point=mount_point,
+            role_name=role_name
+        )
+        return self._adapter.post(url=api_path, json=params)
+
+    def destroy_secret_id_accessor(self, role_name, secret_id_accessor, mount_point=DEFAULT_MOUNT_POINT):
+        """
+        Destroys a Secret ID for a role in the auth method.
+
+        Supported methods:
+            POST: /auth/{mount_point}/role/{role_name}/secret-id-accessor/destroy. Produces: 204 (empty body)
+
+        :param role_name: The name for the role
+        :type role_name: str | unicode
+        :param secret_id_accessor: The accessor for the Secret ID to read.
+        :type secret_id_accessor: str | unicode
+        :param mount_point: The "path" the method/backend was mounted on.
+        :type mount_point: str | unicode
+        """
+        params = {
+            'secret_id_accessor': secret_id_accessor
+        }
+        api_path = utils.format_url(
+            '/v1/auth/{mount_point}/role/{role_name}/secret-id-accessor/destroy',
+            mount_point=mount_point,
+            role_name=role_name
+        )
+        return self._adapter.post(url=api_path, json=params)
+
+    def login(self, role_id, secret_id=None, mount_point=DEFAULT_MOUNT_POINT):
+        """
+        Login with APPROLE credentials.
+
+        Supported methods:
+            POST: /auth/{mount_point}/login. Produces: 200 application/json
+
+        :param role_id: Role ID of the role.
+        :type role_id: str | unicode
+        :param secret_id: Secret ID of the role.
+        :type secret_id: str | unicode
+        :param mount_point: The "path" the method/backend was mounted on.
+        :type mount_point: str | unicode
+        :return: The JSON response of the read_role_id request.
+        :rtype: dict
+        """
+        params = {
+            'role_id': role_id,
+            'secret_id': secret_id
+        }
+        api_path = utils.format_url(
+            '/v1/auth/{mount_point}/login',
+            mount_point=mount_point
+        )
+        return self._adapter.post(url=api_path, json=params)

--- a/hvac/api/auth_methods/approle.py
+++ b/hvac/api/auth_methods/approle.py
@@ -442,7 +442,7 @@ class AppRole(VaultApiBase):
         )
         return self._adapter.post(url=api_path, json=params)
 
-    def login(self, role_id, secret_id=None, mount_point=DEFAULT_MOUNT_POINT):
+    def login(self, role_id, secret_id=None, use_token=True, mount_point=DEFAULT_MOUNT_POINT):
         """
         Login with APPROLE credentials.
 
@@ -453,6 +453,9 @@ class AppRole(VaultApiBase):
         :type role_id: str | unicode
         :param secret_id: Secret ID of the role.
         :type secret_id: str | unicode
+        :param use_token: if True, uses the token in the response received from the auth request to set the "token"
+            attribute on the the :py:meth:`hvac.adapters.Adapter` instance under the _adapater Client attribute.
+        :type use_token: bool
         :param mount_point: The "path" the method/backend was mounted on.
         :type mount_point: str | unicode
         :return: The JSON response of the read_role_id request.
@@ -466,4 +469,8 @@ class AppRole(VaultApiBase):
             '/v1/auth/{mount_point}/login',
             mount_point=mount_point
         )
-        return self._adapter.post(url=api_path, json=params)
+        return self._adapter.login(
+            url=api_path,
+            use_token=use_token,
+            json=params,
+        )

--- a/hvac/constants/approle.py
+++ b/hvac/constants/approle.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Constants related to the APPROLE auth method."""
+
+DEFAULT_MOUNT_POINT = 'approle'
+ALLOWED_TOKEN_TYPES = ['service', 'batch', 'default', 'default-service', 'default-batch']

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -1279,6 +1279,10 @@ class Client(object):
             **kwargs
         )
 
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.12.0',
+        new_method=api.auth_methods.AppRole.create_or_update_approle,
+    )
     def create_role(self, role_name, mount_point='approle', **kwargs):
         """POST /auth/<mount_point>/role/<role name>
 
@@ -1294,6 +1298,10 @@ class Client(object):
 
         return self._adapter.post('/v1/auth/{0}/role/{1}'.format(mount_point, role_name), json=kwargs)
 
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.12.0',
+        new_method=api.auth_methods.AppRole.delete_role,
+    )
     def delete_role(self, role_name, mount_point='approle'):
         """DELETE /auth/<mount_point>/role/<role name>
 
@@ -1307,6 +1315,10 @@ class Client(object):
 
         return self._adapter.delete('/v1/auth/{0}/role/{1}'.format(mount_point, role_name))
 
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.12.0',
+        new_method=api.auth_methods.AppRole.list_roles,
+    )
     def list_roles(self, mount_point='approle'):
         """GET /auth/<mount_point>/role
 
@@ -1318,6 +1330,10 @@ class Client(object):
 
         return self._adapter.get('/v1/auth/{0}/role?list=true'.format(mount_point))
 
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.12.0',
+        new_method=api.auth_methods.AppRole.read_role_id,
+    )
     def get_role_id(self, role_name, mount_point='approle'):
         """GET /auth/<mount_point>/role/<role name>/role-id
 
@@ -1332,6 +1348,10 @@ class Client(object):
         url = '/v1/auth/{0}/role/{1}/role-id'.format(mount_point, role_name)
         return self._adapter.get(url)['data']['role_id']
 
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.12.0',
+        new_method=api.auth_methods.AppRole.update_role_id,
+    )
     def set_role_id(self, role_name, role_id, mount_point='approle'):
         """POST /auth/<mount_point>/role/<role name>/role-id
 
@@ -1351,6 +1371,10 @@ class Client(object):
         }
         return self._adapter.post(url, json=params)
 
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.12.0',
+        new_method=api.auth_methods.AppRole.read_role,
+    )
     def get_role(self, role_name, mount_point='approle'):
         """GET /auth/<mount_point>/role/<role name>
 
@@ -1363,6 +1387,10 @@ class Client(object):
         """
         return self._adapter.get('/v1/auth/{0}/role/{1}'.format(mount_point, role_name))
 
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.12.0',
+        new_method=api.auth_methods.AppRole.generate_secret_id,
+    )
     def create_role_secret_id(self, role_name, meta=None, cidr_list=None, token_bound_cidrs=None, wrap_ttl=None, mount_point='approle'):
         """POST /auth/<mount_point>/role/<role name>/secret-id
 
@@ -1392,6 +1420,10 @@ class Client(object):
             params['token_bound_cidrs'] = token_bound_cidrs
         return self._adapter.post(url, json=params, wrap_ttl=wrap_ttl)
 
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.12.0',
+        new_method=api.auth_methods.AppRole.read_secret_id,
+    )
     def get_role_secret_id(self, role_name, secret_id, mount_point='approle'):
         """POST /auth/<mount_point>/role/<role name>/secret-id/lookup
 
@@ -1410,6 +1442,10 @@ class Client(object):
         }
         return self._adapter.post(url, json=params)
 
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.12.0',
+        new_method=api.auth_methods.AppRole.list_secret_id_accessors,
+    )
     def list_role_secrets(self, role_name, mount_point='approle'):
         """LIST /auth/<mount_point>/role/<role name>/secret-id
 
@@ -1426,6 +1462,10 @@ class Client(object):
         )
         return self._adapter.list(url)
 
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.12.0',
+        new_method=api.auth_methods.AppRole.read_secret_id_accessor,
+    )
     def get_role_secret_id_accessor(self, role_name, secret_id_accessor, mount_point='approle'):
         """POST /auth/<mount_point>/role/<role name>/secret-id-accessor/lookup
 
@@ -1442,6 +1482,10 @@ class Client(object):
         params = {'secret_id_accessor': secret_id_accessor}
         return self._adapter.post(url, json=params)
 
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.12.0',
+        new_method=api.auth_methods.AppRole.destroy_secret_id,
+    )
     def delete_role_secret_id(self, role_name, secret_id, mount_point='approle'):
         """POST /auth/<mount_point>/role/<role name>/secret-id/destroy
 
@@ -1460,6 +1504,10 @@ class Client(object):
         }
         return self._adapter.post(url, json=params)
 
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.12.0',
+        new_method=api.auth_methods.AppRole.destroy_secret_id_accessor,
+    )
     def delete_role_secret_id_accessor(self, role_name, secret_id_accessor, mount_point='approle'):
         """POST /auth/<mount_point>/role/<role name>/secret-id-accessor/destroy
 
@@ -1478,6 +1526,10 @@ class Client(object):
         }
         return self._adapter.post(url, json=params)
 
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.12.0',
+        new_method=api.auth_methods.AppRole.create_custom_secret_id,
+    )
     def create_role_custom_secret_id(self, role_name, secret_id, meta=None, mount_point='approle'):
         """POST /auth/<mount_point>/role/<role name>/custom-secret-id
 
@@ -1500,6 +1552,10 @@ class Client(object):
             params['meta'] = meta
         return self._adapter.post(url, json=params)
 
+    @utils.deprecated_method(
+        to_be_removed_in_version='0.12.0',
+        new_method=api.auth_methods.AppRole.login,
+    )
     def auth_approle(self, role_id, secret_id=None, mount_point='approle', use_token=True):
         """POST /auth/<mount_point>/login
 

--- a/tests/integration_tests/api/auth_methods/test_approle.py
+++ b/tests/integration_tests/api/auth_methods/test_approle.py
@@ -1,0 +1,274 @@
+from unittest import TestCase
+from unittest import skipIf
+
+from parameterized import parameterized
+
+from hvac import exceptions
+from tests import utils
+from tests.utils.hvac_integration_test_case import HvacIntegrationTestCase
+
+
+@skipIf(utils.vault_version_lt('0.6.2'), "AppRole endpoints standardized in version 0.6.2")
+class TestAppRole(HvacIntegrationTestCase, TestCase):
+    TEST_MOUNT_POINT = 'approle-test'
+    TEST_ROLE_NAME = 'testrole'
+    TEST_ROLE_ID = 'test_role_id'
+    TEST_SECRET_ID = 'custom_secret'
+
+    def setUp(self):
+        super(TestAppRole, self).setUp()
+        if '%s/' % self.TEST_MOUNT_POINT not in self.client.list_auth_backends():
+            self.client.enable_auth_backend(
+                backend_type='approle',
+                mount_point=self.TEST_MOUNT_POINT,
+            )
+        _ = self.client.auth.approle.create_or_update_approle(
+            role_name=self.TEST_ROLE_NAME,
+            token_policies=['default'],
+            mount_point=self.TEST_MOUNT_POINT
+        )
+        _ = self.client.auth.approle.update_role_id(
+            role_name=self.TEST_ROLE_NAME,
+            role_id=self.TEST_ROLE_ID,
+            mount_point=self.TEST_MOUNT_POINT
+        )
+
+    def tearDown(self):
+        super(TestAppRole, self).tearDown()
+        self.client.disable_auth_backend(
+            mount_point=self.TEST_MOUNT_POINT
+        )
+
+    def _secret_id(self):
+        secret_id_response = self.client.auth.approle.generate_secret_id(
+            role_name=self.TEST_ROLE_NAME,
+            cidr_list=['127.0.0.1/32'],
+            mount_point=self.TEST_MOUNT_POINT
+        )
+        return secret_id_response['data']
+
+    @parameterized.expand([
+        ("create test role", 'default', None),
+        ("bad token type", 'bad_token', exceptions.ParamValidationError)
+    ])
+    def test_create_or_update_approle(self, test_label, token_type, raises):
+        if raises is not None:
+            with self.assertRaises(raises) as cm:
+                self.client.auth.approle.create_or_update_approle(
+                    role_name='testrole2',
+                    token_policies=['default'],
+                    token_type=token_type,
+                    mount_point=self.TEST_MOUNT_POINT
+                )
+            self.assertIn(
+                member='unsupported token_type',
+                container=str(cm.exception)
+            )
+        else:
+            response = self.client.auth.approle.create_or_update_approle(
+                role_name='testrole2',
+                token_policies=['default'],
+                mount_point=self.TEST_MOUNT_POINT
+            )
+
+            self.assertEqual(
+                first=bool(response),
+                second=True
+            )
+
+    def test_list_roles(self):
+        response = self.client.auth.approle.list_roles(
+            mount_point=self.TEST_MOUNT_POINT
+        )
+
+        self.assertEqual(
+            first=len(response['data']['keys']),
+            second=1
+        )
+
+    def test_read_role(self):
+        response = self.client.auth.approle.read_role(
+            role_name=self.TEST_ROLE_NAME,
+            mount_point=self.TEST_MOUNT_POINT
+        )
+
+        self.assertEqual(
+            first=response['data']['token_type'],
+            second="default"
+        )
+
+    def test_delete_role(self):
+        response = self.client.auth.approle.delete_role(
+            role_name=self.TEST_ROLE_NAME,
+            mount_point=self.TEST_MOUNT_POINT
+        )
+
+        self.assertEqual(
+            first=204,
+            second=response.status_code
+        )
+
+    def test_read_role_id(self):
+        response = self.client.auth.approle.read_role_id(
+            role_name=self.TEST_ROLE_NAME,
+            mount_point=self.TEST_MOUNT_POINT
+        )
+
+        self.assertEqual(
+            first=self.TEST_ROLE_ID,
+            second=response['data']['role_id']
+        )
+
+    @parameterized.expand([
+        ("good request", None),
+        ("bad metadata option", exceptions.ParamValidationError)
+    ])
+    def test_generate_secret_id(self, test_label, raises):
+        if raises is not None:
+            with self.assertRaises(raises) as cm:
+                self.client.auth.approle.generate_secret_id(
+                    role_name=self.TEST_ROLE_NAME,
+                    metadata="metadata string",
+                    mount_point=self.TEST_MOUNT_POINT
+                )
+            self.assertIn(
+                member='unsupported metadata argument',
+                container=str(cm.exception)
+            )
+        else:
+            response = self.client.auth.approle.generate_secret_id(
+                role_name=self.TEST_ROLE_NAME,
+                cidr_list=['127.0.0.1/32'],
+                mount_point=self.TEST_MOUNT_POINT
+            )
+            self.assertIn(
+                member='secret_id',
+                container=response['data']
+            )
+
+    @parameterized.expand([
+        ("good request", None),
+        ("bad metadata option", exceptions.ParamValidationError)
+    ])
+    def test_create_custom_secret_id(self, test_label, raises):
+        if raises is not None:
+            with self.assertRaises(raises) as cm:
+                self.client.auth.approle.create_custom_secret_id(
+                    role_name=self.TEST_ROLE_NAME,
+                    secret_id=self.TEST_SECRET_ID,
+                    cidr_list=['127.0.0.1/32'],
+                    metadata="metadata string",
+                    mount_point=self.TEST_MOUNT_POINT
+                )
+            self.assertIn(
+                member='unsupported metadata argument',
+                container=str(cm.exception)
+            )
+        else:
+            response = self.client.auth.approle.create_custom_secret_id(
+                role_name=self.TEST_ROLE_NAME,
+                secret_id=self.TEST_SECRET_ID,
+                cidr_list=['127.0.0.1/32'],
+                mount_point=self.TEST_MOUNT_POINT
+            )
+
+            self.assertEqual(
+                first=self.TEST_SECRET_ID,
+                second=response['data']['secret_id']
+            )
+
+    def test_read_secret_id(self):
+        secret_id_response = self._secret_id()
+
+        response = self.client.auth.approle.read_secret_id(
+            role_name=self.TEST_ROLE_NAME,
+            secret_id=secret_id_response['secret_id'],
+            mount_point=self.TEST_MOUNT_POINT
+        )
+
+        self.assertEqual(
+            first=0,
+            second=response['data']['secret_id_num_uses']
+        )
+
+    def test_destroy_secret_id(self):
+        secret_id_response = self._secret_id()
+
+        response = self.client.auth.approle.destroy_secret_id(
+            role_name=self.TEST_ROLE_NAME,
+            secret_id=secret_id_response['secret_id'],
+            mount_point=self.TEST_MOUNT_POINT
+        )
+
+        self.assertEqual(
+            first=204,
+            second=response.status_code
+        )
+
+    def test_list_secret_id_accessors(self):
+        self._secret_id()
+
+        response = self.client.auth.approle.list_secret_id_accessors(
+            role_name=self.TEST_ROLE_NAME,
+            mount_point=self.TEST_MOUNT_POINT
+        )
+
+        self.assertEqual(
+            first=1,
+            second=len(response['data']['keys'])
+        )
+
+    def test_read_secret_id_accessor(self):
+        secret_id_response = self._secret_id()
+
+        response = self.client.auth.approle.read_secret_id_accessor(
+            role_name=self.TEST_ROLE_NAME,
+            secret_id_accessor=secret_id_response['secret_id_accessor'],
+            mount_point=self.TEST_MOUNT_POINT
+        )
+
+        self.assertEqual(
+            first=secret_id_response['secret_id_accessor'],
+            second=response['data']['secret_id_accessor']
+        )
+        self.assertEqual(
+            first="127.0.0.1/32",
+            second=response['data']['cidr_list'][0]
+        )
+
+    def test_destroy_secret_id_accessor(self):
+        secret_id_response = self._secret_id()
+
+        response = self.client.auth.approle.read_secret_id_accessor(
+            role_name=self.TEST_ROLE_NAME,
+            secret_id_accessor=secret_id_response['secret_id_accessor'],
+            mount_point=self.TEST_MOUNT_POINT
+        )
+        self.assertEqual(
+            first=secret_id_response['secret_id_accessor'],
+            second=response['data']['secret_id_accessor']
+        )
+
+        response = self.client.auth.approle.destroy_secret_id_accessor(
+            role_name=self.TEST_ROLE_NAME,
+            secret_id_accessor=secret_id_response['secret_id_accessor'],
+            mount_point=self.TEST_MOUNT_POINT
+        )
+        self.assertEqual(
+            first=204,
+            second=response.status_code
+        )
+
+    def test_login(self):
+        secret_id_response = self._secret_id()
+
+        response = self.client.auth.approle.login(
+            role_id=self.TEST_ROLE_ID,
+            secret_id=secret_id_response['secret_id'],
+            mount_point=self.TEST_MOUNT_POINT
+        )
+
+        self.assertIn(
+            member='client_token',
+            container=response['auth']
+        )

--- a/tests/unit_tests/api/auth_methods/test_approle.py
+++ b/tests/unit_tests/api/auth_methods/test_approle.py
@@ -609,8 +609,8 @@ class TestAppRole(TestCase):
         secret_id = 'custom_secret'
 
         mock_response = {
-            'auth': None,
-            'data': {
+            'data': None,
+            'auth': {
                 'renewable': True,
                 'lease_duration': 1200,
                 'metadata': None,

--- a/tests/unit_tests/api/auth_methods/test_approle.py
+++ b/tests/unit_tests/api/auth_methods/test_approle.py
@@ -1,0 +1,648 @@
+from unittest import TestCase
+
+import requests_mock
+from parameterized import parameterized
+
+from hvac import exceptions
+from hvac.adapters import JSONAdapter
+from hvac.api.auth_methods import AppRole
+from hvac.constants.approle import DEFAULT_MOUNT_POINT
+
+
+class TestAppRole(TestCase):
+
+    @parameterized.expand([
+        ("default mount point", DEFAULT_MOUNT_POINT, 'default', None),
+        ("custom mount point", 'approle-test', 'default', None),
+        ("bad token type", DEFAULT_MOUNT_POINT, 'bad_token', exceptions.ParamValidationError)
+    ])
+    @requests_mock.Mocker()
+    def test_create_or_update_approle(self, test_label, mount_point, token_type, raises, requests_mocker):
+        expected_status_code = 204
+        role_name = 'testrole'
+
+        mock_url = 'http://localhost:8200/v1/auth/{mount_point}/role/{role_name}'.format(
+            mount_point=mount_point,
+            role_name=role_name
+        )
+        requests_mocker.register_uri(
+            method='POST',
+            url=mock_url,
+            status_code=expected_status_code,
+        )
+
+        app_role = AppRole(adapter=JSONAdapter())
+
+        if raises is not None:
+            with self.assertRaises(raises) as cm:
+                app_role.create_or_update_approle(
+                    role_name=role_name,
+                    token_policies=['default'],
+                    token_type=token_type,
+                    mount_point=mount_point
+                )
+            self.assertIn(
+                member='unsupported token_type',
+                container=str(cm.exception)
+            )
+        else:
+            response = app_role.create_or_update_approle(
+                role_name=role_name,
+                token_policies=['default'],
+                mount_point=mount_point
+            )
+
+            self.assertEqual(
+                first=expected_status_code,
+                second=response.status_code
+            )
+
+    @parameterized.expand([
+        ("default mount point", DEFAULT_MOUNT_POINT),
+        ("custom mount point", 'approle-test')
+    ])
+    @requests_mock.Mocker()
+    def test_list_roles(self, test_label, mount_point, requests_mocker):
+        expected_status_code = 200
+        mock_response = {
+            'auth': None,
+            'data': {
+                'keys': [
+                    'testrole'
+                ]
+            },
+            'lease_duration': 0,
+            'lease_id': '',
+            'renewable': False,
+            'request_id': '860a11a8-b835-cbab-7fce-de4edc4cf533',
+            'warnings': None,
+            'wrap_info': None
+        }
+        mock_url = 'http://localhost:8200/v1/auth/{mount_point}/role'.format(
+            mount_point=mount_point
+        )
+        requests_mocker.register_uri(
+            method='LIST',
+            url=mock_url,
+            status_code=expected_status_code,
+            json=mock_response,
+        )
+
+        app_role = AppRole(adapter=JSONAdapter())
+        response = app_role.list_roles(
+            mount_point=mount_point
+        )
+
+        self.assertEqual(
+            first=mock_response,
+            second=response
+        )
+
+    @parameterized.expand([
+        ("default mount point", DEFAULT_MOUNT_POINT),
+        ("custom mount point", 'approle-test')
+    ])
+    @requests_mock.Mocker()
+    def test_read_role(self, test_label, mount_point, requests_mocker):
+        expected_status_code = 200
+        role_name = 'testrole'
+
+        mock_response = {
+            'auth': None,
+            'data': {
+                'bind_secret_id': True,
+                'local_secret_ids': False,
+                'secret_id_bound_cidrs': None,
+                'secret_id_num_uses': 0,
+                'secret_id_ttl': 0,
+                'token_bound_cidrs': None,
+                'token_explicit_max_ttl': 0,
+                'token_max_ttl': 0,
+                'token_no_default_poolicy': False,
+                'token_num_uses': 0,
+                'token_period': 14400,
+                'token_policies': None,
+                'token_ttl': 0,
+                'token_type': "default"
+            },
+            'lease_duration': 0,
+            'lease_id': '',
+            'renewable': False,
+            'request_id': '860a11a8-b835-cbab-7fce-de4edc4cf533',
+            'warnings': None,
+            'wrap_info': None
+        }
+        mock_url = 'http://localhost:8200/v1/auth/{mount_point}/role/{role_name}'.format(
+            mount_point=mount_point,
+            role_name=role_name
+        )
+        requests_mocker.register_uri(
+            method='GET',
+            url=mock_url,
+            status_code=expected_status_code,
+            json=mock_response,
+        )
+
+        app_role = AppRole(adapter=JSONAdapter())
+        response = app_role.read_role(
+            role_name="testrole",
+            mount_point=mount_point
+        )
+
+        self.assertEqual(
+            first=mock_response,
+            second=response
+        )
+
+    @parameterized.expand([
+        ("default mount point", DEFAULT_MOUNT_POINT),
+        ("custom mount point", 'approle-test')
+    ])
+    @requests_mock.Mocker()
+    def test_delete_role(self, test_label, mount_point, requests_mocker):
+        expected_status_code = 204
+        role_name = 'testrole'
+
+        mock_url = 'http://localhost:8200/v1/auth/{mount_point}/role/{role_name}'.format(
+            mount_point=mount_point,
+            role_name=role_name
+        )
+        requests_mocker.register_uri(
+            method='DELETE',
+            url=mock_url,
+            status_code=expected_status_code,
+        )
+
+        app_role = AppRole(adapter=JSONAdapter())
+        response = app_role.delete_role(
+            role_name=role_name,
+            mount_point=mount_point
+        )
+
+        self.assertEqual(
+            first=expected_status_code,
+            second=response.status_code
+        )
+
+    @parameterized.expand([
+        ("default mount point", DEFAULT_MOUNT_POINT),
+        ("custom mount point", 'approle-test')
+    ])
+    @requests_mock.Mocker()
+    def test_read_role_id(self, test_label, mount_point, requests_mocker):
+        expected_status_code = 200
+        role_name = 'testrole'
+
+        mock_response = {
+            'auth': None,
+            'data': {
+                'role_id': 'e5a7b66e-5d08-da9c-7075-71984634b882'
+            },
+            'lease_duration': 0,
+            'lease_id': '',
+            'renewable': False,
+            'request_id': '860a11a8-b835-cbab-7fce-de4edc4cf533',
+            'warnings': None,
+            'wrap_info': None
+        }
+        mock_url = 'http://localhost:8200/v1/auth/{mount_point}/role/{role_name}/role-id'.format(
+            mount_point=mount_point,
+            role_name=role_name
+        )
+        requests_mocker.register_uri(
+            method='GET',
+            url=mock_url,
+            status_code=expected_status_code,
+            json=mock_response,
+        )
+
+        app_role = AppRole(adapter=JSONAdapter())
+        response = app_role.read_role_id(
+            role_name=role_name,
+            mount_point=mount_point
+        )
+
+        self.assertEqual(
+            first=mock_response,
+            second=response
+        )
+
+    @parameterized.expand([
+        ("default mount point", DEFAULT_MOUNT_POINT),
+        ("custom mount point", 'approle-test')
+    ])
+    @requests_mock.Mocker()
+    def test_update_role_id(self, test_label, mount_point, requests_mocker):
+        expected_status_code = 200
+        role_name = 'testrole'
+        role_id = 'test_role_id'
+
+        mock_response = {
+            'auth': None,
+            'data': {
+                'role_id': role_id
+            },
+            'lease_duration': 0,
+            'lease_id': '',
+            'renewable': False,
+            'request_id': '860a11a8-b835-cbab-7fce-de4edc4cf533',
+            'warnings': None,
+            'wrap_info': None
+        }
+        mock_url = 'http://localhost:8200/v1/auth/{mount_point}/role/{role_name}/role-id'.format(
+            mount_point=mount_point,
+            role_name=role_name
+        )
+        requests_mocker.register_uri(
+            method='POST',
+            url=mock_url,
+            status_code=expected_status_code,
+            json=mock_response,
+        )
+
+        app_role = AppRole(adapter=JSONAdapter())
+        response = app_role.update_role_id(
+            role_name=role_name,
+            role_id=role_id,
+            mount_point=mount_point
+        )
+
+        self.assertEqual(
+            first=mock_response,
+            second=response
+        )
+
+    @parameterized.expand([
+        ("default mount point", DEFAULT_MOUNT_POINT, None),
+        ("custom mount point", 'approle-test', exceptions.ParamValidationError)
+    ])
+    @requests_mock.Mocker()
+    def test_generate_secret_id(self, test_label, mount_point, raises, requests_mocker):
+        expected_status_code = 200
+        role_name = 'testrole'
+
+        mock_response = {
+            'auth': None,
+            'data': {
+                'secret_id': '841771dc-11c9-bbc7-bcac-6a3945a69cd9',
+                'secret_id_accessor': '84896a0c-1347-aa90-a4f6-aca8b7558780'
+            },
+            'lease_duration': 0,
+            'lease_id': '',
+            'renewable': False,
+            'request_id': '860a11a8-b835-cbab-7fce-de4edc4cf533',
+            'warnings': None,
+            'wrap_info': None
+        }
+        mock_url = 'http://localhost:8200/v1/auth/{mount_point}/role/{role_name}/secret-id'.format(
+            mount_point=mount_point,
+            role_name=role_name
+        )
+        requests_mocker.register_uri(
+            method='POST',
+            url=mock_url,
+            status_code=expected_status_code,
+            json=mock_response,
+        )
+
+        app_role = AppRole(adapter=JSONAdapter())
+
+        if raises is not None:
+            with self.assertRaises(raises) as cm:
+                app_role.generate_secret_id(
+                    role_name=role_name,
+                    metadata="metadata string",
+                    mount_point=mount_point
+                )
+            self.assertIn(
+                member='unsupported metadata argument',
+                container=str(cm.exception)
+            )
+        else:
+            response = app_role.generate_secret_id(
+                role_name=role_name,
+                cidr_list=['127.0.0.1/32'],
+                mount_point=mount_point
+            )
+
+            self.assertEqual(
+                first=mock_response,
+                second=response
+            )
+
+    @parameterized.expand([
+        ("default mount point", DEFAULT_MOUNT_POINT, None),
+        ("custom mount point", 'approle-test', exceptions.ParamValidationError)
+    ])
+    @requests_mock.Mocker()
+    def test_create_custom_secret_id(self, test_label, mount_point, raises, requests_mocker):
+        expected_status_code = 200
+        role_name = 'testrole'
+        secret_id = 'custom_secret'
+
+        mock_response = {
+            'auth': None,
+            'data': {
+                'secret_id': secret_id,
+                'secret_id_accessor': '84896a0c-1347-aa90-a4f6-aca8b7558780'
+            },
+            'lease_duration': 0,
+            'lease_id': '',
+            'renewable': False,
+            'request_id': '860a11a8-b835-cbab-7fce-de4edc4cf533',
+            'warnings': None,
+            'wrap_info': None
+        }
+        mock_url = 'http://localhost:8200/v1/auth/{mount_point}/role/{role_name}/custom-secret-id'.format(
+            mount_point=mount_point,
+            role_name=role_name
+        )
+        requests_mocker.register_uri(
+            method='POST',
+            url=mock_url,
+            status_code=expected_status_code,
+            json=mock_response,
+        )
+
+        app_role = AppRole(adapter=JSONAdapter())
+
+        if raises is not None:
+            with self.assertRaises(raises) as cm:
+                app_role.create_custom_secret_id(
+                    role_name=role_name,
+                    secret_id=secret_id,
+                    cidr_list=['127.0.0.1/32'],
+                    metadata="metadata string",
+                    mount_point=mount_point
+                )
+            self.assertIn(
+                member='unsupported metadata argument',
+                container=str(cm.exception)
+            )
+        else:
+            response = app_role.create_custom_secret_id(
+                role_name=role_name,
+                secret_id=secret_id,
+                cidr_list=['127.0.0.1/32'],
+                mount_point=mount_point
+            )
+
+            self.assertEqual(
+                first=mock_response,
+                second=response
+            )
+
+    @parameterized.expand([
+        ("default mount point", DEFAULT_MOUNT_POINT),
+        ("custom mount point", 'approle-test')
+    ])
+    @requests_mock.Mocker()
+    def test_read_secret_id(self, test_label, mount_point, requests_mocker):
+        expected_status_code = 200
+        role_name = 'testrole'
+        secret_id = 'custom_secret'
+
+        mock_response = {
+            'auth': None,
+            'data': {
+                'secret_id': secret_id,
+                'secret_id_accessor': '84896a0c-1347-aa90-a4f6-aca8b7558780'
+            },
+            'lease_duration': 0,
+            'lease_id': '',
+            'renewable': False,
+            'request_id': '860a11a8-b835-cbab-7fce-de4edc4cf533',
+            'warnings': None,
+            'wrap_info': None
+        }
+        mock_url = 'http://localhost:8200/v1/auth/{mount_point}/role/{role_name}/secret-id/lookup'.format(
+            mount_point=mount_point,
+            role_name=role_name
+        )
+        requests_mocker.register_uri(
+            method='POST',
+            url=mock_url,
+            status_code=expected_status_code,
+            json=mock_response,
+        )
+
+        app_role = AppRole(adapter=JSONAdapter())
+        response = app_role.read_secret_id(
+            role_name=role_name,
+            secret_id=secret_id,
+            mount_point=mount_point
+        )
+
+        self.assertEqual(
+            first=mock_response,
+            second=response
+        )
+
+    @parameterized.expand([
+        ("default mount point", DEFAULT_MOUNT_POINT),
+        ("custom mount point", 'approle-test')
+    ])
+    @requests_mock.Mocker()
+    def test_destroy_secret_id(self, test_label, mount_point, requests_mocker):
+        expected_status_code = 204
+        role_name = 'testrole'
+        secret_id = 'custom_secret'
+
+        mock_url = 'http://localhost:8200/v1/auth/{mount_point}/role/{role_name}/secret-id/destroy'.format(
+            mount_point=mount_point,
+            role_name=role_name
+        )
+        requests_mocker.register_uri(
+            method='POST',
+            url=mock_url,
+            status_code=expected_status_code,
+        )
+
+        app_role = AppRole(adapter=JSONAdapter())
+        response = app_role.destroy_secret_id(
+            role_name=role_name,
+            secret_id=secret_id,
+            mount_point=mount_point
+        )
+
+        self.assertEqual(
+            first=expected_status_code,
+            second=response.status_code
+        )
+
+    @parameterized.expand([
+        ("default mount point", DEFAULT_MOUNT_POINT),
+        ("custom mount point", 'approle-test')
+    ])
+    @requests_mock.Mocker()
+    def test_list_secret_id_accessors(self, test_label, mount_point, requests_mocker):
+        expected_status_code = 200
+        role_name = 'testrole'
+
+        mock_response = {
+            'auth': None,
+            'data': {
+                'keys': [
+                    'ce102d2a-8253-c437-bf9a-aceed4241491',
+                    'a1c8dee4-b869-e68d-3520-2040c1a0849a',
+                    'be83b7e2-044c-7244-07e1-47560ca1c787',
+                    '84896a0c-1347-aa90-a4f6-aca8b7558780',
+                    '239b1328-6523-15e7-403a-a48038cdc45a'
+                ]
+            },
+            'lease_duration': 0,
+            'lease_id': '',
+            'renewable': False,
+            'request_id': '860a11a8-b835-cbab-7fce-de4edc4cf533',
+            'warnings': None,
+            'wrap_info': None
+        }
+        mock_url = 'http://localhost:8200/v1/auth/{mount_point}/role/{role_name}/secret-id'.format(
+            mount_point=mount_point,
+            role_name=role_name
+        )
+        requests_mocker.register_uri(
+            method='LIST',
+            url=mock_url,
+            status_code=expected_status_code,
+            json=mock_response,
+        )
+
+        app_role = AppRole(adapter=JSONAdapter())
+        response = app_role.list_secret_id_accessors(
+            role_name=role_name,
+            mount_point=mount_point
+        )
+
+        self.assertEqual(
+            first=mock_response,
+            second=response
+        )
+
+    @parameterized.expand([
+        ("default mount point", DEFAULT_MOUNT_POINT),
+        ("custom mount point", 'approle-test')
+    ])
+    @requests_mock.Mocker()
+    def test_read_secret_id_accessor(self, test_label, mount_point, requests_mocker):
+        expected_status_code = 200
+        role_name = 'testrole'
+        secret_id = 'custom_secret'
+        secret_id_accessor = '84896a0c-1347-aa90-a4f6-aca8b7558780'
+
+        mock_response = {
+            'auth': None,
+            'data': {
+                'secret_id': secret_id,
+                'secret_id_accessor': '84896a0c-1347-aa90-a4f6-aca8b7558780'
+            },
+            'lease_duration': 0,
+            'lease_id': '',
+            'renewable': False,
+            'request_id': '860a11a8-b835-cbab-7fce-de4edc4cf533',
+            'warnings': None,
+            'wrap_info': None
+        }
+        mock_url = 'http://localhost:8200/v1/auth/{mount_point}/role/{role_name}/secret-id-accessor/lookup'.format(
+            mount_point=mount_point,
+            role_name=role_name
+        )
+        requests_mocker.register_uri(
+            method='POST',
+            url=mock_url,
+            status_code=expected_status_code,
+            json=mock_response,
+        )
+
+        app_role = AppRole(adapter=JSONAdapter())
+        response = app_role.read_secret_id_accessor(
+            role_name=role_name,
+            secret_id_accessor=secret_id_accessor,
+            mount_point=mount_point
+        )
+
+        self.assertEqual(
+            first=mock_response,
+            second=response
+        )
+
+    @parameterized.expand([
+        ("default mount point", DEFAULT_MOUNT_POINT),
+        ("custom mount point", 'approle-test')
+    ])
+    @requests_mock.Mocker()
+    def test_destroy_secret_id_accessor(self, test_label, mount_point, requests_mocker):
+        expected_status_code = 204
+        role_name = 'testrole'
+        secret_id_accessor = '84896a0c-1347-aa90-a4f6-aca8b7558780'
+
+        mock_url = 'http://localhost:8200/v1/auth/{mount_point}/role/{role_name}/secret-id-accessor/destroy'.format(
+            mount_point=mount_point,
+            role_name=role_name
+        )
+        requests_mocker.register_uri(
+            method='POST',
+            url=mock_url,
+            status_code=expected_status_code,
+        )
+
+        app_role = AppRole(adapter=JSONAdapter())
+        response = app_role.destroy_secret_id_accessor(
+            role_name=role_name,
+            secret_id_accessor=secret_id_accessor,
+            mount_point=mount_point
+        )
+
+        self.assertEqual(
+            first=expected_status_code,
+            second=response.status_code
+        )
+
+    @parameterized.expand([
+        ("default mount point", DEFAULT_MOUNT_POINT),
+        ("custom mount point", 'approle-test')
+    ])
+    @requests_mock.Mocker()
+    def test_login(self, test_label, mount_point, requests_mocker):
+        expected_status_code = 200
+        role_id = 'test_role_id'
+        secret_id = 'custom_secret'
+
+        mock_response = {
+            'auth': None,
+            'data': {
+                'renewable': True,
+                'lease_duration': 1200,
+                'metadata': None,
+                'token_policies': ['default'],
+                'accessor': 'fd6c9a00-d2dc-3b11-0be5-af7ae0e1d374',
+                'client_token': '5b1a0318-679c-9c45-e5c6-d1b9a9035d49'
+            },
+            'lease_duration': 0,
+            'lease_id': '',
+            'renewable': False,
+            'request_id': '860a11a8-b835-cbab-7fce-de4edc4cf533',
+            'warnings': None,
+            'wrap_info': None
+        }
+        mock_url = 'http://localhost:8200/v1/auth/{mount_point}/login'.format(
+            mount_point=mount_point,
+        )
+        requests_mocker.register_uri(
+            method='POST',
+            url=mock_url,
+            status_code=expected_status_code,
+            json=mock_response,
+        )
+
+        app_role = AppRole(adapter=JSONAdapter())
+        response = app_role.login(
+            role_id=role_id,
+            secret_id=secret_id,
+            mount_point=mount_point
+        )
+
+        self.assertEqual(
+            first=mock_response,
+            second=response
+        )

--- a/tests/utils/hvac_integration_test_case.py
+++ b/tests/utils/hvac_integration_test_case.py
@@ -153,17 +153,17 @@ class HvacIntegrationTestCase(object):
             name=test_admin_policy_name,
             policy=test_admin_policy,
         )
-        self.client.create_role(
+        self.client.auth.approle.create_or_update_approle(
             role_name=role_name,
             mount_point=path,
             token_policies=[test_admin_policy_name],
         )
-        self.client.set_role_id(
+        self.client.auth.approle.update_role_id(
             role_name=role_name,
             role_id=role_id,
             mount_point=path,
         )
-        secret_id_resp = self.client.create_role_secret_id(
+        secret_id_resp = self.client.auth.approle.generate_secret_id(
             role_name=role_name,
             mount_point=self.TEST_APPROLE_PATH,
         )
@@ -176,7 +176,7 @@ class HvacIntegrationTestCase(object):
             path=path
         )
 
-        self.client.auth_approle(
+        self.client.auth.approle.login(
             role_id=role_id,
             secret_id=secret_id,
             mount_point=path,


### PR DESCRIPTION
This PR deprecates the methods for AppRole authentication in the base client and adds an `AppRole` class to `auth_methods`. It includes tests and full docstrings for the class.