### PR TITLE
Change STS to PUT

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.10.13
+current_version = 0.10.14
 commit = True
 tag = True
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.10.14 (May 21st, 2021)
+
+### 🐛 Bug Fixes
+
+- Python 2.7: Drop Trailing Comma In `Cert.login()`. GH-712
+
 ## 0.10.13 (May 20th, 2021)
 
 ### 🐛 Bug Fixes

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,9 +16,9 @@ copyright = u'2018-2020, Ian Unruh, Jeffrey Hogan'
 author = u'Ian Unruh, Jeffrey Hogan'
 
 # The short X.Y version
-version = '0.10.13'
+version = '0.10.14'
 # The full version, including alpha/beta/rc tags
-release = '0.10.13'
+release = '0.10.14'
 
 
 # -- General configuration ---------------------------------------------------

--- a/hvac/api/secrets_engines/aws.py
+++ b/hvac/api/secrets_engines/aws.py
@@ -313,7 +313,7 @@ class Aws(VaultApiBase):
         :type ttl: str | unicode
         :param endpoint: Supported endpoints:
             GET: /{mount_point}/creds/{name}. Produces: 200 application/json
-            GET: /{mount_point}/sts/{name}. Produces: 200 application/json
+            PUT: /{mount_point}/sts/{name}. Produces: 200 application/json
         :type endpoint: str | unicode
         :param mount_point: The "path" the method/backend was mounted on.
         :type mount_point: str | unicode
@@ -342,7 +342,13 @@ class Aws(VaultApiBase):
             name=name,
         )
 
-        return self._adapter.get(
-            url=api_path,
-            params=params,
-        )
+        if endpoint == 'sts':
+            return self._adapter.put(
+                url=api_path,
+                params=params,
+            )
+        else:
+            return self._adapter.get(
+                url=api_path,
+                params=params,
+            )

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def load_long_description():
 
 setup(
     name='hvac',
-    version='0.10.13',
+    version='0.10.14',
     description='HashiCorp Vault API client',
     long_description=load_long_description(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
For the AWS secrets engine STS is a PUT request and iam user creds are GET. The API docs on vaults website say they are a GET but they were wrong. I submitted a MR to vault that just got merged fixing that here https://github.com/hashicorp/vault/pull/11681 this also has a little bit more info. going through the git history ive seen this go back and forth a couple times not quite sure why for example most recently here https://github.com/hvac/hvac/commit/3bfee6fe2dde39d1531fb0d1c1b14c2eee4659ba  maybe @JadeHayes can help shed some light. 