### PR TITLE
Add X-Vault-Request header to all requests by default

### DIFF
--- a/hvac/adapters.py
+++ b/hvac/adapters.py
@@ -30,6 +30,7 @@ class Adapter(object):
         namespace=None,
         ignore_exceptions=False,
         strict_http=False,
+        request_header=True,
     ):
         """Create a new request adapter instance.
 
@@ -59,6 +60,8 @@ class Adapter(object):
         :type ignore_exceptions: bool
         :param strict_http: If True, use only standard HTTP verbs in request with additional params, otherwise process as is
         :type strict_http: bool
+        :param request_header: If true, add the X-Vault-Request header to all requests to protect against SSRF vulnerabilities.
+        :type request_header: bool
         """
         if not session:
             session = requests.Session()
@@ -70,6 +73,7 @@ class Adapter(object):
         self.allow_redirects = allow_redirects
         self.ignore_exceptions = ignore_exceptions
         self.strict_http = strict_http
+        self.request_header = request_header
 
         self._kwargs = {
             "cert": cert,
@@ -280,6 +284,9 @@ class RawAdapter(Adapter):
 
         if not headers:
             headers = {}
+
+        if self.request_header:
+            headers["X-Vault-Request"] = "true"
 
         if self.token:
             headers["X-Vault-Token"] = self.token


### PR DESCRIPTION
Closes #761.

This change is intended to update the behavior of `hvac` to match the [Go client](https://github.com/hashicorp/vault/blob/main/api/client.go#L479) where the `X-Vault-Request: true` header is added to all requests regardless of whether they are made to a Vault Server or Vault Agent.

This header is used for providing protection against SSRF vulnerabilities. Since adding it should be backwards compatible, I've enabled it by default. This will match the Go client behavior and also ensure that `hvac` uses secure defaults where possible.