### PR TITLE
Reformat docstring

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -108,8 +108,9 @@ autodoc_default_options = {
 
 
 def skip(app, what, name, obj, skip, options):
-    """Method to override default autodoc skip call. Ensures class constructor (e.g., __init__()) methods are included
-    regardless of if private methods are included in the documentation generally.
+    """Method to override default autodoc skip call. Ensures class constructor
+    (e.g., __init__()) methods are included regardless of if private methods
+    are included in the documentation generally.
     """
     if name == "__init__":
         return False


### PR DESCRIPTION
This PR simply reformats a single docstring to be < 100 characters and look nicer.

The motivation for this is that we clone this repo in StackStorm-Exchange/stackstorm-vault (see PR: StackStorm-Exchange/stackstorm-vault#19), but the line limit on our flake8 checks is only 100 characters, and when flake8 checked this file, the build failed ([CircleCI result](https://app.circleci.com/pipelines/github/StackStorm-Exchange/stackstorm-vault/84/workflows/f60720b3-84c0-4597-9f96-271e3c150af0/jobs/355)) due to that.

We are tweaking our test setup script so that flake8 ignores the clone of hvac (see StackStorm-Exchange/stackstorm-vault#20), in an effort to decouple the formatting settings of this repo with our own. But I also figured that you might be interested in a small but nice docstring fixup. Everybody likes nicely formatted code, right? 😄

Anyway, thanks for your consideration on this, and thank you for this wonderful library!