### PR TITLE
docs: Add RTD config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,20 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.6"
+
+sphinx:
+   configuration: docs/conf.py
+
+# Optionally declare the Python requirements required to build your docs
+python:
+  install:
+    - requirements: docs/requirements.txt
+    - method: pip
+      path: .

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,15 @@
+# Requirements.txt file for Read the Docs
+autodocsumm==0.1.13
+m2r2==0.2.5
+mistune==0.8.4
+python-ldap-test==0.3.1
+requests-mock==1.9.3
+six==1.16.0
+sphinx-rtd-theme==0.5.0
+sphinx==3.1.2
+sphinxcontrib-applehelp==1.0.2
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.0
+sphinxcontrib-jsmath==1.0.1
+sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-serializinghtml==1.1.5


### PR DESCRIPTION
Upgrading to Poetry broke RTD's ability to build the docs.

Adds Readthedocs config file to properly build documentation.

Signed-off-by: Colin McAllister <colinmca242@gmail.com>