### PR TITLE
Python 2.7: Drop Trailing Comma In `Cert.login()`

### DIFF
--- a/hvac/api/auth_methods/cert.py
+++ b/hvac/api/auth_methods/cert.py
@@ -251,7 +251,7 @@ class Cert(VaultApiBase):
         return self._adapter.login(
             url=api_path,
             json=params,
-            **additional_request_kwargs,
+            **additional_request_kwargs
         )
 
     class CertificateAuthError(Exception):


### PR DESCRIPTION
Resolves #711