### PR TITLE
Update approle.rst

### DIFF
--- a/docs/usage/auth_methods/approle.rst
+++ b/docs/usage/auth_methods/approle.rst
@@ -85,4 +85,4 @@ Generate Secret ID
         role_name='some-role',
         cidr_list=['127.0.0.1/32'],
     )
-    print(f'AppRole secret ID for some-role: {resp["data"]["role_id"]}')
+    print(f'AppRole secret ID for some-role: {resp["data"]["secret_id"]}')


### PR DESCRIPTION
Under the function for generating the secret id the f-string incorrectly points to role id. This patch fixes it to correctly point to ['data']['secret_id']