### PR TITLE
Improvement: error_msg changed to f-strings

### DIFF
--- a/hvac/api/auth_methods/approle.py
+++ b/hvac/api/auth_methods/approle.py
@@ -85,13 +85,8 @@ class AppRole(VaultApiBase):
         }
 
         if token_type is not None and token_type not in ALLOWED_TOKEN_TYPES:
-            error_msg = 'unsupported token_type argument provided "{arg}", supported types: "{token_types}"'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=token_type,
-                    token_types=",".join(ALLOWED_TOKEN_TYPES),
-                )
-            )
+            error_msg = f'unsupported token_type argument provided "{token_type}", supported types: "{",".join(ALLOWED_TOKEN_TYPES)}"'
+            raise exceptions.ParamValidationError(error_msg)
 
         params = dict()
 
@@ -259,13 +254,8 @@ class AppRole(VaultApiBase):
         :rtype: dict
         """
         if metadata is not None and not isinstance(metadata, dict):
-            error_msg = 'unsupported metadata argument provided "{arg}" ({arg_type}), required type: dict"'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=metadata,
-                    arg_type=type(metadata),
-                )
-            )
+            error_msg = f'unsupported metadata argument provided "{metadata}" ({type(metadata)}), required type: dict"'
+            raise exceptions.ParamValidationError(error_msg)
 
         params = {"metadata": json.dumps(metadata) if metadata else metadata}
 
@@ -319,13 +309,8 @@ class AppRole(VaultApiBase):
         :rtype: dict
         """
         if metadata is not None and not isinstance(metadata, dict):
-            error_msg = 'unsupported metadata argument provided "{arg}" ({arg_type}), required type: dict"'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=metadata,
-                    arg_type=type(metadata),
-                )
-            )
+            error_msg = f'unsupported metadata argument provided "{metadata}" ({type(metadata)}), required type: dict"'
+            raise exceptions.ParamValidationError(error_msg)
 
         params = {"secret_id": secret_id, "metadata": metadata}
 

--- a/hvac/api/auth_methods/aws.py
+++ b/hvac/api/auth_methods/aws.py
@@ -157,19 +157,11 @@ class Aws(VaultApiBase):
         :rtype: request.Response
         """
         if iam_alias is not None and iam_alias not in ALLOWED_IAM_ALIAS_TYPES:
-            error_msg = 'invalid iam alias type provided: "{arg}"; supported iam alias types: "{alias_types}"'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=iam_alias, environments=",".join(ALLOWED_IAM_ALIAS_TYPES)
-                )
-            )
+            error_msg = f'invalid iam alias type provided: "{iam_alias}"; supported iam alias types: "{",".join(ALLOWED_IAM_ALIAS_TYPES)}"'
+            raise exceptions.ParamValidationError(error_msg)
         if ec2_alias is not None and ec2_alias not in ALLOWED_EC2_ALIAS_TYPES:
-            error_msg = 'invalid ec2 alias type provided: "{arg}"; supported ec2 alias types: "{alias_types}"'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=ec2_alias, environments=",".join(ALLOWED_EC2_ALIAS_TYPES)
-                )
-            )
+            error_msg = f'invalid ec2 alias type provided: "{ec2_alias}"; supported ec2 alias types: "{",".join(ALLOWED_EC2_ALIAS_TYPES)}"'
+            raise exceptions.ParamValidationError(error_msg)
         params = utils.remove_nones(
             {
                 "iam_alias": iam_alias,

--- a/hvac/api/auth_methods/azure.py
+++ b/hvac/api/auth_methods/azure.py
@@ -50,13 +50,8 @@ class Azure(VaultApiBase):
         :rtype: requests.Response
         """
         if environment is not None and environment not in VALID_ENVIRONMENTS:
-            error_msg = 'invalid environment argument provided: "{arg}"; supported environments: "{environments}"'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=environment,
-                    environments=",".join(VALID_ENVIRONMENTS),
-                )
-            )
+            error_msg = f'invalid environment argument provided: "{environment}"; supported environments: "{",".join(VALID_ENVIRONMENTS)}"'
+            raise exceptions.ParamValidationError(error_msg)
         params = {
             "tenant_id": tenant_id,
             "resource": resource,
@@ -179,13 +174,8 @@ class Azure(VaultApiBase):
                     and all(isinstance(p, str) for p in policies)
                 )
             ):
-                error_msg = 'unsupported policies argument provided "{arg}" ({arg_type}), required type: str or List[str]"'
-                raise exceptions.ParamValidationError(
-                    error_msg.format(
-                        arg=policies,
-                        arg_type=type(policies),
-                    )
-                )
+                error_msg = f'unsupported policies argument provided "{policies}" ({type(policies)}), required type: str or List[str]"'
+                raise exceptions.ParamValidationError(error_msg)
         params = utils.remove_nones(
             {
                 "policies": policies,

--- a/hvac/api/auth_methods/gcp.py
+++ b/hvac/api/auth_methods/gcp.py
@@ -206,13 +206,8 @@ class Gcp(VaultApiBase):
             )
 
         if role_type not in ALLOWED_ROLE_TYPES:
-            error_msg = 'unsupported role_type argument provided "{arg}", supported types: "{role_types}"'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=type,
-                    role_types=",".join(ALLOWED_ROLE_TYPES),
-                )
-            )
+            error_msg = f'unsupported role_type argument provided "{role_type}", supported types: "{",".join(ALLOWED_ROLE_TYPES)}"'
+            raise exceptions.ParamValidationError(error_msg)
 
         params = {
             "type": role_type,

--- a/hvac/api/auth_methods/github.py
+++ b/hvac/api/auth_methods/github.py
@@ -104,13 +104,8 @@ class Github(VaultApiBase):
         if not isinstance(policies, list) or not all(
             isinstance(p, str) for p in policies
         ):
-            error_msg = 'unsupported policies argument provided "{arg}" ({arg_type}), required type: List[str]"'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=policies,
-                    arg_type=type(policies),
-                )
-            )
+            error_msg = f'unsupported policies argument provided "{policies}" ({type(policies)}), required type: List[str]"'
+            raise exceptions.ParamValidationError(error_msg)
         # Then, perform request.
         params = {
             "value": ",".join(policies),
@@ -168,13 +163,8 @@ class Github(VaultApiBase):
         if not isinstance(policies, list) or not all(
             isinstance(p, str) for p in policies
         ):
-            error_msg = 'unsupported policies argument provided "{arg}" ({arg_type}), required type: List[str]"'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=policies,
-                    arg_type=type(policies),
-                )
-            )
+            error_msg = f'unsupported policies argument provided "{policies}" ({type(policies)}), required type: List[str]"'
+            raise exceptions.ParamValidationError(error_msg)
 
         # Then, perform request.
         params = {

--- a/hvac/api/auth_methods/mfa.py
+++ b/hvac/api/auth_methods/mfa.py
@@ -41,13 +41,8 @@ class Mfa(VaultApiBase):
         if mfa_type != "duo" and not force:
             # The situation described via this exception is not likely to change in the future.
             # However we provided that flexibility here just in case.
-            error_msg = 'Unsupported mfa_type argument provided "{arg}", supported types: "{mfa_types}"'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    mfa_types=",".join(SUPPORTED_MFA_TYPES),
-                    arg=mfa_type,
-                )
-            )
+            error_msg = f'Unsupported mfa_type argument provided "{mfa_type}", supported types: "{",".join(SUPPORTED_MFA_TYPES)}"'
+            raise exceptions.ParamValidationError(error_msg)
         params = {
             "type": mfa_type,
         }

--- a/hvac/api/secrets_engines/aws.py
+++ b/hvac/api/secrets_engines/aws.py
@@ -217,13 +217,8 @@ class Aws(VaultApiBase):
         :rtype: requests.Response
         """
         if credential_type not in ALLOWED_CREDS_TYPES:
-            error_msg = 'invalid credential_type argument provided "{arg}", supported types: "{allowed_types}"'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=credential_type,
-                    allowed_types=", ".join(ALLOWED_CREDS_TYPES),
-                )
-            )
+            error_msg = f'invalid credential_type argument provided "{credential_type}", supported types: "{", ".join(ALLOWED_CREDS_TYPES)}"'
+            raise exceptions.ParamValidationError(error_msg)
         if isinstance(policy_document, dict):
             policy_document = json.dumps(policy_document, indent=4, sort_keys=True)
 
@@ -364,13 +359,8 @@ class Aws(VaultApiBase):
         :rtype: dict
         """
         if endpoint not in ALLOWED_CREDS_ENDPOINTS:
-            error_msg = 'invalid endpoint argument provided "{arg}", supported types: "{allowed_endpoints}"'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=endpoint,
-                    allowed_endpoints=", ".join(ALLOWED_CREDS_ENDPOINTS),
-                )
-            )
+            error_msg = f'invalid endpoint argument provided "{endpoint}", supported types: "{", ".join(ALLOWED_CREDS_ENDPOINTS)}"'
+            raise exceptions.ParamValidationError(error_msg)
         params = {
             "name": name,
         }

--- a/hvac/api/secrets_engines/azure.py
+++ b/hvac/api/secrets_engines/azure.py
@@ -49,13 +49,8 @@ class Azure(VaultApiBase):
         :rtype: requests.Response
         """
         if environment is not None and environment not in VALID_ENVIRONMENTS:
-            error_msg = 'invalid environment argument provided "{arg}", supported environments: "{environments}"'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=environment,
-                    environments=",".join(VALID_ENVIRONMENTS),
-                )
-            )
+            error_msg = f'invalid environment argument provided "{environment}", supported environments: "{",".join(VALID_ENVIRONMENTS)}"'
+            raise exceptions.ParamValidationError(error_msg)
         params = {
             "subscription_id": subscription_id,
             "tenant_id": tenant_id,

--- a/hvac/api/secrets_engines/gcp.py
+++ b/hvac/api/secrets_engines/gcp.py
@@ -107,13 +107,8 @@ class Gcp(VaultApiBase):
         :rtype: requests.Response
         """
         if secret_type is not None and secret_type not in ALLOWED_SECRETS_TYPES:
-            error_msg = 'unsupported secret_type argument provided "{arg}", supported types: "{secret_type}"'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=secret_type,
-                    secret_type=",".join(ALLOWED_SECRETS_TYPES),
-                )
-            )
+            error_msg = f'unsupported secret_type argument provided "{secret_type}", supported types: "{",".join(ALLOWED_SECRETS_TYPES)}"'
+            raise exceptions.ParamValidationError(error_msg)
 
         if isinstance(bindings, dict):
             bindings = json.dumps(bindings).replace(" ", "")
@@ -315,21 +310,11 @@ class Gcp(VaultApiBase):
 
         if method == "POST":
             if key_algorithm not in SERVICE_ACCOUNT_KEY_ALGORITHMS:
-                error_msg = 'unsupported key_algorithm argument provided "{arg}", supported algorithms: "{algorithms}"'
-                raise exceptions.ParamValidationError(
-                    error_msg.format(
-                        arg=key_algorithm,
-                        algorithms=",".join(SERVICE_ACCOUNT_KEY_ALGORITHMS),
-                    )
-                )
+                error_msg = f'unsupported key_algorithm argument provided "{key_algorithm}", supported algorithms: "{",".join(SERVICE_ACCOUNT_KEY_ALGORITHMS)}"'
+                raise exceptions.ParamValidationError(error_msg)
             if key_type not in SERVICE_ACCOUNT_KEY_TYPES:
-                error_msg = 'unsupported key_type argument provided "{arg}", supported types: "{key_types}"'
-                raise exceptions.ParamValidationError(
-                    error_msg.format(
-                        arg=key_type,
-                        key_types=",".join(SERVICE_ACCOUNT_KEY_TYPES),
-                    )
-                )
+                error_msg = f'unsupported key_type argument provided "{key_type}", supported types: "{",".join(SERVICE_ACCOUNT_KEY_TYPES)}"'
+                raise exceptions.ParamValidationError(error_msg)
             params = {
                 "key_algorithm": key_algorithm,
                 "key_type": key_type,

--- a/hvac/api/secrets_engines/identity.py
+++ b/hvac/api/secrets_engines/identity.py
@@ -48,13 +48,8 @@ class Identity(VaultApiBase):
         :rtype: dict | requests.Response
         """
         if metadata is not None and not isinstance(metadata, dict):
-            error_msg = 'unsupported metadata argument provided "{arg}" ({arg_type}), required type: dict"'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=metadata,
-                    arg_type=type(metadata),
-                )
-            )
+            error_msg = f'unsupported metadata argument provided "{metadata}" ({type(metadata)}), required type: dict"'
+            raise exceptions.ParamValidationError(error_msg)
         params = utils.remove_nones(
             {
                 "id": entity_id,
@@ -98,13 +93,8 @@ class Identity(VaultApiBase):
         :rtype: requests.Response | dict
         """
         if metadata is not None and not isinstance(metadata, dict):
-            error_msg = 'unsupported metadata argument provided "{arg}" ({arg_type}), required type: dict"'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=metadata,
-                    arg_type=type(metadata),
-                )
-            )
+            error_msg = 'unsupported metadata argument provided "{metadata}" ({type(metadata)}), required type: dict"'
+            raise exceptions.ParamValidationError(error_msg)
         params = utils.remove_nones(
             {
                 "metadata": metadata,
@@ -195,13 +185,8 @@ class Identity(VaultApiBase):
         :rtype: dict | requests.Response
         """
         if metadata is not None and not isinstance(metadata, dict):
-            error_msg = 'unsupported metadata argument provided "{arg}" ({arg_type}), required type: dict"'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=metadata,
-                    arg_type=type(metadata),
-                )
-            )
+            error_msg = f'unsupported metadata argument provided "{metadata}" ({type(metadata)}), required type: dict"'
+            raise exceptions.ParamValidationError(error_msg)
         params = utils.remove_nones(
             {
                 "name": name,
@@ -614,21 +599,11 @@ class Identity(VaultApiBase):
         :rtype: dict | requests.Response
         """
         if metadata is not None and not isinstance(metadata, dict):
-            error_msg = 'unsupported metadata argument provided "{arg}" ({arg_type}), required type: dict"'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=metadata,
-                    arg_type=type(metadata),
-                )
-            )
+            error_msg = f'unsupported metadata argument provided "{metadata}" ({type(metadata)}), required type: dict"'
+            raise exceptions.ParamValidationError(error_msg)
         if group_type not in ALLOWED_GROUP_TYPES:
-            error_msg = 'unsupported group_type argument provided "{arg}", allowed values: ({allowed_values})'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=group_type,
-                    allowed_values=ALLOWED_GROUP_TYPES,
-                )
-            )
+            error_msg = f'unsupported group_type argument provided "{group_type}", allowed values: ({ALLOWED_GROUP_TYPES})'
+            raise exceptions.ParamValidationError(error_msg)
         params = utils.remove_nones(
             {
                 "id": group_id,
@@ -710,21 +685,11 @@ class Identity(VaultApiBase):
         :rtype: dict | requests.Response
         """
         if metadata is not None and not isinstance(metadata, dict):
-            error_msg = 'unsupported metadata argument provided "{arg}" ({arg_type}), required type: dict"'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=metadata,
-                    arg_type=type(metadata),
-                )
-            )
+            error_msg = f'unsupported metadata argument provided "{metadata}" ({type(metadata)}), required type: dict"'
+            raise exceptions.ParamValidationError(error_msg)
         if group_type not in ALLOWED_GROUP_TYPES:
-            error_msg = 'unsupported group_type argument provided "{arg}", allowed values: ({allowed_values})'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=group_type,
-                    allowed_values=ALLOWED_GROUP_TYPES,
-                )
-            )
+            error_msg = f'unsupported group_type argument provided "{group_type}", allowed values: ({ALLOWED_GROUP_TYPES})'
+            raise exceptions.ParamValidationError(error_msg)
         params = utils.remove_nones(
             {
                 "name": name,
@@ -879,21 +844,11 @@ class Identity(VaultApiBase):
         """
 
         if metadata is not None and not isinstance(metadata, dict):
-            error_msg = 'unsupported metadata argument provided "{arg}" ({arg_type}), required type: dict"'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=metadata,
-                    arg_type=type(metadata),
-                )
-            )
+            error_msg = 'unsupported metadata argument provided "{metadata}" ({type(metadata)}), required type: dict"'
+            raise exceptions.ParamValidationError(error_msg)
         if group_type not in ALLOWED_GROUP_TYPES:
-            error_msg = 'unsupported group_type argument provided "{arg}", allowed values: ({allowed_values})'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=group_type,
-                    allowed_values=ALLOWED_GROUP_TYPES,
-                )
-            )
+            error_msg = f'unsupported group_type argument provided "{group_type}", allowed values: ({ALLOWED_GROUP_TYPES})'
+            raise exceptions.ParamValidationError(error_msg)
         params = utils.remove_nones(
             {
                 "type": group_type,

--- a/hvac/api/secrets_engines/transit.py
+++ b/hvac/api/secrets_engines/transit.py
@@ -67,13 +67,8 @@ class Transit(VaultApiBase):
                 "derived must be set to True when convergent_encryption is True"
             )
         if key_type is not None and key_type not in transit_constants.ALLOWED_KEY_TYPES:
-            error_msg = 'invalid key_type argument provided "{arg}", supported types: "{allowed_types}"'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=key_type,
-                    allowed_types=", ".join(transit_constants.ALLOWED_KEY_TYPES),
-                )
-            )
+            error_msg = f'invalid key_type argument provided "{key_type}", supported types: "{", ".join(transit_constants.ALLOWED_KEY_TYPES)}"'
+            raise exceptions.ParamValidationError(error_msg)
         params = utils.remove_nones(
             {
                 "convergent_encryption": convergent_encryption,
@@ -284,13 +279,8 @@ class Transit(VaultApiBase):
         :rtype: dict
         """
         if key_type not in transit_constants.ALLOWED_EXPORT_KEY_TYPES:
-            error_msg = 'invalid key_type argument provided "{arg}", supported types: "{allowed_types}"'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=key_type,
-                    allowed_types=", ".join(transit_constants.ALLOWED_EXPORT_KEY_TYPES),
-                )
-            )
+            error_msg = f'invalid key_type argument provided "{key_type}", supported types: "{", ".join(transit_constants.ALLOWED_EXPORT_KEY_TYPES)}"'
+            raise exceptions.ParamValidationError(error_msg)
         api_path = utils.format_url(
             "/v1/{mount_point}/export/{key_type}/{name}",
             mount_point=mount_point,
@@ -545,23 +535,11 @@ class Transit(VaultApiBase):
         :rtype: dict
         """
         if key_type not in transit_constants.ALLOWED_DATA_KEY_TYPES:
-            error_msg = 'invalid key_type argument provided "{arg}", supported types: "{allowed_types}"'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=key_type,
-                    allowed_types=", ".join(transit_constants.ALLOWED_DATA_KEY_TYPES),
-                )
-            )
+            error_msg = f'invalid key_type argument provided "{key_type}", supported types: "{", ".join(transit_constants.ALLOWED_DATA_KEY_TYPES)}"'
+            raise exceptions.ParamValidationError(error_msg)
         if bits is not None and bits not in transit_constants.ALLOWED_DATA_KEY_BITS:
-            error_msg = 'invalid bits argument provided "{arg}", supported values: "{allowed_values}"'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=bits,
-                    allowed_values=", ".join(
-                        [str(b) for b in transit_constants.ALLOWED_DATA_KEY_BITS]
-                    ),
-                )
-            )
+            error_msg = f'invalid bits argument provided "{bits}", supported values: "{", ".join([str(b) for b in transit_constants.ALLOWED_DATA_KEY_BITS])}"'
+            raise exceptions.ParamValidationError(error_msg)
         params = utils.remove_nones(
             {
                 "context": context,
@@ -638,28 +616,14 @@ class Transit(VaultApiBase):
             algorithm is not None
             and algorithm not in transit_constants.ALLOWED_HASH_DATA_ALGORITHMS
         ):
-            error_msg = 'invalid algorithm argument provided "{arg}", supported types: "{allowed_types}"'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=algorithm,
-                    allowed_types=", ".join(
-                        transit_constants.ALLOWED_HASH_DATA_ALGORITHMS
-                    ),
-                )
-            )
+            error_msg = f'invalid algorithm argument provided "{algorithm}", supported types: "{", ".join(transit_constants.ALLOWED_HASH_DATA_ALGORITHMS)}"'
+            raise exceptions.ParamValidationError(error_msg)
         if (
             output_format is not None
             and output_format not in transit_constants.ALLOWED_HASH_DATA_FORMATS
         ):
-            error_msg = 'invalid output_format argument provided "{arg}", supported types: "{allowed_types}"'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=output_format,
-                    allowed_types=", ".join(
-                        transit_constants.ALLOWED_HASH_DATA_FORMATS
-                    ),
-                )
-            )
+            error_msg = f'invalid output_format argument provided "{output_format}", supported types: "{", ".join(transit_constants.ALLOWED_HASH_DATA_FORMATS)}"'
+            raise exceptions.ParamValidationError(error_msg)
         params = {
             "input": hash_input,
         }
@@ -713,15 +677,8 @@ class Transit(VaultApiBase):
             algorithm is not None
             and algorithm not in transit_constants.ALLOWED_HASH_DATA_ALGORITHMS
         ):
-            error_msg = 'invalid algorithm argument provided "{arg}", supported types: "{allowed_types}"'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=algorithm,
-                    allowed_types=", ".join(
-                        transit_constants.ALLOWED_HASH_DATA_ALGORITHMS
-                    ),
-                )
-            )
+            error_msg = f'invalid algorithm argument provided "{algorithm}", supported types: "{", ".join(transit_constants.ALLOWED_HASH_DATA_ALGORITHMS)}"'
+            raise exceptions.ParamValidationError(error_msg)
         params = {
             "input": hash_input,
         }
@@ -804,54 +761,28 @@ class Transit(VaultApiBase):
             hash_algorithm is not None
             and hash_algorithm not in transit_constants.ALLOWED_HASH_DATA_ALGORITHMS
         ):
-            error_msg = 'invalid hash_algorithm argument provided "{arg}", supported types: "{allowed_types}"'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=hash_algorithm,
-                    allowed_types=", ".join(
-                        transit_constants.ALLOWED_HASH_DATA_ALGORITHMS
-                    ),
-                )
-            )
+            error_msg = f'invalid hash_algorithm argument provided "{hash_algorithm}", supported types: "{", ".join(transit_constants.ALLOWED_HASH_DATA_ALGORITHMS)}"'
+            raise exceptions.ParamValidationError(error_msg)
         if (
             signature_algorithm is not None
             and signature_algorithm
             not in transit_constants.ALLOWED_SIGNATURE_ALGORITHMS
         ):
-            error_msg = 'invalid signature_algorithm argument provided "{arg}", supported types: "{allowed_types}"'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=signature_algorithm,
-                    allowed_types=", ".join(
-                        transit_constants.ALLOWED_SIGNATURE_ALGORITHMS
-                    ),
-                )
-            )
+            error_msg = f'invalid signature_algorithm argument provided "{signature_algorithm}", supported types: "{", ".join(transit_constants.ALLOWED_SIGNATURE_ALGORITHMS)}"'
+            raise exceptions.ParamValidationError(error_msg)
         if (
             marshaling_algorithm is not None
             and marshaling_algorithm
             not in transit_constants.ALLOWED_MARSHALING_ALGORITHMS
         ):
-            error_msg = 'invalid marshaling_algorithm argument provided "{arg}", supported types: "{allowed_types}"'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=marshaling_algorithm,
-                    allowed_types=", ".join(
-                        transit_constants.ALLOWED_MARSHALING_ALGORITHMS
-                    ),
-                )
-            )
+            error_msg = f'invalid marshaling_algorithm argument provided "{marshaling_algorithm}", supported types: "{", ".join(transit_constants.ALLOWED_MARSHALING_ALGORITHMS)}"'
+            raise exceptions.ParamValidationError(error_msg)
         if (
             salt_length is not None
             and not transit_constants.ALLOWED_SALT_LENGTHS.fullmatch(salt_length)
         ):
-            error_msg = 'invalid salt_length argument provided "{arg}", supported types: "{allowed_types}"'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=salt_length,
-                    allowed_types=transit_constants.ALLOWED_SALT_LENGTHS.pattern,
-                )
-            )
+            error_msg = f'invalid salt_length argument provided "{salt_length}", supported types: "{transit_constants.ALLOWED_SALT_LENGTHS.pattern}"'
+            raise exceptions.ParamValidationError(error_msg)
         params = {
             "input": hash_input,
         }
@@ -942,54 +873,28 @@ class Transit(VaultApiBase):
             hash_algorithm is not None
             and hash_algorithm not in transit_constants.ALLOWED_HASH_DATA_ALGORITHMS
         ):
-            error_msg = 'invalid hash_algorithm argument provided "{arg}", supported types: "{allowed_types}"'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=hash_algorithm,
-                    allowed_types=", ".join(
-                        transit_constants.ALLOWED_HASH_DATA_ALGORITHMS
-                    ),
-                )
-            )
+            error_msg = f'invalid hash_algorithm argument provided "{hash_algorithm}", supported types: "{", ".join(transit_constants.ALLOWED_HASH_DATA_ALGORITHMS)}"'
+            raise exceptions.ParamValidationError(error_msg)
         if (
             signature_algorithm is not None
             and signature_algorithm
             not in transit_constants.ALLOWED_SIGNATURE_ALGORITHMS
         ):
-            error_msg = 'invalid signature_algorithm argument provided "{arg}", supported types: "{allowed_types}"'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=signature_algorithm,
-                    allowed_types=", ".join(
-                        transit_constants.ALLOWED_SIGNATURE_ALGORITHMS
-                    ),
-                )
-            )
+            error_msg = f'invalid signature_algorithm argument provided "{signature_algorithm}", supported types: "{", ".join(transit_constants.ALLOWED_SIGNATURE_ALGORITHMS)}"'
+            raise exceptions.ParamValidationError(error_msg)
         if (
             marshaling_algorithm is not None
             and marshaling_algorithm
             not in transit_constants.ALLOWED_MARSHALING_ALGORITHMS
         ):
-            error_msg = 'invalid marshaling_algorithm argument provided "{arg}", supported types: "{allowed_types}"'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=marshaling_algorithm,
-                    allowed_types=", ".join(
-                        transit_constants.ALLOWED_MARSHALING_ALGORITHMS
-                    ),
-                )
-            )
+            error_msg = f'invalid marshaling_algorithm argument provided "{marshaling_algorithm}", supported types: "{", ".join(transit_constants.ALLOWED_MARSHALING_ALGORITHMS)}"'
+            raise exceptions.ParamValidationError(error_msg)
         if (
             salt_length is not None
             and not transit_constants.ALLOWED_SALT_LENGTHS.fullmatch(salt_length)
         ):
-            error_msg = 'invalid salt_length argument provided "{arg}", supported types: "{allowed_types}"'
-            raise exceptions.ParamValidationError(
-                error_msg.format(
-                    arg=salt_length,
-                    allowed_types=transit_constants.ALLOWED_SALT_LENGTHS.pattern,
-                )
-            )
+            error_msg = f'invalid salt_length argument provided "{salt_length}", supported types: "{transit_constants.ALLOWED_SALT_LENGTHS.pattern}"'
+            raise exceptions.ParamValidationError(error_msg)
         params = {
             "name": name,
             "input": hash_input,

--- a/hvac/utils.py
+++ b/hvac/utils.py
@@ -236,14 +236,8 @@ def validate_list_of_strings_param(param_name, param_argument):
     if not isinstance(param_argument, list) or not all(
         isinstance(p, str) for p in param_argument
     ):
-        error_msg = 'unsupported {param} argument provided "{arg}" ({arg_type}), required type: List[str]'
-        raise exceptions.ParamValidationError(
-            error_msg.format(
-                param=param_name,
-                arg=param_argument,
-                arg_type=type(param_argument),
-            )
-        )
+        error_msg = f'unsupported {param_name} argument provided "{param_argument}" ({type(param_argument)}), required type: List[str]'
+        raise exceptions.ParamValidationError(error_msg)
 
 
 def list_to_comma_delimited(list_param):
@@ -319,10 +313,8 @@ def validate_pem_format(param_name, param_argument):
     if not isinstance(param_argument, list) or not all(
         _check_pem(p) for p in param_argument
     ):
-        error_msg = (
-            "unsupported {param} public key / certificate format, required type: PEM"
-        )
-        raise exceptions.ParamValidationError(error_msg.format(param=param_name))
+        error_msg = (f"unsupported {param_name} public key / certificate format, required type: PEM")
+        raise exceptions.ParamValidationError(error_msg)
 
 
 def remove_nones(params):


### PR DESCRIPTION
As @colin-pm suggested in https://github.com/hvac/hvac/pull/873#discussion_r968735250,
updating `error_msg` to f-string