### PR TITLE
Add stock version-resolver cfg for release-drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -21,6 +21,17 @@ categories:
     labels:
       - 'misc'
 change-template: '- $TITLE. GH-$NUMBER'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
 template: |
 
   $CHANGES


### PR DESCRIPTION
cc: @colin-pm 

As a method for getting release-drafter aligned with non-patch releases. I.e., this config addition + the `major` label on https://github.com/hvac/hvac/pull/829 will get the draft GitHub release set with the intended tag and name.