### PR TITLE
Add `python_requires='>=2.7'` to setuptools Metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         "Programming Language :: Python :: Implementation :: CPython",
     ],
     packages=find_packages(exclude=["docs*", "tests*"]),
+    python_requires=">=2.7",
     install_requires=[
         "requests>=2.21.0",
         "six>=1.5.0",


### PR DESCRIPTION
I'm [given to understand](https://packaging.python.org/guides/dropping-older-python-versions/#dropping-a-python-release) we will need to have one release with this `python_requires` setuptools argument for "automated fallback" to work when our subsequent v1 releases drops of Python 2.7 support. 