### PR TITLE
Handle HTTP 204 empty responses in JSON adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ docs/_build/
 *.iml
 venv/
 .envrc
+.vscode/

--- a/hvac/adapters.py
+++ b/hvac/adapters.py
@@ -366,6 +366,8 @@ class JSONAdapter(RawAdapter):
                 return response.json()
             except ValueError:
                 pass
+        elif response.status_code == 204:
+            return {}
 
         return response
 


### PR DESCRIPTION
Closes #797 
Closes #293 
Closes #385 
Closes #660

Most detail is in #797 . Discussed this a bit on the discord, and we came to the conclusion of returning an empty dict on 204, but looking at #660 and the [documentation it references](https://hvac.readthedocs.io/en/v0.10.10/source/hvac_api_secrets_engines.html#hvac.api.secrets_engines.Identity.lookup_group), there's at least one method that is explicitly saying it will return `None` on no response, so I'm torn again.

It's possible to update the methods to either change their documentation, or to make them interpret the empty dict and return `None` if that's what best for them, or we can default the adapter to return `None`.

Putting up what I have for now with the empty dict return and we can figure out what would be best.