### PR TITLE
fix health.py read_health_status GET method

### DIFF
--- a/hvac/api/system_backend/health.py
+++ b/hvac/api/system_backend/health.py
@@ -63,7 +63,7 @@ class Health(SystemBackendMixin):
             api_path = utils.format_url('/v1/sys/health')
             return self._adapter.get(
                 url=api_path,
-                json=params,
+                params=params,
                 raise_exception=False,
             )
         else:


### PR DESCRIPTION
Fixed sys.read_health_status GET method passing params as POST body instead of query-string (params).

Testing against 3 node cluster before change, Response 429 returned for 2 out of 3 calls when standby_ok=True, and the URL has no query string.
```
>>> import logging, hvac
>>> logging.basicConfig()
>>> logging.getLogger().setLevel(logging.DEBUG)
>>> requests_log = logging.getLogger("requests.packages.urllib3")
>>> requests_log.setLevel(logging.DEBUG)
>>> requests_log.propagate = True
>>> client = hvac.Client(url='https://127.0.0.1:8200')
>>> client.sys.read_health_status(method='GET', standby_ok=True)                                                  
DEBUG:urllib3.connectionpool:https://127.0.0.1:8200 "GET /v1/sys/health HTTP/1.1" 200 None                                                                                                         
{'initialized': True, 'sealed': False, 'standby': False, 'performance_standby': False, 'replication_performance_mode': 'disabled', 'replication_dr_mode': 'disabled', 'server_time_utc': 1607527388, 'versi$
n': '1.1.5', 'cluster_name': 'vault-cluster-redacted', 'cluster_id': 'redacted'}
>>> client.sys.read_health_status(method='GET', standby_ok=True)                                                  
DEBUG:urllib3.connectionpool:https://127.0.0.1:8200 "GET /v1/sys/health HTTP/1.1" 429 293                                                                                                          
<Response [429]>                                                                                           
>>> client.sys.read_health_status(method='GET', standby_ok=True)
DEBUG:urllib3.connectionpool:https://127.0.0.1:8200 "GET /v1/sys/health HTTP/1.1" 429 293                
<Response [429]>  
```

After the fix (same setup as above) query string appears in the URL and a valid dictionary is returned each time as expected with standby_ok=True
```
>>> client.sys.read_health_status(method='GET', standby_ok=True)
DEBUG:urllib3.connectionpool:https://127.0.0.1:8200 "GET /v1/sys/health?standbyok=True HTTP/1.1" 200 None
{'initialized': True, 'sealed': False, 'standby': True, 'performance_standby': False, 'replication_performance_mode': 'disabled', 'replication_dr_mode': 'disabled', 'server_time_utc': 1607527527, 'versio$
': '1.1.5', 'cluster_name': 'vault-cluster-redacted', 'cluster_id': 'redacted'}
```