### PR TITLE
Token: Add create orphaned token method

### DIFF
--- a/hvac/api/auth_methods/token.py
+++ b/hvac/api/auth_methods/token.py
@@ -128,6 +128,102 @@ class Token(VaultApiBase):
             wrap_ttl=wrap_ttl,
         )
 
+    def create_orphan(
+        self,
+        id=None,
+        policies=None,
+        meta=None,
+        no_default_policy=False,
+        renewable=True,
+        ttl=None,
+        type=None,
+        explicit_max_ttl=None,
+        display_name="token",
+        num_uses=0,
+        period=None,
+        entity_alias=None,
+        wrap_ttl=None,
+        mount_point=DEFAULT_MOUNT_POINT,
+    ):
+        """Create a new orphaned token.
+
+        Creates a token via the /auth/token/create-orphan endpoint. A root token
+        is not required to create an orphan token with this endpoint (otherwise
+        an orphaned token can be set with the `create` no_parent option).
+
+
+        :param id: The ID of the client token. Can only be specified by a root token.
+            The ID provided may not contain a `.` character. Otherwise, the
+            token ID is a randomly generated value.
+        :type id: str
+        :param policies: A list of policies for the token. This must be a
+            subset of the policies belonging to the token making the request, unless root.
+            If not specified, defaults to all the policies of the calling token.
+        :type policies: list
+        :param meta: A map of string to string valued metadata. This is
+            passed through to the audit devices.
+        :type meta: map
+        :param no_default_policy: If `True` the default policy will not be contained in this token's policy set.
+        :type no_default_policy: bool
+        :param renewable:  Set to false to disable the ability of the token to be renewed past its initial TTL.
+            Setting the value to true will allow the token to be renewable up to the system/mount maximum TTL.
+        :type renewable: bool
+        :param ttl: The TTL period of the token, provided as "1h", where hour is the largest suffix. If not provided,
+            the token is valid for the default lease TTL, or indefinitely if the root policy is used.
+        :type ttl: str
+        :param type: The token type. Can be "batch" or "service". Defaults to the type
+            specified by the role configuration named by role_name.
+        :type type: str
+        :param explicit_max_ttl: If set, the token will have an explicit max TTL set upon it.
+            This maximum token TTL cannot be changed later, and unlike with normal tokens, updates to the system/mount
+            max TTL value will have no effect at renewal time -- the token will never be able to be renewed or used past
+            the value set at issue time.
+        :type explicit_max_ttl: str
+        :param display_name: The display name of the token.
+        :type display_name: str
+        :param num_uses: The maximum uses for the given token. This can be
+            used to create a one-time-token or limited use token. The value of 0 has no
+            limit to the number of uses.
+        :type num_uses: int
+        :param period: If specified, the token will be periodic; it will have
+            no maximum TTL (unless an "explicit-max-ttl" is also set) but every renewal
+            will use the given period. Requires a root token or one with the sudo capability.
+        :type period: str
+        :param entity_alias: Name of the entity alias to associate with during token creation.
+            Only works in combination with role_name argument and used entity alias must be listed in
+            `allowed_entity_aliases`. If this has been specified, the entity will not be inherited from the parent.
+        :type entity_alias: str
+        :param wrap_ttl: Specifies response wrapping token creation with duration. IE: '15s', '20m', '25h'.
+        :type wrap_ttl: str
+        :param mount_point: The "path" the method/backend was mounted on.
+        :type mount_point: str
+        :return: The response of the create request.
+        :rtype: requests.Response
+        """
+        params = utils.remove_nones(
+            {
+                "id": id,
+                "policies": policies,
+                "meta": meta,
+                "no_default_policy": no_default_policy,
+                "renewable": renewable,
+                "ttl": ttl,
+                "type": type,
+                "explicit_max_ttl": explicit_max_ttl,
+                "display_name": display_name,
+                "num_uses": num_uses,
+                "period": period,
+                "entity_alias": entity_alias,
+            }
+        )
+
+        api_path = f"/v1/auth/{mount_point}/create-orphan"
+        return self._adapter.post(
+            url=api_path,
+            json=params,
+            wrap_ttl=wrap_ttl,
+        )
+
     def list_accessors(self, mount_point=DEFAULT_MOUNT_POINT):
         """List token accessors.
 

--- a/hvac/api/auth_methods/token.py
+++ b/hvac/api/auth_methods/token.py
@@ -149,7 +149,7 @@ class Token(VaultApiBase):
 
         Creates a token via the /auth/token/create-orphan endpoint. A root token
         is not required to create an orphan token with this endpoint (otherwise
-        an orphaned token can be set with the `create` no_parent option).
+        an orphaned token can be set with the `create` method's `no_parent` option).
 
 
         :param id: The ID of the client token. Can only be specified by a root token.
@@ -168,10 +168,10 @@ class Token(VaultApiBase):
         :param renewable:  Set to false to disable the ability of the token to be renewed past its initial TTL.
             Setting the value to true will allow the token to be renewable up to the system/mount maximum TTL.
         :type renewable: bool
-        :param ttl: The TTL period of the token, provided as "1h", where hour is the largest suffix. If not provided,
+        :param ttl: The TTL period of the token, provided as `1h`, where hour is the largest suffix. If not provided,
             the token is valid for the default lease TTL, or indefinitely if the root policy is used.
         :type ttl: str
-        :param type: The token type. Can be "batch" or "service". Defaults to the type
+        :param type: The token type. Can be `batch` or `service`. Defaults to the type
             specified by the role configuration named by role_name.
         :type type: str
         :param explicit_max_ttl: If set, the token will have an explicit max TTL set upon it.
@@ -182,18 +182,18 @@ class Token(VaultApiBase):
         :param display_name: The display name of the token.
         :type display_name: str
         :param num_uses: The maximum uses for the given token. This can be
-            used to create a one-time-token or limited use token. The value of 0 has no
+            used to create a one-time-token or limited use token. The value of `0` has no
             limit to the number of uses.
         :type num_uses: int
         :param period: If specified, the token will be periodic; it will have
-            no maximum TTL (unless an "explicit-max-ttl" is also set) but every renewal
+            no maximum TTL (unless an `explicit-max-ttl` is also set) but every renewal
             will use the given period. Requires a root token or one with the sudo capability.
         :type period: str
         :param entity_alias: Name of the entity alias to associate with during token creation.
             Only works in combination with role_name argument and used entity alias must be listed in
             `allowed_entity_aliases`. If this has been specified, the entity will not be inherited from the parent.
         :type entity_alias: str
-        :param wrap_ttl: Specifies response wrapping token creation with duration. IE: '15s', '20m', '25h'.
+        :param wrap_ttl: Specifies response wrapping token creation with duration. IE: `15s`, `20m`, `25h`.
         :type wrap_ttl: str
         :param mount_point: The "path" the method/backend was mounted on.
         :type mount_point: str


### PR DESCRIPTION
The Vault API allows orphaned tokens to be created without root privileges using the create-orphan endpoint, a separate method should exist to use that endpoint. This allows implementers the choice of using the create endpoint with the no_parent parameter set to true or with the new create_orphan method.

This closes #758

Signed-off-by: Colin McAllister <colinmca242@gmail.com>