### PR TITLE
Fix premature read on stream requests in the `sys.take_raft_snapshot` method

### DIFF
--- a/hvac/adapters.py
+++ b/hvac/adapters.py
@@ -370,6 +370,10 @@ class JSONAdapter(RawAdapter):
         :rtype: dict | requests.Response
         """
         response = super().request(*args, **kwargs)
+        # Do not attempt to jsonify stream requests, doing so will empty the
+        # socket and the caller has explicitly opted out
+        if kwargs.get('stream', False):
+            return response
         if response.status_code == 200:
             try:
                 return response.json()

--- a/hvac/adapters.py
+++ b/hvac/adapters.py
@@ -397,10 +397,6 @@ class JSONAdapter(RawAdapter):
         :rtype: dict | requests.Response
         """
         response = super().request(*args, **kwargs)
-        # Do not attempt to jsonify stream requests, doing so will empty the
-        # socket and the caller has explicitly opted out
-        if kwargs.get('stream', False):
-            return response
         if response.status_code == 200:
             try:
                 return response.json()

--- a/hvac/adapters.py
+++ b/hvac/adapters.py
@@ -14,6 +14,33 @@ from hvac.constants.client import DEFAULT_URL
 class Adapter(metaclass=ABCMeta):
     """Abstract base class used when constructing adapters for use with the Client class."""
 
+    @classmethod
+    def from_adapter(
+        cls,
+        adapter,
+    ):
+        """Create a new adapter based on an existing Adapter instance.
+        This can be used to create a new type of adapter that inherits the properties of an existing one.
+
+        :param adapter: The existing Adapter instance.
+        :type adapter: hvac.Adapters.Adapter
+        """
+
+        return cls(
+            base_uri=adapter.base_uri,
+            token=adapter.token,
+            cert=adapter._kwargs.get("cert"),
+            verify=adapter._kwargs.get("verify"),
+            timeout=adapter._kwargs.get("timeout"),
+            proxies=adapter._kwargs.get("proxies"),
+            allow_redirects=adapter.allow_redirects,
+            session=adapter.session,
+            namespace=adapter.namespace,
+            ignore_exceptions=adapter.ignore_exceptions,
+            strict_http=adapter.strict_http,
+            request_header=adapter.request_header,
+        )
+
     def __init__(
         self,
         base_uri=DEFAULT_URL,

--- a/hvac/api/system_backend/raft.py
+++ b/hvac/api/system_backend/raft.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """Raft methods module."""
 from hvac.api.system_backend.system_backend_mixin import SystemBackendMixin
-from hvac import utils
+from hvac import utils, adapters
 
 
 class Raft(SystemBackendMixin):
@@ -102,14 +102,17 @@ class Raft(SystemBackendMixin):
 
         The snapshot is returned as binary data and should be redirected to a file.
 
+        This endpoint will ignore your chosen adapter and always uses a RawAdapter.
+
         Supported methods:
             GET: /sys/storage/raft/snapshot.
 
-        :return: The response of the s request.
+        :return: The response of the snapshot request.
         :rtype: requests.Response
         """
         api_path = "/v1/sys/storage/raft/snapshot"
-        return self._adapter.get(
+        raw_adapter = adapters.RawAdapter.from_adapter(self._adapter)
+        return raw_adapter.get(
             url=api_path,
             stream=True,
         )

--- a/tests/unit_tests/test_adapters.py
+++ b/tests/unit_tests/test_adapters.py
@@ -12,6 +12,52 @@ from hvac import exceptions
 from hvac import adapters
 
 
+class TestAdapters:
+    CONSTRUCTOR_ARGS = (
+        "base_uri",
+        "token",
+        "cert",
+        "verify",
+        "timeout",
+        "proxies",
+        "allow_redirects",
+        "session",
+        "namespace",
+        "ignore_exceptions",
+        "strict_http",
+        "request_header",
+    )
+
+    INTERNAL_KWARGS = (
+        "cert",
+        "verify",
+        "timeout",
+        "proxies",
+    )
+
+    @pytest.mark.parametrize(
+        "conargs",
+        [
+            {arg: arg.capitalize() for arg in CONSTRUCTOR_ARGS},
+            {arg: arg.upper() for arg in CONSTRUCTOR_ARGS},
+        ],
+    )
+    def test_from_adapter(self, conargs):
+        expected = conargs.copy()
+        for internal_kwarg in self.INTERNAL_KWARGS:
+            expected.setdefault("_kwargs", {})[internal_kwarg] = expected.pop(
+                internal_kwarg
+            )
+
+        # let's start with a JSONAdapter, and make a RawAdapter out of it
+        json_adapter = adapters.JSONAdapter(**conargs)
+
+        raw_adapter = adapters.RawAdapter.from_adapter(json_adapter)
+
+        for property, value in expected.items():
+            assert getattr(raw_adapter, property) == value
+
+
 class TestRequest(TestCase):
     """Unit tests providing coverage for requests-related methods in the hvac Client class."""
 


### PR DESCRIPTION
When a caller (such as `sys.take_raft_snapshot`) performs a stream
request, the act of attempting to parse the response as JSON causes the
entire response body to be read and the underlying connection to be
closed. This renders the streaming response moot.

This change addresses that issue by examining if the caller requested a
stream response, and if so returning the response as is.

Without the change, it is impossible to read raft snapshots that are
larger than memory as the entire response is read into memory to attempt
to read as JSON.