### PR TITLE
Add support for custom metadata in kv2 engine

### DIFF
--- a/docs/usage/secrets_engines/kv_v2.rst
+++ b/docs/usage/secrets_engines/kv_v2.rst
@@ -331,6 +331,21 @@ Set "delete_version_after" value to 30 minutes for all new versions written to t
         delete_version_after="30m",
     )
 
+Describe the secret with custom metadata values in "custom_metadata":
+
+.. code:: python
+
+   import hvac
+   client = hvac.Client()
+
+   clients.secrets.kv.v2.update_metadata(
+        path='hvac',
+        custom_metadata={
+            "type": "api-token",
+            "color": "blue",
+        },
+   )
+
 
 Delete Metadata and All Versions
 --------------------------------

--- a/docs/usage/secrets_engines/kv_v2.rst
+++ b/docs/usage/secrets_engines/kv_v2.rst
@@ -331,20 +331,20 @@ Set "delete_version_after" value to 30 minutes for all new versions written to t
         delete_version_after="30m",
     )
 
-Describe the secret with custom metadata values in "custom_metadata":
+Describe the secret with custom metadata values in ``custom_metadata`` (Vault >= 1.9.0):
 
 .. code:: python
 
-   import hvac
-   client = hvac.Client()
+    import hvac
+    client = hvac.Client()
 
-   clients.secrets.kv.v2.update_metadata(
+    clients.secrets.kv.v2.update_metadata(
         path='hvac',
         custom_metadata={
             "type": "api-token",
             "color": "blue",
         },
-   )
+    )
 
 
 Delete Metadata and All Versions

--- a/hvac/api/secrets_engines/kv_v2.py
+++ b/hvac/api/secrets_engines/kv_v2.py
@@ -357,9 +357,9 @@ class KvV2(VaultApiBase):
         path,
         max_versions=None,
         cas_required=None,
-        custom_metadata=None,
         delete_version_after="0s",
         mount_point=DEFAULT_MOUNT_POINT,
+        custom_metadata=None,
     ):
         """Updates the max_versions of cas_required setting on an existing path.
 
@@ -376,13 +376,13 @@ class KvV2(VaultApiBase):
         :param cas_required: If true the key will require the cas parameter to be set on all write requests. If false,
             the backend's configuration will be used.
         :type cas_required: bool
-        :param custom_metadata: A dictionary of key/value metadata to describe the secret.
-        :type custom_metadata: dict
         :param delete_version_after: Specifies the length of time before a version is deleted. Accepts Go duration format string.
             Defaults to "0s" (i.e., disabled).
         :type delete_version_after: str
         :param mount_point: The "path" the secret engine was mounted on.
         :type mount_point: str | unicode
+        :param custom_metadata: A dictionary of key/value metadata to describe the secret. Requires Vault 1.9.0 or greater.
+        :type custom_metadata: dict
         :return: The response of the request.
         :rtype: requests.Response
         """

--- a/hvac/api/secrets_engines/kv_v2.py
+++ b/hvac/api/secrets_engines/kv_v2.py
@@ -357,6 +357,7 @@ class KvV2(VaultApiBase):
         path,
         max_versions=None,
         cas_required=None,
+        custom_metadata=None,
         delete_version_after="0s",
         mount_point=DEFAULT_MOUNT_POINT,
     ):
@@ -375,6 +376,8 @@ class KvV2(VaultApiBase):
         :param cas_required: If true the key will require the cas parameter to be set on all write requests. If false,
             the backend's configuration will be used.
         :type cas_required: bool
+        :param custom_metadata: A dictionary of key/value metadata to describe the secret.
+        :type custom_metadata: dict
         :param delete_version_after: Specifies the length of time before a version is deleted. Accepts Go duration format string.
             Defaults to "0s" (i.e., disabled).
         :type delete_version_after: str
@@ -397,6 +400,15 @@ class KvV2(VaultApiBase):
                 )
                 raise exceptions.ParamValidationError(error_msg)
             params["cas_required"] = cas_required
+        if custom_metadata is not None:
+            if not isinstance(custom_metadata, dict):
+                error_msg = (
+                    "dict expected for custom_metadata param, {type} received".format(
+                        type=type(custom_metadata)
+                    )
+                )
+                raise exceptions.ParamValidationError(error_msg)
+            params["custom_metadata"] = custom_metadata
         api_path = utils.format_url(
             "/v1/{mount_point}/metadata/{path}", mount_point=mount_point, path=path
         )

--- a/tests/integration_tests/api/secrets_engines/test_kv_v2.py
+++ b/tests/integration_tests/api/secrets_engines/test_kv_v2.py
@@ -810,6 +810,9 @@ class TestKvV2(HvacIntegrationTestCase, TestCase):
         raises=None,
         exception_message="",
     ):
+        if test_label == "update custom_medata" and utils.vault_version_lt("1.9.0"):
+            self.skipTest("custom_metadata support added in Vault 1.9.0")
+
         if write_secret_before_test:
             test_secret = {
                 "pssst": "hi itsame hvac",

--- a/tests/integration_tests/api/secrets_engines/test_kv_v2.py
+++ b/tests/integration_tests/api/secrets_engines/test_kv_v2.py
@@ -778,9 +778,22 @@ class TestKvV2(HvacIntegrationTestCase, TestCase):
                 None,
                 "cats",
                 "0s",
+                None,
                 True,
                 exceptions.ParamValidationError,
                 "bool expected for cas_required param",
+            ),
+            ("update custom_medata", "hvac", None, None, "0s", dict(color="blue")),
+            (
+                "update with invalid custom_metadata param",
+                "hvac",
+                None,
+                None,
+                "0s",
+                "not-a-dict",
+                True,
+                exceptions.ParamValidationError,
+                "dict expected for custom_metadata param",
             ),
             ("update with delete_version_after set", "hvac", None, True, "30s"),
         ]
@@ -792,6 +805,7 @@ class TestKvV2(HvacIntegrationTestCase, TestCase):
         max_versions=None,
         cas_required=None,
         delete_version_after="0s",
+        custom_metadata=None,
         write_secret_before_test=True,
         raises=None,
         exception_message="",
@@ -809,6 +823,7 @@ class TestKvV2(HvacIntegrationTestCase, TestCase):
                     path=path,
                     max_versions=max_versions,
                     cas_required=cas_required,
+                    custom_metadata=custom_metadata,
                     delete_version_after=delete_version_after,
                     mount_point=self.DEFAULT_MOUNT_POINT,
                 )
@@ -821,6 +836,7 @@ class TestKvV2(HvacIntegrationTestCase, TestCase):
                 path=path,
                 max_versions=max_versions,
                 cas_required=cas_required,
+                custom_metadata=custom_metadata,
                 delete_version_after=delete_version_after,
                 mount_point=self.DEFAULT_MOUNT_POINT,
             )
@@ -837,6 +853,7 @@ class TestKvV2(HvacIntegrationTestCase, TestCase):
             for key, argument in dict(
                 max_versions=max_versions,
                 cas_required=cas_required,
+                custom_metadata=custom_metadata,
                 delete_version_after=delete_version_after,
             ).items():
                 if argument is not None:


### PR DESCRIPTION
Vault 1.9 added support to custom metadata, "a map of arbitrary string
to string valued ser-provided metadata meant to describe the secret.".

This is already supported by the read_secret_metadata method as part
of the Vault server response. This change adds support to update it,
as a new parameter `custom_metadata` for the update_metadata method.

Reference: https://www.vaultproject.io/api-docs/secret/kv/kv-v2

Fixes #804