### PR TITLE
Fix Cert.login() handling of use_token argument

### DIFF
--- a/hvac/api/auth_methods/cert.py
+++ b/hvac/api/auth_methods/cert.py
@@ -207,7 +207,7 @@ class Cert(VaultApiBase):
         :return: The response of the login request.
         :rtype: requests.Response
         """
-        params = {'use_token': use_token}
+        params = {}
         if name != "":
             params['name'] = name
         api_path = '/v1/auth/{mount_point}/login'.format(mount_point=mount_point)
@@ -250,6 +250,7 @@ class Cert(VaultApiBase):
 
         return self._adapter.login(
             url=api_path,
+            use_token=use_token,
             json=params,
             **additional_request_kwargs
         )


### PR DESCRIPTION
The `client.auth.cert.login(use_token=True)` argument should be passed internally to `Adapter.login()`. But instead it was sent to Vault in the POST body, which is not recognized by Vault: https://www.vaultproject.io/api/auth/cert#login-with-tls-certificate-method

Regression in #691 (7bb92f72da5968b4fc08f7b6434fdad631dd2f2d).