### PR TITLE
jwt: use login adapter and add `use_token` param

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ the latest `vault` binary is available in your `PATH`.
 
 ```
 cd hvac
-pip install -r requirements.txt
+pip install -r requirements-dev.txt
 ```
 3. Run tests: `make test`
 

--- a/hvac/api/auth_methods/jwt.py
+++ b/hvac/api/auth_methods/jwt.py
@@ -412,7 +412,7 @@ class JWT(VaultApiBase):
             json=params,
         )
 
-    def jwt_login(self, role, jwt, path=None):
+    def jwt_login(self, role, jwt, use_token=True, path=None):
         """Fetch a token.
 
         This endpoint takes a signed JSON Web Token (JWT) and a role name for some entity.
@@ -439,7 +439,8 @@ class JWT(VaultApiBase):
             "/v1/auth/{path}/login",
             path=self.resolve_path(path),
         )
-        return self._adapter.post(
+        return self._adapter.login(
             url=api_path,
+            use_token=use_token,
             json=params,
         )


### PR DESCRIPTION
Fixes: #644

Using https://github.com/hvac/hvac/pull/733 for inspiration, trying to fix JWT auth so it assigns the token the way other auth methods do.

Also updating the contributing doc with the right requirements to install.

However, once I was able to actually execute the tests, they all failed; it seems that it couldn't start a Vault server on my  machine for some reason, I'm not certain why and I wasn't able to get any info out of the pytest results (it's very verbose), other than possibly some kind of SSL issue.

So I wasn't able to run the tests locally first, will see if the change works in CI I guess 🤞