### PR TITLE
Test utils: Fix OTP length for Vault >=1.10.0

### DIFF
--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -70,7 +70,9 @@ def get_generate_root_otp():
     :return: OTP to use in generate root operations
     :rtype: str
     """
-    if vault_version_ge("1.0.0"):
+    if vault_version_ge("1.10.0"):
+        test_otp = "BMjzW3wAsEzINXCM05Wbas3u9zSl"
+    elif vault_version_ge("1.0.0"):
         test_otp = "ygs0vL8GIxu0AjRVEmJ5jLCVq8"
     else:
         test_otp = "RSMGkAqBH5WnVLrDTbZ+UQ=="


### PR DESCRIPTION
Token prefixes changed in Vault 1.10.0. get_generate_root_otp is updated to use an OTP length that handles the prefix length change from 2 to 4.

Closes #865

Signed-off-by: Colin McAllister <colinmca242@gmail.com>