### PR TITLE
Tests: Handle different response due to upstream change

### DIFF
--- a/tests/integration_tests/api/secrets_engines/test_identity.py
+++ b/tests/integration_tests/api/secrets_engines/test_identity.py
@@ -1061,7 +1061,11 @@ class TestIdentity(HvacIntegrationTestCase, TestCase):
                     second=member_group_ids,
                 )
                 expected_member_entity_ids = (
-                    member_entity_ids if member_entity_ids is not None else []
+                    member_entity_ids
+                    if member_entity_ids is not None
+                    else []
+                    if group_type == "external" and utils.vault_version_lt("1.11")
+                    else None
                 )
                 self.assertEqual(
                     first=read_group_response["data"]["member_entity_ids"],


### PR DESCRIPTION
An external group type with no populated members returns null for member_entity_ids instead of an empty list starting in Vault 1.11.

The failing test that discovered this API change has been updated to handle null.

This closes #862 if no other solution is identified upstream in hashicorp/vault#17107

Signed-off-by: Colin McAllister <colinmca242@gmail.com>