### PR TITLE
Removed vestigial accessor parameter from auth token revoke_self

### DIFF
--- a/docs/usage/auth_methods/token.rst
+++ b/docs/usage/auth_methods/token.rst
@@ -25,6 +25,11 @@ Token creation and revocation:
     client.auth.token.revoke('xxx')
     client.auth.token.revoke('yyy', orphan=True)
 
+    # revoke current token
+    client.auth.token.revoke_self()
+    # logout and revoke current token
+    client.logout(revoke_token=True)
+
     client.auth.token.renew('aaa')
 
 

--- a/docs/usage/auth_methods/token.rst
+++ b/docs/usage/auth_methods/token.rst
@@ -19,7 +19,7 @@ Token creation and revocation:
 
     token = client.auth.token.create(policies=['root'], lease='1h')
 
-    current_token = client.auth.token.lookup()
+    current_token = client.auth.token.lookup_self()
     some_other_token = client.auth.token.lookup('xxx')
 
     client.auth.token.revoke('xxx')

--- a/hvac/api/auth_methods/token.py
+++ b/hvac/api/auth_methods/token.py
@@ -342,7 +342,7 @@ class Token(VaultApiBase):
             json=params,
         )
 
-    def revoke_self(self, accessor, mount_point=DEFAULT_MOUNT_POINT):
+    def revoke_self(self, mount_point=DEFAULT_MOUNT_POINT):
         """Revoke the token used to call it and all child tokens.
 
         When the token is revoked, all dynamic secrets generated with it are also revoked.
@@ -350,20 +350,14 @@ class Token(VaultApiBase):
         Supported methods:
             POST: /auth/{mount_point}/revoke-self.
 
-        :param accessor: Accessor of the token.
-        :type accessor: str
         :param mount_point: The "path" the method/backend was mounted on.
         :type mount_point: str
         :return: The response of the revoke_a_self request.
         :rtype: requests.Response
         """
-        params = {
-            "accessor": accessor,
-        }
         api_path = "/v1/auth/{mount_point}/revoke-self".format(mount_point=mount_point)
         return self._adapter.post(
-            url=api_path,
-            json=params,
+            url=api_path
         )
 
     def revoke_accessor(self, accessor, mount_point=DEFAULT_MOUNT_POINT):

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -641,7 +641,7 @@ class Client(object):
         :rtype:
         """
         if revoke_token:
-            self.revoke_self_token()
+            self.auth.token.revoke_self()
 
         self.token = None
 

--- a/tests/integration_tests/api/auth_methods/test_token.py
+++ b/tests/integration_tests/api/auth_methods/test_token.py
@@ -32,13 +32,13 @@ class TestToken(HvacIntegrationTestCase, TestCase):
         assert result["auth"]["client_token"]
         self.client.token = result["auth"]["client_token"]
 
-        lookup = self.client.auth.token.lookup(result["auth"]["client_token"])
+        lookup = self.client.auth.token.lookup_self()
         assert result["auth"]["client_token"] == lookup["data"]["id"]
 
         renew = self.client.auth.token.renew_self()
         assert result["auth"]["client_token"] == renew["auth"]["client_token"]
 
-        self.client.auth.token.revoke(lookup["data"]["id"])
+        self.client.auth.token.revoke_self()
 
         try:
             lookup = self.client.auth.token.lookup(result["auth"]["client_token"])

--- a/tests/integration_tests/v1/test_integration.py
+++ b/tests/integration_tests/v1/test_integration.py
@@ -335,6 +335,19 @@ class IntegrationTest(HvacIntegrationTestCase, TestCase):
         self.client.logout()
         assert not self.client.is_authenticated()
 
+    def test_client_logout_and_revoke(self):
+        # create a new token
+        result = self.client.auth.token.create(ttl="1h", renewable=True)
+        # set the token
+        self.client.token = result["auth"]["client_token"]
+
+        # logout and revoke the token
+        self.client.logout(revoke_token=True)
+        # set the original token back
+        self.client.token = result["auth"]["client_token"]
+        # confirm that it no longer is able to authenticate
+        assert not self.client.is_authenticated()
+
     def test_revoke_self_token(self):
         if "userpass/" in self.client.sys.list_auth_methods()["data"]:
             self.client.sys.disable_auth_method("userpass")


### PR DESCRIPTION
Hello,

I noticed that the auth token revoke_self() method is asking for an accessor parameter, which it does not require per:

https://www.vaultproject.io/api-docs/auth/token#revoke-a-token-self

I've removed it in this PR.

Best Regards,
--Chris Manfre