### PR TITLE
Fix lambda authentication example in aws auth documentation

### DIFF
--- a/docs/usage/auth_methods/aws.rst
+++ b/docs/usage/auth_methods/aws.rst
@@ -91,7 +91,6 @@ Lambda and/or EC2 Instance
         on_lambda = 'AWS_LAMBDA_FUNCTION_NAME' in os.environ
         if on_lambda:
             return os.environ['AWS_ACCESS_KEY_ID'], os.environ['AWS_SECRET_ACCESS_KEY'], os.environ['AWS_SESSION_TOKEN']
-    else:
         else:
             security_credentials = load_aws_ec2_role_iam_credentials(iam_role)
             return security_credentials['AccessKeyId'], security_credentials['SecretAccessKey']

--- a/docs/usage/auth_methods/aws.rst
+++ b/docs/usage/auth_methods/aws.rst
@@ -90,13 +90,14 @@ Lambda and/or EC2 Instance
     def infer_credentials_from_iam_role(iam_role):
         on_lambda = 'AWS_LAMBDA_FUNCTION_NAME' in os.environ
         if on_lambda:
-            return os.environ['AWS_ACCESS_KEY_ID'], os.environ['AWS_SECRET_ACCESS_KEY']
+            return os.environ['AWS_ACCESS_KEY_ID'], os.environ['AWS_SECRET_ACCESS_KEY'], os.environ['AWS_SESSION_TOKEN']
+    else:
         else:
             security_credentials = load_aws_ec2_role_iam_credentials(iam_role)
             return security_credentials['AccessKeyId'], security_credentials['SecretAccessKey']
 
 
-    access_key_id, secret_access_key = infer_credentials_from_iam_role('some-role')
+    access_key_id, secret_access_key, session_token = infer_credentials_from_iam_role('some-role')
 
     client = hvac.Client()
     client.auth.aws.iam_login(access_key_id, secret_access_key, session_token)


### PR DESCRIPTION
The current lambda example code is missing a session token reference and doesn't work as highlighted in [issue 640](https://github.com/hvac/hvac/issues/640). With it everything works as expected although I'd be tempted to split out the ec2 and Lambda implementations as it I found it a little confusing.