### PR TITLE
Add token_type to kubernetes auth create_role

### DIFF
--- a/hvac/api/auth_methods/kubernetes.py
+++ b/hvac/api/auth_methods/kubernetes.py
@@ -114,6 +114,7 @@ class Kubernetes(VaultApiBase):
         max_ttl=None,
         period=None,
         policies=None,
+        token_type="",
         mount_point=DEFAULT_MOUNT_POINT,
     ):
         """Create a role in the method.
@@ -143,6 +144,11 @@ class Kubernetes(VaultApiBase):
         :type period: str | unicode
         :param policies: Policies to be set on tokens issued using this role.
         :type policies: list | str | unicode
+        :param token_type: The type of token that should be generated. Can be service, batch, or default to use the
+            mount's tuned default (which unless changed will be service tokens). For token store roles, there are two
+            additional possibilities: default-service and default-batch which specify the type to return unless the
+            client requests a different type at generation time.
+        :type token_type: str
         :param mount_point: The "path" the azure auth method was mounted on.
         :type mount_point: str | unicode
         :return: The response of the request.
@@ -178,6 +184,9 @@ class Kubernetes(VaultApiBase):
         )
         if policies is not None:
             params["policies"] = comma_delimited_to_list(policies)
+
+        if token_type:
+            params['token_type'] = token_type
 
         api_path = utils.format_url(
             "/v1/auth/{mount_point}/role/{name}", mount_point=mount_point, name=name

--- a/hvac/api/auth_methods/kubernetes.py
+++ b/hvac/api/auth_methods/kubernetes.py
@@ -186,7 +186,7 @@ class Kubernetes(VaultApiBase):
             params["policies"] = comma_delimited_to_list(policies)
 
         if token_type:
-            params['token_type'] = token_type
+            params["token_type"] = token_type
 
         api_path = utils.format_url(
             "/v1/auth/{mount_point}/role/{name}", mount_point=mount_point, name=name

--- a/tests/integration_tests/api/auth_methods/test_kubernetes.py
+++ b/tests/integration_tests/api/auth_methods/test_kubernetes.py
@@ -146,7 +146,7 @@ class TestKubernetes(HvacIntegrationTestCase, TestCase):
                 "token type",
                 bound_service_account_names=["vault-auth"],
                 bound_service_account_namespaces=["default"],
-                token_type='service',
+                token_type="service",
             ),
         ]
     )

--- a/tests/integration_tests/api/auth_methods/test_kubernetes.py
+++ b/tests/integration_tests/api/auth_methods/test_kubernetes.py
@@ -142,6 +142,12 @@ class TestKubernetes(HvacIntegrationTestCase, TestCase):
                 bound_service_account_names=["*"],
                 bound_service_account_namespaces=["*"],
             ),
+            param(
+                "token type",
+                bound_service_account_names=["vault-auth"],
+                bound_service_account_namespaces=["default"],
+                token_type='service',
+            ),
         ]
     )
     def test_create_role(
@@ -149,6 +155,7 @@ class TestKubernetes(HvacIntegrationTestCase, TestCase):
         label,
         bound_service_account_names=None,
         bound_service_account_namespaces=None,
+        token_type=None,
         raises=None,
         exception_message="",
     ):
@@ -159,6 +166,7 @@ class TestKubernetes(HvacIntegrationTestCase, TestCase):
                     name=role_name,
                     bound_service_account_names=bound_service_account_names,
                     bound_service_account_namespaces=bound_service_account_namespaces,
+                    token_type=token_type,
                     mount_point=self.TEST_MOUNT_POINT,
                 )
             self.assertIn(
@@ -170,6 +178,7 @@ class TestKubernetes(HvacIntegrationTestCase, TestCase):
                 name=role_name,
                 bound_service_account_names=bound_service_account_names,
                 bound_service_account_namespaces=bound_service_account_namespaces,
+                token_type=token_type,
                 mount_point=self.TEST_MOUNT_POINT,
             )
             logging.debug("create_role_response: %s" % create_role_response)


### PR DESCRIPTION
related to #664

Adds support for the create_token parameter to the kubernetes API Auth class create_role method similar to the v1 create_kubernetes_role function.