### PR TITLE
Tests: Fix broken oidc test

### DIFF
--- a/tests/integration_tests/api/auth_methods/test_oidc.py
+++ b/tests/integration_tests/api/auth_methods/test_oidc.py
@@ -197,6 +197,9 @@ class TestOIDC(HvacIntegrationTestCase, TestCase):
             )
         id_token_role_name = "hvac-oidc-test"
         key_name = "oidc-test-key"
+        create_named_key_response = self.client.secrets.identity.create_named_key(
+            name=key_name,
+        )
         create_or_update_role_response = (
             self.client.secrets.identity.create_or_update_role(
                 name=id_token_role_name,


### PR DESCRIPTION
It appears that when creating a identity role for OIDC, Vault ensures that the key exists. In order to fix the error, an additonal step was added in the broken test to create the key assigned to the role.

Signed-off-by: Colin McAllister <colinmca242@gmail.com>

Closes #860