### PR TITLE
Drop Python 2.7 Support Explicitly

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,4 +3,4 @@ description = README.md
 license_files = LICENSE.txt
 
 [bdist_wheel]
-universal = 1
+universal = 0

--- a/setup.py
+++ b/setup.py
@@ -21,14 +21,12 @@ setup(
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: Implementation :: CPython",
     ],
     packages=find_packages(exclude=["docs*", "tests*"]),
-    python_requires=">=2.7",
+    python_requires=">=3.6",
     install_requires=[
         "requests>=2.25.1",
     ],


### PR DESCRIPTION
closes #582 (🤞🏻) 🎉 

TODO's:

- [ ] Validate expected behavior installing the module in both Python 2.7 and 3.x using test.pypi.org before shipping this!