### PR TITLE
approle - fix metadata for generated secret IDs, re-add `wrap_ttl`

### DIFF
--- a/hvac/api/auth_methods/approle.py
+++ b/hvac/api/auth_methods/approle.py
@@ -267,7 +267,9 @@ class AppRole(VaultApiBase):
                 )
             )
 
-        params = {"metadata": json.dumps(metadata) if metadata else metadata}
+        params = {}
+        if metadata:
+            params = {"metadata": json.dumps(metadata)}
 
         list_of_strings_params = {
             "cidr_list": cidr_list,

--- a/hvac/api/auth_methods/approle.py
+++ b/hvac/api/auth_methods/approle.py
@@ -238,6 +238,7 @@ class AppRole(VaultApiBase):
         cidr_list=None,
         token_bound_cidrs=None,
         mount_point=DEFAULT_MOUNT_POINT,
+        wrap_ttl=None,
     ):
         """
         Generates and issues a new Secret ID on a role in the auth method.
@@ -255,6 +256,9 @@ class AppRole(VaultApiBase):
         :type token_bound_cidrs: list
         :param mount_point: The "path" the method/backend was mounted on.
         :type mount_point: str | unicode
+        :param wrap_ttl: Returns the request as a response-wrapping token.
+            Can be either an integer number of seconds or a string duration of seconds (`15s`), minutes (`20m`), or hours (`25h`).
+        :type wrap_ttl: int | str
         :return: The JSON response of the read_role_id request.
         :rtype: dict
         """
@@ -288,7 +292,7 @@ class AppRole(VaultApiBase):
             mount_point=mount_point,
             role_name=role_name,
         )
-        return self._adapter.post(url=api_path, json=params)
+        return self._adapter.post(url=api_path, json=params, wrap_ttl=wrap_ttl)
 
     def create_custom_secret_id(
         self,
@@ -298,6 +302,7 @@ class AppRole(VaultApiBase):
         cidr_list=None,
         token_bound_cidrs=None,
         mount_point=DEFAULT_MOUNT_POINT,
+        wrap_ttl=None,
     ):
         """
         Generates and issues a new Secret ID on a role in the auth method.
@@ -317,6 +322,9 @@ class AppRole(VaultApiBase):
         :type token_bound_cidrs: list
         :param mount_point: The "path" the method/backend was mounted on.
         :type mount_point: str | unicode
+        :param wrap_ttl: Returns the request as a response-wrapping token.
+            Can be either an integer number of seconds or a string duration of seconds (`15s`), minutes (`20m`), or hours (`25h`).
+        :type wrap_ttl: int | str
         :return: The JSON response of the read_role_id request.
         :rtype: dict
         """
@@ -351,7 +359,7 @@ class AppRole(VaultApiBase):
             mount_point=mount_point,
             role_name=role_name,
         )
-        return self._adapter.post(url=api_path, json=params)
+        return self._adapter.post(url=api_path, json=params, wrap_ttl=wrap_ttl)
 
     def read_secret_id(self, role_name, secret_id, mount_point=DEFAULT_MOUNT_POINT):
         """

--- a/hvac/api/auth_methods/approle.py
+++ b/hvac/api/auth_methods/approle.py
@@ -329,7 +329,10 @@ class AppRole(VaultApiBase):
                 )
             )
 
-        params = {"secret_id": secret_id, "metadata": metadata}
+        params = {"secret_id": secret_id}
+
+        if metadata:
+            params["metadata"] = json.dumps(metadata)
 
         list_of_strings_params = {
             "cidr_list": cidr_list,

--- a/tests/integration_tests/api/auth_methods/test_approle.py
+++ b/tests/integration_tests/api/auth_methods/test_approle.py
@@ -102,16 +102,17 @@ class TestAppRole(HvacIntegrationTestCase, TestCase):
 
     @parameterized.expand(
         [
-            ("good request", None),
-            ("bad metadata option", exceptions.ParamValidationError),
+            ("good request, no metadata", None, None),
+            ("good request, good metadata", None, {"a": "val1", "B": "two"}),
+            ("bad metadata option", exceptions.ParamValidationError, "bad"),
         ]
     )
-    def test_generate_secret_id(self, test_label, raises):
+    def test_generate_secret_id(self, test_label, raises, metadata):
         if raises is not None:
             with self.assertRaises(raises) as cm:
                 self.client.auth.approle.generate_secret_id(
                     role_name=self.TEST_ROLE_NAME,
-                    metadata="metadata string",
+                    metadata=metadata,
                     mount_point=self.TEST_MOUNT_POINT,
                 )
             self.assertIn(
@@ -122,23 +123,25 @@ class TestAppRole(HvacIntegrationTestCase, TestCase):
                 role_name=self.TEST_ROLE_NAME,
                 cidr_list=["127.0.0.1/32"],
                 mount_point=self.TEST_MOUNT_POINT,
+                metadata=metadata,
             )
             self.assertIn(member="secret_id", container=response["data"])
 
     @parameterized.expand(
         [
-            ("good request", None),
-            ("bad metadata option", exceptions.ParamValidationError),
+            ("good request, no metadata", None, None),
+            ("good request, good metadata", None, {"a": "val1", "B": "two"}),
+            ("bad metadata option", exceptions.ParamValidationError, "bad"),
         ]
     )
-    def test_create_custom_secret_id(self, test_label, raises):
+    def test_create_custom_secret_id(self, test_label, raises, metadata):
         if raises is not None:
             with self.assertRaises(raises) as cm:
                 self.client.auth.approle.create_custom_secret_id(
                     role_name=self.TEST_ROLE_NAME,
                     secret_id=self.TEST_SECRET_ID,
                     cidr_list=["127.0.0.1/32"],
-                    metadata="metadata string",
+                    metadata=metadata,
                     mount_point=self.TEST_MOUNT_POINT,
                 )
             self.assertIn(
@@ -150,6 +153,7 @@ class TestAppRole(HvacIntegrationTestCase, TestCase):
                 secret_id=self.TEST_SECRET_ID,
                 cidr_list=["127.0.0.1/32"],
                 mount_point=self.TEST_MOUNT_POINT,
+                metadata=metadata,
             )
 
             self.assertEqual(

--- a/tests/unit_tests/api/auth_methods/test_approle.py
+++ b/tests/unit_tests/api/auth_methods/test_approle.py
@@ -251,12 +251,19 @@ class TestAppRole(TestCase):
         [
             ("default mount point", DEFAULT_MOUNT_POINT, None, None),
             ("metadata as dict", DEFAULT_MOUNT_POINT, None, {"a": "val1", "b": "two"}),
-            ("invalid metadata", DEFAULT_MOUNT_POINT, exceptions.ParamValidationError, "bad metadata"),
+            (
+                "invalid metadata",
+                DEFAULT_MOUNT_POINT,
+                exceptions.ParamValidationError,
+                "bad metadata",
+            ),
             ("custom mount point", "approle-test", None, None),
         ]
     )
     @requests_mock.Mocker()
-    def test_generate_secret_id(self, test_label, mount_point, raises, metadata, requests_mocker):
+    def test_generate_secret_id(
+        self, test_label, mount_point, raises, metadata, requests_mocker
+    ):
         expected_status_code = 200
         role_name = "testrole"
 
@@ -300,7 +307,10 @@ class TestAppRole(TestCase):
 
         else:
             response = app_role.generate_secret_id(
-                role_name=role_name, cidr_list=["127.0.0.1/32"], mount_point=mount_point, metadata=metadata
+                role_name=role_name,
+                cidr_list=["127.0.0.1/32"],
+                mount_point=mount_point,
+                metadata=metadata,
             )
 
             self.assertEqual(first=mock_response, second=response)
@@ -312,7 +322,12 @@ class TestAppRole(TestCase):
         [
             ("default mount point", DEFAULT_MOUNT_POINT, None, None),
             ("metadata as dict", DEFAULT_MOUNT_POINT, None, {"a": "val1", "b": "two"}),
-            ("invalid metadata", DEFAULT_MOUNT_POINT, exceptions.ParamValidationError, "bad metadata"),
+            (
+                "invalid metadata",
+                DEFAULT_MOUNT_POINT,
+                exceptions.ParamValidationError,
+                "bad metadata",
+            ),
             ("custom mount point", "approle-test", None, None),
         ]
     )


### PR DESCRIPTION
Fixes #781 
Fixes #950
Fixes #683 
Closes #778 