### PR TITLE
CI: Update Vault versions for integration tests

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -178,10 +178,14 @@ jobs:
         python-version:
           - 3.7
         vault-version:
-          - 1.4.7
-          - 1.5.9
-          - 1.6.5
-          - 1.7.2
+          - "vault-enterprise=1.6.5+ent"
+          - "vault-enterprise=1.7.2+ent"
+          - "vault=1.6.5"
+          - "vault=1.7.2"
+          - "vault=1.8.0"
+          - "vault=1.9.0"
+          - "vault=1.10.0"
+          - "vault=1.11.0-1"
 
     steps:
     - uses: actions/checkout@v3
@@ -225,7 +229,7 @@ jobs:
 
         sudo apt install \
           consul \
-          vault-enterprise=${{ matrix.vault-version }}+ent \
+          ${{ matrix.vault-version }} \
           ;
 
         # We disble cap_ipc_lock here as its generally incompatabile with GitHub

--- a/tests/integration_tests/api/secrets_engines/test_identity.py
+++ b/tests/integration_tests/api/secrets_engines/test_identity.py
@@ -1064,7 +1064,7 @@ class TestIdentity(HvacIntegrationTestCase, TestCase):
                     member_entity_ids
                     if member_entity_ids is not None
                     else []
-                    if group_type == "external" and utils.vault_version_lt("1.11")
+                    if group_type == "external" and utils.vault_version_lt("1.11.1")
                     else None
                 )
                 self.assertEqual(


### PR DESCRIPTION
Remove Vault versions no longer supported by Hashicorp and add latest versions.

Since we do not have a key to use Vault Enterprise, integration testing from v1.8.0 onwards will use Open Source Vault.

Signed-off-by: Colin McAllister <colinmca242@gmail.com>

Closes #851