### PR TITLE
Add default to `group_type` argument in `update_group` and `create_or_update_group_by_name`

### DIFF
--- a/hvac/api/secrets_engines/identity.py
+++ b/hvac/api/secrets_engines/identity.py
@@ -578,7 +578,7 @@ class Identity(VaultApiBase):
             url=api_path,
         )
 
-    def update_group(self, group_id, name, group_type=None, metadata=None, policies=None, member_group_ids=None,
+    def update_group(self, group_id, name, group_type='internal', metadata=None, policies=None, member_group_ids=None,
                      member_entity_ids=None, mount_point=DEFAULT_MOUNT_POINT):
         """Update an existing group.
 
@@ -722,7 +722,7 @@ class Identity(VaultApiBase):
 
         return response
 
-    def create_or_update_group_by_name(self, name, group_type=None, metadata=None, policies=None, member_group_ids=None,
+    def create_or_update_group_by_name(self, name, group_type='internal', metadata=None, policies=None, member_group_ids=None,
                                        member_entity_ids=None, mount_point=DEFAULT_MOUNT_POINT):
         """Create or update a group by its name.
 


### PR DESCRIPTION
Doc strings say that `group_type` defaults to `'internal'`. However, when no value is set to `group_type` argument, `ParamValidationError` raised. The `create_or_update_group` method adds the default value for the argument as well.