### PR TITLE
Allow Omission of Password Argument on Userpass `create_or_update_user()`

### DIFF
--- a/hvac/api/auth_methods/userpass.py
+++ b/hvac/api/auth_methods/userpass.py
@@ -12,7 +12,7 @@ class Userpass(VaultApiBase):
     Reference: https://www.vaultproject.io/api/auth/userpass/index.html
     """
 
-    def create_or_update_user(self, username, password, policies=None, mount_point=DEFAULT_MOUNT_POINT):
+    def create_or_update_user(self, username, password=None, policies=None, mount_point=DEFAULT_MOUNT_POINT):
         """
         Create/update user in userpass.
 
@@ -28,14 +28,11 @@ class Userpass(VaultApiBase):
         :param mount_point: The "path" the method/backend was mounted on.
         :type mount_point: str | unicode
         """
-        params = {
+        params = utils.remove_nones({
             'password': password,
-        }
-        params.update(
-            utils.remove_nones({
-                'policies': policies,
-            })
-        )
+            'policies': policies,
+        })
+
         api_path = '/v1/auth/{mount_point}/users/{username}'.format(mount_point=mount_point, username=username)
         return self._adapter.post(
             url=api_path,


### PR DESCRIPTION
… users

Fixed auth.userpass.create_or_update_user to match API doc allowing for not providing password field when updating users.
Python method did not allow for omission of password argument.

Reference API doc which says password is not required for pre-existing users:
* https://www.vaultproject.io/api/auth/userpass#create-update-user
* https://hvac.readthedocs.io/en/stable/source/hvac_api_auth_methods.html#hvac.api.auth_methods.Userpass.create_or_update_user

## proof of bug
Create a user with a password and try to update it without a password set to None fails:
```
>>> # create a user
>>> client.auth.userpass.create_or_update_user("user1", "foobar", ["userpass_policy1"])
<Response [204]>
>>> # list the user to show it is there
>>> client.auth.userpass.list_user()
{'request_id': '4d707d9f-30b3-f0c8-9dd7-836716e135aa', 'lease_id': '', 'renewable': False, 'lease_duration': 0, 'data': {'keys': ['user1']}, 'wrap_info': None, 'warnings': None, 'auth': None}
>>> # update policies without providing the password
>>> client.auth.userpass.create_or_update_user("user1", None, ["userpass_policy2"])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/mike/Documents/vault/lib/python3.8/site-packages/hvac/api/auth_methods/userpass.py", line 40, in create_or_update_user
    return self._adapter.post(
  File "/home/mike/Documents/vault/lib/python3.8/site-packages/hvac/adapters.py", line 110, in post
    return self.request('post', url, **kwargs)
  File "/home/mike/Documents/vault/lib/python3.8/site-packages/hvac/adapters.py", line 353, in request
    response = super(JSONAdapter, self).request(*args, **kwargs)
  File "/home/mike/Documents/vault/lib/python3.8/site-packages/hvac/adapters.py", line 315, in request
    utils.raise_for_error(
  File "/home/mike/Documents/vault/lib/python3.8/site-packages/hvac/utils.py", line 37, in raise_for_error
    raise exceptions.InvalidRequest(message, errors=errors, method=method, url=url)
hvac.exceptions.InvalidRequest: missing password, on post http://127.0.0.1:8200/v1/auth/userpass/users/user1
```

## proof of fix
```
>>> # create a user
>>> client.auth.userpass.create_or_update_user("user1", "foobar", ["userpass_policy1"])
<Response [204]>
>>> # list the user to show it is there
>>> client.auth.userpass.list_user()
{'request_id': '0b567a0f-8aac-8786-d633-c21782b87daa', 'lease_id': '', 'renewable': False, 'lease_duration': 0, 'data': {'keys': ['user1']}, 'wrap_info': None, 'warnings': None, 'auth': None}
>>> # update policies without providing the password
>>> client.auth.userpass.create_or_update_user("user1", policies=["userpass_policy2"])
<Response [204]>
>>> # confirm the policy change
>>> client.auth.userpass.read_user('user1')
{'request_id': '102954de-8edb-d650-a991-ce03e5f19a8d', 'lease_id': '', 'renewable': False, 'lease_duration': 0, 'data': {'bound_cidrs': [], 'max_ttl': 0, 'policies': ['userpass_policy2'], 'ttl': 0}, 'wrap_info': None, 'warnings': None, 'auth': None}
```

Both before & after fix, attempting to create a *new* user without supplying a password, i.e. setting password to None, fails with the same error as expected.