### PR TITLE
Allow configuring the possible salt lengths for RSA PSS signatures

### DIFF
--- a/hvac/api/secrets_engines/transit.py
+++ b/hvac/api/secrets_engines/transit.py
@@ -753,6 +753,7 @@ class Transit(VaultApiBase):
         prehashed=None,
         signature_algorithm=None,
         marshaling_algorithm=None,
+        salt_length=None,
         mount_point=DEFAULT_MOUNT_POINT,
     ):
         """Return the cryptographic signature of the given data using the named key and the specified hash algorithm.
@@ -788,6 +789,12 @@ class Transit(VaultApiBase):
         :param marshaling_algorithm: Specifies the way in which the signature should be marshaled. This currently only applies to ECDSA keys.
             Supported types are: asn1, jws
         :type marshaling_algorithm: str | unicode
+        :param salt_length: The salt length used to sign. Currently only applies to the RSA PSS signature scheme.
+            Options are 'auto' (the default used by Golang, causing the salt to be as large as possible when signing),
+            'hash' (causes the salt length to equal the length of the hash used in the signature),
+            or an integer between the minimum and the maximum permissible salt lengths for the given RSA key size.
+            Defaults to 'auto'.
+        :type salt_length: str | unicode
         :param mount_point: The "path" the method/backend was mounted on.
         :type mount_point: str | unicode
         :return: The JSON response of the request.
@@ -834,6 +841,17 @@ class Transit(VaultApiBase):
                     ),
                 )
             )
+        if (
+            salt_length is not None
+            and not transit_constants.ALLOWED_SALT_LENGTHS.fullmatch(salt_length)
+        ):
+            error_msg = 'invalid salt_length argument provided "{arg}", supported types: "{allowed_types}"'
+            raise exceptions.ParamValidationError(
+                error_msg.format(
+                    arg=salt_length,
+                    allowed_types=transit_constants.ALLOWED_SALT_LENGTHS.pattern,
+                )
+            )
         params = {
             "input": hash_input,
         }
@@ -846,6 +864,7 @@ class Transit(VaultApiBase):
                     "prehashed": prehashed,
                     "signature_algorithm": signature_algorithm,
                     "marshaling_algorithm": marshaling_algorithm,
+                    "salt_length": salt_length,
                 }
             )
         )
@@ -869,6 +888,7 @@ class Transit(VaultApiBase):
         context=None,
         prehashed=None,
         signature_algorithm=None,
+        salt_length=None,
         marshaling_algorithm=None,
         mount_point=DEFAULT_MOUNT_POINT,
     ):
@@ -902,6 +922,12 @@ class Transit(VaultApiBase):
         :param marshaling_algorithm: Specifies the way in which the signature should be marshaled. This currently only applies to ECDSA keys.
             Supported types are: asn1, jws
         :type marshaling_algorithm: str | unicode
+        :param salt_length: The salt length used to sign. Currently only applies to the RSA PSS signature scheme.
+            Options are 'auto' (the default used by Golang, causing the salt to be as large as possible when signing),
+            'hash' (causes the salt length to equal the length of the hash used in the signature),
+            or an integer between the minimum and the maximum permissible salt lengths for the given RSA key size.
+            Defaults to 'auto'.
+        :type salt_length: str | unicode
         :param mount_point: The "path" the method/backend was mounted on.
         :type mount_point: str | unicode
         :return: The JSON response of the request.
@@ -953,6 +979,17 @@ class Transit(VaultApiBase):
                     ),
                 )
             )
+        if (
+            salt_length is not None
+            and not transit_constants.ALLOWED_SALT_LENGTHS.fullmatch(salt_length)
+        ):
+            error_msg = 'invalid salt_length argument provided "{arg}", supported types: "{allowed_types}"'
+            raise exceptions.ParamValidationError(
+                error_msg.format(
+                    arg=salt_length,
+                    allowed_types=transit_constants.ALLOWED_SALT_LENGTHS.pattern,
+                )
+            )
         params = {
             "name": name,
             "input": hash_input,
@@ -967,6 +1004,7 @@ class Transit(VaultApiBase):
                     "prehashed": prehashed,
                     "signature_algorithm": signature_algorithm,
                     "marshaling_algorithm": marshaling_algorithm,
+                    "salt_length": salt_length,
                 }
             )
         )

--- a/hvac/constants/transit.py
+++ b/hvac/constants/transit.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 """Constants related to the Transit secrets engine."""
 
+import re
+
 ALLOWED_KEY_TYPES = [
     "aes256-gcm96",
     "chacha20-poly1305",
@@ -44,3 +46,7 @@ ALLOWED_MARSHALING_ALGORITHMS = [
     "asn1",
     "jws",
 ]
+
+# https://github.com/hashicorp/vault/pull/16549
+# Either 'auto', 'hash', '-1', or any nonnegative integer.
+ALLOWED_SALT_LENGTHS = re.compile(r"auto|hash|-1|\d+")

--- a/tests/integration_tests/api/secrets_engines/test_transit.py
+++ b/tests/integration_tests/api/secrets_engines/test_transit.py
@@ -590,6 +590,38 @@ class TestTransit(HvacIntegrationTestCase, TestCase):
                 raises=exceptions.ParamValidationError,
                 exception_message="invalid signature_algorithm argument provided",
             ),
+            param(
+                "auto salt length",
+                salt_length="auto",
+            ),
+            param(
+                "hash salt length",
+                salt_length="hash",
+            ),
+            param(
+                "invalid string for salt length",
+                salt_length="foobar",
+                raises=exceptions.ParamValidationError,
+                exception_message="invalid salt_length argument provided",
+            ),
+            param(
+                "invalid negative salt length",
+                salt_length="-2",
+                raises=exceptions.ParamValidationError,
+                exception_message="invalid salt_length argument provided",
+            ),
+            param(
+                "valid negative salt length",
+                salt_length="-1",
+            ),
+            param(
+                "zero salt length",
+                salt_length="0",
+            ),
+            param(
+                "positive salt length",
+                salt_length="1",
+            ),
         ]
     )
     def test_sign_data(
@@ -598,6 +630,7 @@ class TestTransit(HvacIntegrationTestCase, TestCase):
         hash_input="hash this ish",
         hash_algorithm="sha2-256",
         signature_algorithm="pss",
+        salt_length=None,
         raises=False,
         exception_message="",
     ):
@@ -617,6 +650,7 @@ class TestTransit(HvacIntegrationTestCase, TestCase):
                     hash_input=hash_input,
                     hash_algorithm=hash_algorithm,
                     signature_algorithm=signature_algorithm,
+                    salt_length=salt_length,
                     mount_point=self.TEST_MOUNT_POINT,
                 )
             self.assertIn(
@@ -629,6 +663,7 @@ class TestTransit(HvacIntegrationTestCase, TestCase):
                 hash_input=hash_input,
                 hash_algorithm=hash_algorithm,
                 signature_algorithm=signature_algorithm,
+                salt_length=salt_length,
                 mount_point=self.TEST_MOUNT_POINT,
             )
             logging.debug("sign_data_response: %s" % sign_data_response)
@@ -654,6 +689,38 @@ class TestTransit(HvacIntegrationTestCase, TestCase):
                 raises=exceptions.ParamValidationError,
                 exception_message="invalid signature_algorithm argument provided",
             ),
+            param(
+                "auto salt length",
+                verify_salt_length="auto",
+            ),
+            param(
+                "hash salt length",
+                verify_salt_length="hash",
+            ),
+            param(
+                "invalid string for salt length",
+                verify_salt_length="foobar",
+                raises=exceptions.ParamValidationError,
+                exception_message="invalid salt_length argument provided",
+            ),
+            param(
+                "invalid negative salt length",
+                verify_salt_length="-2",
+                raises=exceptions.ParamValidationError,
+                exception_message="invalid salt_length argument provided",
+            ),
+            param(
+                "valid negative salt length",
+                verify_salt_length="-1",
+            ),
+            param(
+                "zero salt length",
+                verify_salt_length="0",
+            ),
+            param(
+                "positive salt length",
+                verify_salt_length="1",
+            ),
         ]
     )
     def test_verify_signed_data(
@@ -662,6 +729,7 @@ class TestTransit(HvacIntegrationTestCase, TestCase):
         hash_input="hash this ish",
         hash_algorithm="sha2-256",
         signature_algorithm="pss",
+        verify_salt_length=None,
         raises=False,
         exception_message="",
     ):
@@ -674,11 +742,18 @@ class TestTransit(HvacIntegrationTestCase, TestCase):
             mount_point=self.TEST_MOUNT_POINT,
         )
         logging.debug("create_key_response: %s" % create_key_response)
+        if raises:
+            # We want the error, possibly related to verify_salt_length,
+            # happen while verifying, not signing.
+            sign_salt_length = "auto"
+        else:
+            sign_salt_length = verify_salt_length
         sign_data_response = self.client.secrets.transit.sign_data(
             name=key_name,
             hash_input=hash_input,
             hash_algorithm="sha2-256",
             signature_algorithm="pss",
+            salt_length=sign_salt_length,
             mount_point=self.TEST_MOUNT_POINT,
         )
         logging.debug("sign_data_response: %s" % sign_data_response)
@@ -691,6 +766,7 @@ class TestTransit(HvacIntegrationTestCase, TestCase):
                     signature=signature,
                     hash_algorithm=hash_algorithm,
                     signature_algorithm=signature_algorithm,
+                    salt_length=verify_salt_length,
                     mount_point=self.TEST_MOUNT_POINT,
                 )
             self.assertIn(
@@ -705,6 +781,7 @@ class TestTransit(HvacIntegrationTestCase, TestCase):
                     signature=signature,
                     hash_algorithm=hash_algorithm,
                     signature_algorithm=signature_algorithm,
+                    salt_length=verify_salt_length,
                     mount_point=self.TEST_MOUNT_POINT,
                 )
             )


### PR DESCRIPTION
The Golang crypto/rsa package [allows](https://pkg.go.dev/crypto/rsa#pkg-constants) for using at least two possible [salt lengths](https://crypto.stackexchange.com/questions/1217/rsa-pss-salt-size) (auto and hash for want better terminology) when creating/verifying RSA PSS signatures. However, these options are currently not exposed via the Vault Transit Secrets Engine and, hence, HVAC. These options would allow for cross-platform signature verification without modifying downstream clients (e.g., the https://github.com/secure-systems-lab/securesystemslib/pull/262 package, used by the [python-tuf](https://github.com/theupdateframework/python-tuf) and [python-in-toto](https://github.com/in-toto/in-toto) supply chain security frameworks, which currently assumes a different salt length by default than Vault does).

This PR is related to Vault PR https://github.com/hashicorp/vault/pull/16549. Assuming that that PR is merged, this PR would update HVAC correspondingly.