### PR TITLE
Tests: Handle 204 response in jwt test

### DIFF
--- a/tests/integration_tests/api/auth_methods/test_jwt.py
+++ b/tests/integration_tests/api/auth_methods/test_jwt.py
@@ -108,10 +108,16 @@ class TestJWT(HvacIntegrationTestCase, TestCase):
             path=self.TEST_JWT_PATH,
         )
         logging.debug("create_role response: %s" % response)
-        self.assertIn(
-            member="data",
-            container=response,
-        )
+        if utils.vault_version_lt("1.11"):
+            self.assertIn(
+                member="data",
+                container=response,
+            )
+        else:
+            self.assertEqual(
+                204,
+                response.status_code,
+            )
 
     @parameterized.expand(
         [


### PR DESCRIPTION
The create role test fails because a 204 response is returned by the Vault API when the role is created. As of Vault 1.11, the 204 response does not contain data, which was expected in the test.

Reworked the test to validate success by the return code for Vault versions 1.11 and greater.

Signed-off-by: Colin McAllister <colinmca242@gmail.com>

Closes #857 until a better solution is implemented (#847)