### PR TITLE
Add handling of unsupported HTTP methods inside adapter

### DIFF
--- a/hvac/adapters.py
+++ b/hvac/adapters.py
@@ -288,7 +288,7 @@ class RawAdapter(Adapter):
         _kwargs.update(kwargs)
 
         if self.strict_http and method.lower() in ('list',):
-            # Encty point for standard HTTP substitution
+            # Entry point for standard HTTP substitution
             params = _kwargs.get('params', {})
             if method.lower() == 'list':
                 method = 'get'


### PR DESCRIPTION
## Add handling of unsupported HTTP methods inside adapter

### Background
We are using Kubernetes in our setup and Istio Gateway which is using Envoy behind the scenes.
- Unfortunately, envoy does not support custom HTTP methods, according to [the issue](https://github.com/envoyproxy/envoy/issues/8247).
- When [this issue](https://github.com/envoyproxy/envoy/issues/5155) will be closed, the parser will allow custom HTTP verbs but currently, we are locked out.

The only way to have a workaround, to replace `list` custom verb with `get` plus additional params.

### NOTE
Additional actions:
- now we can always use `LIST` everywhere and if the adapter does not support it, it will be converted before the request.
- there are a lot of places with logic if method == 'LIST' etc... And there are a lot of places where we are propagating list=true to params.

Fixes #551 