### PR TITLE
Re-add arguments to create_or_update_role() from old API

### DIFF
--- a/hvac/api/auth_methods/token.py
+++ b/hvac/api/auth_methods/token.py
@@ -555,6 +555,8 @@ class Token(VaultApiBase):
         renewable=True,
         path_suffix=None,
         allowed_entity_aliases=None,
+        period=None,
+        explicit_max_ttl=None,
         mount_point=DEFAULT_MOUNT_POINT,
     ):
         """Create (or replace) the named role.
@@ -586,6 +588,10 @@ class Token(VaultApiBase):
         :type path_suffix: str
         :param allowed_entity_aliases: not case sensitive.
         :type allowed_entity_aliases: str
+        :param period: the token will have no maximum TTL, every renewal will use the given period.
+        :type period: str
+        :param explicit_max_ttl: the token cannot be renewed past this TTL value.
+        :type explicit_max_ttl: str
         :param mount_point: The "path" the method/backend was mounted on.
         :type mount_point: str
         :return: The response of the create_or_update_role request.
@@ -599,6 +605,8 @@ class Token(VaultApiBase):
                 "renewable": renewable,
                 "path_suffix": path_suffix,
                 "allowed_entity_aliases": allowed_entity_aliases,
+                "period": period,
+                "explicit_max_ttl": explicit_max_ttl,
             }
         )
         api_path = "/v1/auth/{mount_point}/roles/{role_name}".format(

--- a/hvac/api/auth_methods/token.py
+++ b/hvac/api/auth_methods/token.py
@@ -555,8 +555,8 @@ class Token(VaultApiBase):
         renewable=True,
         path_suffix=None,
         allowed_entity_aliases=None,
-        period=None,
-        explicit_max_ttl=None,
+        token_period=None,
+        token_explicit_max_ttl=None,
         mount_point=DEFAULT_MOUNT_POINT,
     ):
         """Create (or replace) the named role.
@@ -588,10 +588,10 @@ class Token(VaultApiBase):
         :type path_suffix: str
         :param allowed_entity_aliases: not case sensitive.
         :type allowed_entity_aliases: str
-        :param period: the token will have no maximum TTL, every renewal will use the given period.
-        :type period: str
-        :param explicit_max_ttl: the token cannot be renewed past this TTL value.
-        :type explicit_max_ttl: str
+        :param token_period: the token will have no maximum TTL, every renewal will use the given period.
+        :type token_period: str
+        :param token_explicit_max_ttl: the token cannot be renewed past this TTL value.
+        :type token_explicit_max_ttl: str
         :param mount_point: The "path" the method/backend was mounted on.
         :type mount_point: str
         :return: The response of the create_or_update_role request.
@@ -605,8 +605,8 @@ class Token(VaultApiBase):
                 "renewable": renewable,
                 "path_suffix": path_suffix,
                 "allowed_entity_aliases": allowed_entity_aliases,
-                "period": period,
-                "explicit_max_ttl": explicit_max_ttl,
+                "token_period": token_period,
+                "token_explicit_max_ttl": token_explicit_max_ttl,
             }
         )
         api_path = "/v1/auth/{mount_point}/roles/{role_name}".format(

--- a/hvac/api/auth_methods/token.py
+++ b/hvac/api/auth_methods/token.py
@@ -555,9 +555,9 @@ class Token(VaultApiBase):
         renewable=True,
         path_suffix=None,
         allowed_entity_aliases=None,
+        mount_point=DEFAULT_MOUNT_POINT,
         token_period=None,
         token_explicit_max_ttl=None,
-        mount_point=DEFAULT_MOUNT_POINT,
     ):
         """Create (or replace) the named role.
 

--- a/tests/unit_tests/api/auth_methods/test_token.py
+++ b/tests/unit_tests/api/auth_methods/test_token.py
@@ -1,0 +1,63 @@
+import pytest
+
+from unittest import mock
+from hvac.api.auth_methods.token import Token
+from hvac.adapters import Adapter
+
+
+# TODO: move this to a conftest.py somewhere
+class MockAdapter(Adapter):
+    def __init__(self, *args, **kwargs):
+        kwargs["session"] = mock.MagicMock()
+        super().__init__(*args, **kwargs)
+
+    def request(self, *args, **kwargs):
+        return (args, kwargs)
+
+    def get_login_token(self, response):
+        raise NotImplementedError()
+
+
+@pytest.fixture
+def token_auth():
+    return Token(MockAdapter())
+
+
+class TestToken:
+    @pytest.mark.parametrize("allowed_policies", ["allowed_policies", None])
+    @pytest.mark.parametrize("disallowed_policies", ["disallowed_policies", None])
+    @pytest.mark.parametrize("orphan", ["orphan", None])
+    @pytest.mark.parametrize("renewable", ["renewable", None])
+    @pytest.mark.parametrize("path_suffix", ["path_suffix", None])
+    @pytest.mark.parametrize("allowed_entity_aliases", ["allowed_entity_aliases", None])
+    @pytest.mark.parametrize("token_period", ["token_period", None])
+    @pytest.mark.parametrize("token_explicit_max_ttl", ["token_explicit_max_ttl", None])
+    def test_create_or_update_role_optional_parameters(
+        self,
+        token_auth,
+        allowed_policies,
+        disallowed_policies,
+        orphan,
+        renewable,
+        path_suffix,
+        allowed_entity_aliases,
+        token_period,
+        token_explicit_max_ttl,
+    ):
+        params = {
+            "allowed_policies": allowed_policies,
+            "disallowed_policies": disallowed_policies,
+            "orphan": orphan,
+            "renewable": renewable,
+            "path_suffix": path_suffix,
+            "allowed_entity_aliases": allowed_entity_aliases,
+            "token_period": token_period,
+            "token_explicit_max_ttl": token_explicit_max_ttl,
+        }
+        expected = params.copy()
+
+        _, rkwargs = token_auth.create_or_update_role("role_name", **params)
+
+        assert "json" in rkwargs
+        for key, value in expected.items():
+            assert value is None or rkwargs["json"][key] == value


### PR DESCRIPTION
The previous, deprecated `create_token_role()` method has arguments `period` and `explicit_max_ttl` that were dropped in the new one for some reason (in #734).

Re-added these two arguments to the new `create_or_update_role()` method (using new spelling `token_period`, `token_explicit_max_ttl`).

There are plenty more that are supported by Vault but missing here: https://www.vaultproject.io/api-docs/auth/token#create-update-token-role