### PR TITLE
Fix issue #838

### DIFF
--- a/hvac/api/vault_api_category.py
+++ b/hvac/api/vault_api_category.py
@@ -34,8 +34,8 @@ class VaultApiCategory(VaultApiBase, metaclass=ABCMeta):
         :return: The requested class instance where available.
         :rtype: hvac.api.VaultApiBase
         """
-        if item in self.implemented_class_names:
-            private_attr_name = self.get_private_attr_name(item)
+        private_attr_name = self.get_private_attr_name(item)
+        if item in self.implemented_class_names and hasattr(self, private_attr_name):
             return getattr(self, private_attr_name)
         if item in [u.lower() for u in self.unimplemented_classes]:
             raise NotImplementedError(


### PR DESCRIPTION
Fixes #838 

Check attribute exist before calling `getattr()` within `__getattr__()` to prevent infinite recursion loops.
