### PR TITLE
Update wrapping.rst - example for unauthenticated unwrap

### DIFF
--- a/docs/usage/system_backend/wrapping.rst
+++ b/docs/usage/system_backend/wrapping.rst
@@ -8,10 +8,8 @@ Wrapping
 
 Unwrap
 ------
-Is Sealed
----------
 
-.. automethod:: hvac.api.system_backend.Seal.is_sealed
+.. automethod:: hvac.api.system_backend.Wrapping.is_sealed
    :noindex:
 
 Examples
@@ -47,10 +45,18 @@ Examples
     import hvac
 
     client = hvac.Client(url='https://127.0.0.1:8200')
-    client.token = "s.xxxxxxxxxxxxxxxxxxxxxx"
+    client.write(
+        path="auth/approle-test/role/testrole",
+    )
+    result = client.write(
+        path='auth/approle-test/role/testrole/secret-id',
+        wrap_ttl="10s",
+    )
+
+    unwrapping_client = hvac.Client(url='https://127.0.0.1:8200', token=result)
 
     # Do not pass the token to unwrap when authenticating with the wrapping token
-    unwrap_response = client.sys.unwrap()
+    unwrap_response = unwrapping_client.sys.unwrap()
     print('Unwrapped approle role token secret id accessor: "%s"' % unwrap_response['data']['secret_id_accessor'])
 
 Example output:

--- a/docs/usage/system_backend/wrapping.rst
+++ b/docs/usage/system_backend/wrapping.rst
@@ -42,6 +42,17 @@ Examples
     )
     print('Unwrapped approle role token secret id accessor: "%s"' % unwrap_response['data']['secret_id_accessor'])
 
+.. testcode:: sys_wrapping
+
+    import hvac
+
+    client = hvac.Client(url='https://127.0.0.1:8200')
+    client.token = "s.xxxxxxxxxxxxxxxxxxxxxx"
+
+    # Do not pass the token to unwrap when authenticating with the wrapping token
+    unwrap_response = client.sys.unwrap()
+    print('Unwrapped approle role token secret id accessor: "%s"' % unwrap_response['data']['secret_id_accessor'])
+
 Example output:
 
 .. testoutput:: sys_wrapping

--- a/docs/usage/system_backend/wrapping.rst
+++ b/docs/usage/system_backend/wrapping.rst
@@ -9,7 +9,7 @@ Wrapping
 Unwrap
 ------
 
-.. automethod:: hvac.api.system_backend.Wrapping.is_sealed
+.. automethod:: hvac.api.system_backend.Wrapping.unwrap
    :noindex:
 
 Examples

--- a/docs/usage/system_backend/wrapping.rst
+++ b/docs/usage/system_backend/wrapping.rst
@@ -40,6 +40,13 @@ Examples
     )
     print('Unwrapped approle role token secret id accessor: "%s"' % unwrap_response['data']['secret_id_accessor'])
 
+Example output:
+
+.. testoutput:: sys_wrapping
+
+    Unwrapped approle role token secret id accessor: "..."
+
+
 .. testcode:: sys_wrapping
 
     import hvac
@@ -52,11 +59,13 @@ Examples
         path='auth/approle-test/role/testrole/secret-id',
         wrap_ttl="10s",
     )
+    result_token = result['wrap_info']['token']
 
-    unwrapping_client = hvac.Client(url='https://127.0.0.1:8200', token=result)
+    unwrapping_client = hvac.Client(url='https://127.0.0.1:8200', token=result_token)
 
     # Do not pass the token to unwrap when authenticating with the wrapping token
     unwrap_response = unwrapping_client.sys.unwrap()
+
     print('Unwrapped approle role token secret id accessor: "%s"' % unwrap_response['data']['secret_id_accessor'])
 
 Example output:


### PR DESCRIPTION
Provide example of using unwrap with just the wrapping token. Previous example is non-functional unless already authenticated.