### PR TITLE
Update kubernetes authentication example

### DIFF
--- a/docs/usage/auth_methods/kubernetes.rst
+++ b/docs/usage/auth_methods/kubernetes.rst
@@ -9,4 +9,4 @@ Authentication
     # Kubernetes (from k8s pod)
     f = open('/var/run/secrets/kubernetes.io/serviceaccount/token')
     jwt = f.read()
-    client.auth_kubernetes("example", jwt)
+    client.auth.kubernetes.login("example", jwt)


### PR DESCRIPTION
Update kubernetes authentication example to use the current API call rather than the deprecated one.