### PR TITLE
Documentation updates for use with a private CA

### DIFF
--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -57,6 +57,19 @@ You then use hvac's Client.session and requests.Session() to pass the new CA bun
 
 .. _documented in the advanced usage section for requests: https://requests.readthedocs.io/en/master/user/advanced/#ssl-cert-verification
 
+If only using the certificate authority for trust, not authentication, SSL verification can be set using the `verify` parameter.
+
+This configures the client to trust the connection only if the certificate recieved is signed by a CA in that bundle:
+
+.. code:: python
+
+	vault_client = hvac.Client(
+		url=vault_url,
+		verify='/etc/ssl/my-ca-bundle'
+	)
+
+.. _documented in the advanced usage section for requests: https://requests.readthedocs.io/en/master/user/advanced/#ssl-cert-verification
+
 Custom Requests / HTTP Adapter
 ------------------------------
 


### PR DESCRIPTION
Hello! 

# Summary

I'm hoping to add a bit of documentation around using the `verify` parameter when initializing a client. 

The use case I'm working with, is we are only using a private CA to provide trust. The actual authentication is done through another channel (AWS IAM). 

My understanding of the `cert` parameter, is to address the former, where the client provides its own certificate to authenticate with Vault. 

# Validation 

To validate this works as expected, here's a snippet of code in use with our system: 

```
self.client = hvac.Client(url=self.vault_address, verify=os.environ.get('CA_BUNDLE'))
self.client.auth.aws.iam_login(credentials.access_key, credentials.secret_key, credentials.token)
```

Using this code, the connection to Vault is only trusted if signed by our internal CA root certificate. The code snippet added in the documentation is the same flow, simply more generic