### PR TITLE
Tests: Fix kubernetes integration test

### DIFF
--- a/tests/integration_tests/api/auth_methods/test_kubernetes.py
+++ b/tests/integration_tests/api/auth_methods/test_kubernetes.py
@@ -55,7 +55,9 @@ class TestKubernetes(HvacIntegrationTestCase, TestCase):
                 token_reviewer_jwt="reviewer_jwt",
                 issuer="bob",
                 raises=exceptions.InternalServerError,
-                exception_message="* not a compact JWS",
+                exception_message="* not a compact JWS"
+                if utils.vault_version_lt("1.11.0")
+                else "compact JWS format must have three parts",
             ),
         ]
     )


### PR DESCRIPTION
The error message returned when configuring the Kubernetes auth engine changed in Vault 1.11 when sending an invalid JWT. The test has been updated to expect the latest error message.

Signed-off-by: Colin McAllister <colinmca242@gmail.com>

Closes #858