### PR TITLE
Use PUTs for AWS Secrets Engine STS Requests

### DIFF
--- a/hvac/api/secrets_engines/aws.py
+++ b/hvac/api/secrets_engines/aws.py
@@ -313,7 +313,7 @@ class Aws(VaultApiBase):
         :type ttl: str | unicode
         :param endpoint: Supported endpoints:
             GET: /{mount_point}/creds/{name}. Produces: 200 application/json
-            GET: /{mount_point}/sts/{name}. Produces: 200 application/json
+            PUT: /{mount_point}/sts/{name}. Produces: 200 application/json
         :type endpoint: str | unicode
         :param mount_point: The "path" the method/backend was mounted on.
         :type mount_point: str | unicode
@@ -342,7 +342,13 @@ class Aws(VaultApiBase):
             name=name,
         )
 
-        return self._adapter.get(
-            url=api_path,
-            params=params,
-        )
+        if endpoint == 'sts':
+            return self._adapter.put(
+                url=api_path,
+                params=params,
+            )
+        else:
+            return self._adapter.get(
+                url=api_path,
+                params=params,
+            )


### PR DESCRIPTION
For the AWS secrets engine STS is a PUT request and iam user creds are GET. The API docs on vaults website say they are a GET but they were wrong. I submitted a MR to vault that just got merged fixing that here https://github.com/hashicorp/vault/pull/11681 this also has a little bit more info. going through the git history ive seen this go back and forth a couple times not quite sure why for example most recently here https://github.com/hvac/hvac/commit/3bfee6fe2dde39d1531fb0d1c1b14c2eee4659ba  maybe @JadeHayes can help shed some light. 