### PR TITLE
Readding 3.6 support

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -17,6 +17,7 @@ jobs:
     strategy:
       matrix:
         python-version:
+          - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"
@@ -87,6 +88,7 @@ jobs:
     strategy:
       matrix:
         python-version:
+          - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@
 Tested against the latest release, HEAD ref, and 3 previous minor versions (counting back from the latest release) of Vault.
 Current official support covers Vault v1.4.7 or later.
 
+> **_NOTE:_**  Support for EOL Python versions will be dropped at the end of 2022.  Starting in 2023, hvac will track
+> with the CPython EOL dates.
+
 ## Installation
 
 ```console

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         "Programming Language :: Python :: Implementation :: CPython",
     ],
     packages=find_packages(exclude=["docs*", "tests*"]),
-    python_requires=">=3.7",
+    python_requires=">=3.6",
     install_requires=[
         "requests>=2.21.0",
         "six>=1.5.0",


### PR DESCRIPTION
Pulling back in 3.6 support for the rest of the year.  Afterwards HVAC will strive to track Python version support against CPython EOL dates.