### PR TITLE
Fix Client TLS `verify` Behavior 

### DIFF
--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -31,7 +31,7 @@ class Client(object):
         url=None,
         token=None,
         cert=None,
-        verify=True,
+        verify=None,
         timeout=30,
         proxies=None,
         allow_redirects=True,
@@ -83,7 +83,7 @@ class Client(object):
 
         # Consider related CA env vars _only if_ no argument is passed in under the
         # `verify` parameter.
-        if verify is not None:
+        if verify is None:
             # Reference: https://www.vaultproject.io/docs/commands#vault_cacert
             # Note: "[VAULT_CACERT] takes precedence over VAULT_CAPATH." and thus we
             # check for VAULT_CAPATH _first_.
@@ -91,6 +91,9 @@ class Client(object):
                 verify = VAULT_CAPATH
             if VAULT_CACERT:
                 verify = VAULT_CACERT
+            if not verify:
+                # default to verifying certificates if the above aren't defined
+                verify = True
 
         self._adapter = adapter(
             base_uri=url,


### PR DESCRIPTION
Currently, the HVAC client defaults the 'verify' parameter to True.  Later, in the init method, if 'verify' is not None, then it will be overridden by environmental variables, if present.  If a user specifically sets a value of 'verify' (say to False), the if block that overrides the parameter is ran clobbering whatever the user specified when creating the client.

The comments indicate that this if block should only run if the user did not specify anything to verify.  This pull will default verify to None and update the if block to only run if verify is set to None.  If no environmental variables are available, then 'verify' will get set to True.