### PR TITLE
Set daemon attribute instead of using setDaemon method that was deprecated in Python 3.10

### DIFF
--- a/tests/integration_tests/api/auth_methods/test_github.py
+++ b/tests/integration_tests/api/auth_methods/test_github.py
@@ -32,7 +32,7 @@ class TestGithub(HvacIntegrationTestCase, TestCase):
             # Start running mock server in a separate thread.
             # Daemon threads automatically shut down when the main process exits.
             cls.mock_server_thread = Thread(target=cls.mock_server.serve_forever)
-            cls.mock_server_thread.setDaemon(True)
+            cls.mock_server_thread.daemon = True
             cls.mock_server_thread.start()
         except Exception:
             # Ensure that Vault server is taken down if setUpClass fails


### PR DESCRIPTION
Fixes #687 