### PR TITLE
.gitignore: Add vscode config directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ docs/_build/
 *.iml
 venv/
 .envrc
+.vscode/


### PR DESCRIPTION
Ensures .vscode configuration directory will be ignored.

Signed-off-by: Colin McAllister <colinmca242@gmail.com>