### PR TITLE
setup.py: Add encoding for long_description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 def load_long_description():
-    with open("README.md") as fh:
+    with open("README.md", encoding="utf-8") as fh:
         long_description = fh.read()
     return long_description
 


### PR DESCRIPTION
Without an encoding enabled, open() will default to the platform's default encoding. For *nix, this is fine as utf-8 is the default encoding. For windows, the default is CP-1252. This is a problem if something like an emoji is added to the readme, where open() will fail parsing the unicode character. This breaks installing the wheel for Windows machines.

Specifying the encoding as UTF-8 should ensure the README.md can be parsed by both platforms.

Signed-off-by: Colin McAllister <colinmca242@gmail.com>