### PR TITLE
Tests: Fix Azure test failure

### DIFF
--- a/tests/integration_tests/api/secrets_engines/test_azure.py
+++ b/tests/integration_tests/api/secrets_engines/test_azure.py
@@ -103,8 +103,16 @@ class TestAzure(HvacIntegrationTestCase, TestCase):
             mount_point=self.DEFAULT_MOUNT_POINT,
         )
         logging.debug("read_configuration_response: %s" % read_configuration_response)
-        for key in read_configuration_response.keys():
-            self.assertEqual(
-                first="",
-                second=read_configuration_response[key],
-            )
+        read_expected_response = {
+            "client_id": "",
+            "environment": "",
+            "subscription_id": "",
+            "tenant_id": "",
+        }
+        if utils.vault_version_ge("1.9.0"):
+            read_expected_response["root_password_ttl"] = 0
+            read_expected_response["use_microsoft_graph_api"] = False
+        self.assertEqual(
+            first=read_expected_response,
+            second=read_configuration_response,
+        )


### PR DESCRIPTION
Vault 1.9.0 introduced the root_password_ttl and use_microsoft_graph_api parameters in the read configuration response for the Azure security engine. The default values are not empty strings, so the asserts are updated to handle these two new parameters.

Signed-off-by: Colin McAllister <colinmca242@gmail.com>

This closes #861