### PR TITLE
Allow for reading deleted secret versions (kv2) without an exception

### DIFF
--- a/hvac/adapters.py
+++ b/hvac/adapters.py
@@ -309,16 +309,31 @@ class RawAdapter(Adapter):
         )
 
         if not response.ok and (raise_exception and not self.ignore_exceptions):
-            text = errors = None
+            msg = json = text = errors = None
+            try:
+                text = response.text
+            except Exception:
+                pass
+
             if response.headers.get("Content-Type") == "application/json":
                 try:
-                    errors = response.json().get("errors")
+                    json = response.json()
                 except Exception:
                     pass
+                else:
+                    errors = json.get("errors")
+
             if errors is None:
-                text = response.text
+                msg = response.text
+
             utils.raise_for_error(
-                method, url, response.status_code, text, errors=errors
+                method,
+                url,
+                response.status_code,
+                msg,
+                errors=errors,
+                text=text,
+                json=json,
             )
 
         return response

--- a/hvac/adapters.py
+++ b/hvac/adapters.py
@@ -324,7 +324,7 @@ class RawAdapter(Adapter):
                     errors = json.get("errors")
 
             if errors is None:
-                msg = response.text
+                msg = text
 
             utils.raise_for_error(
                 method,

--- a/hvac/adapters.py
+++ b/hvac/adapters.py
@@ -237,6 +237,34 @@ class RawAdapter(Adapter):
     but always returns Response objects for requests.
     """
 
+    def _raise_for_error(self, method: str, url: str, response: requests.Response):
+        msg = json = text = errors = None
+        try:
+            text = response.text
+        except Exception:
+            pass
+
+        if response.headers.get("Content-Type") == "application/json":
+            try:
+                json = response.json()
+            except Exception:
+                pass
+            else:
+                errors = json.get("errors")
+
+        if errors is None:
+            msg = text
+
+        utils.raise_for_error(
+            method,
+            url,
+            response.status_code,
+            msg,
+            errors=errors,
+            text=text,
+            json=json,
+        )
+
     def get_login_token(self, response):
         """Extracts the client token from a login response.
 
@@ -309,32 +337,7 @@ class RawAdapter(Adapter):
         )
 
         if not response.ok and (raise_exception and not self.ignore_exceptions):
-            msg = json = text = errors = None
-            try:
-                text = response.text
-            except Exception:
-                pass
-
-            if response.headers.get("Content-Type") == "application/json":
-                try:
-                    json = response.json()
-                except Exception:
-                    pass
-                else:
-                    errors = json.get("errors")
-
-            if errors is None:
-                msg = text
-
-            utils.raise_for_error(
-                method,
-                url,
-                response.status_code,
-                msg,
-                errors=errors,
-                text=text,
-                json=json,
-            )
+            self._raise_for_error(method, url, response)
 
         return response
 

--- a/hvac/api/secrets_engines/kv_v2.py
+++ b/hvac/api/secrets_engines/kv_v2.py
@@ -2,7 +2,6 @@
 """KvV2 methods module."""
 from hvac import exceptions, utils
 from hvac.api.vault_api_base import VaultApiBase
-from requests import Response
 
 DEFAULT_MOUNT_POINT = "secret"
 
@@ -95,37 +94,10 @@ class KvV2(VaultApiBase):
         api_path = utils.format_url(
             "/v1/{mount_point}/data/{path}", mount_point=mount_point, path=path
         )
-        response = self._adapter.get(
+        return self._adapter.get(
             url=api_path,
             params=params,
-            raise_exception=False,
         )
-
-        if isinstance(response, Response):
-            errors = None
-            if response.status_code == 404:
-                try:
-                    data = response.json()
-                except Exception:
-                    pass
-                else:
-                    try:
-                        if data["data"]["metadata"]["deletion_time"] != "":
-                            return data
-                    except KeyError:
-                        pass
-
-                    errors = data.get("errors")
-
-            utils.raise_for_error(
-                response.request.method,
-                response.request.url,
-                response.status_code,
-                response.text,
-                errors=errors,
-            )
-
-        return response
 
     def create_or_update_secret(
         self, path, secret, cas=None, mount_point=DEFAULT_MOUNT_POINT

--- a/hvac/api/secrets_engines/kv_v2.py
+++ b/hvac/api/secrets_engines/kv_v2.py
@@ -94,10 +94,20 @@ class KvV2(VaultApiBase):
         api_path = utils.format_url(
             "/v1/{mount_point}/data/{path}", mount_point=mount_point, path=path
         )
-        return self._adapter.get(
-            url=api_path,
-            params=params,
-        )
+        try:
+            return self._adapter.get(
+                url=api_path,
+                params=params,
+            )
+        except exceptions.InvalidPath as e:
+            if e.json is None:
+                raise
+
+            try:
+                if e.json["data"]["metadata"]["deletion_time"] != "":
+                    return e.json
+            except KeyError:
+                raise e
 
     def create_or_update_secret(
         self, path, secret, cas=None, mount_point=DEFAULT_MOUNT_POINT

--- a/hvac/api/secrets_engines/kv_v2.py
+++ b/hvac/api/secrets_engines/kv_v2.py
@@ -107,7 +107,9 @@ class KvV2(VaultApiBase):
                 if e.json["data"]["metadata"]["deletion_time"] != "":
                     return e.json
             except KeyError:
-                raise e
+                pass
+
+            raise
 
     def create_or_update_secret(
         self, path, secret, cas=None, mount_point=DEFAULT_MOUNT_POINT

--- a/hvac/api/secrets_engines/kv_v2.py
+++ b/hvac/api/secrets_engines/kv_v2.py
@@ -75,6 +75,26 @@ class KvV2(VaultApiBase):
     def read_secret(
         self, path, mount_point=DEFAULT_MOUNT_POINT, raise_on_deleted_version=None
     ):
+        """Retrieve the secret at the specified location.
+
+        Equivalent to calling read_secret_version with version=None.
+
+        Supported methods:
+            GET: /{mount_point}/data/{path}. Produces: 200 application/json
+
+
+        :param path: Specifies the path of the secret to read. This is specified as part of the URL.
+        :type path: str | unicode
+        :param mount_point: The "path" the secret engine was mounted on.
+        :type mount_point: str | unicode
+        :param raise_on_deleted_version: Changes the behavior when the requested version is deleted.
+            If True an exception will be raised.
+            If False, some metadata about the deleted secret is returned.
+            If None (pre-v3), a default of True will be used and a warning will be issued.
+        :type raise_on_deleted_version: bool
+        :return: The JSON response of the request.
+        :rtype: dict
+        """
         return self.read_secret_version(
             path,
             mount_point=mount_point,
@@ -88,7 +108,7 @@ class KvV2(VaultApiBase):
         mount_point=DEFAULT_MOUNT_POINT,
         raise_on_deleted_version=None,
     ):
-        """Retrieve the secret at the specified location.
+        """Retrieve the secret at the specified location, with the specified version.
 
         Supported methods:
             GET: /{mount_point}/data/{path}. Produces: 200 application/json
@@ -100,6 +120,11 @@ class KvV2(VaultApiBase):
         :type version: int
         :param mount_point: The "path" the secret engine was mounted on.
         :type mount_point: str | unicode
+        :param raise_on_deleted_version: Changes the behavior when the requested version is deleted.
+            If True an exception will be raised.
+            If False, some metadata about the deleted secret is returned.
+            If None (pre-v3), a default of True will be used and a warning will be issued.
+        :type raise_on_deleted_version: bool
         :return: The JSON response of the request.
         :rtype: dict
         """

--- a/hvac/api/secrets_engines/kv_v2.py
+++ b/hvac/api/secrets_engines/kv_v2.py
@@ -2,6 +2,7 @@
 """KvV2 methods module."""
 from hvac import exceptions, utils
 from hvac.api.vault_api_base import VaultApiBase
+from requests import Response
 
 DEFAULT_MOUNT_POINT = "secret"
 
@@ -94,10 +95,37 @@ class KvV2(VaultApiBase):
         api_path = utils.format_url(
             "/v1/{mount_point}/data/{path}", mount_point=mount_point, path=path
         )
-        return self._adapter.get(
+        response = self._adapter.get(
             url=api_path,
             params=params,
+            raise_exception=False,
         )
+
+        if isinstance(response, Response):
+            errors = None
+            if response.status_code == 404:
+                try:
+                    data = response.json()
+                except Exception:
+                    pass
+                else:
+                    try:
+                        if data["data"]["metadata"]["deletion_time"] != "":
+                            return data
+                    except KeyError:
+                        pass
+
+                    errors = data.get("errors")
+
+            utils.raise_for_error(
+                response.request.method,
+                response.request.url,
+                response.status_code,
+                response.text,
+                errors=errors,
+            )
+
+        return response
 
     def create_or_update_secret(
         self, path, secret, cas=None, mount_point=DEFAULT_MOUNT_POINT

--- a/hvac/api/secrets_engines/kv_v2.py
+++ b/hvac/api/secrets_engines/kv_v2.py
@@ -100,11 +100,11 @@ class KvV2(VaultApiBase):
                 params=params,
             )
         except exceptions.InvalidPath as e:
-            if e.json is None:
-                raise
-
             try:
-                if e.json["data"]["metadata"]["deletion_time"] != "":
+                if (
+                    e.json is not None
+                    and e.json["data"]["metadata"]["deletion_time"] != ""
+                ):
                     return e.json
             except KeyError:
                 pass

--- a/hvac/exceptions.py
+++ b/hvac/exceptions.py
@@ -1,11 +1,15 @@
 class VaultError(Exception):
-    def __init__(self, message=None, errors=None, method=None, url=None):
+    def __init__(
+        self, message=None, errors=None, method=None, url=None, text=None, json=None
+    ):
         if errors:
             message = ", ".join(errors)
 
         self.errors = errors
         self.method = method
         self.url = url
+        self.text = text
+        self.json = json
 
         super().__init__(message)
 

--- a/hvac/exceptions.py
+++ b/hvac/exceptions.py
@@ -12,6 +12,22 @@ class VaultError(Exception):
     def __str__(self):
         return f"{self.args[0]}, on {self.method} {self.url}"
 
+    @classmethod
+    def from_status(cls, status_code: int, *args, **kwargs):
+        _STATUS_EXCEPTION_MAP = {
+            400: InvalidRequest,
+            401: Unauthorized,
+            403: Forbidden,
+            404: InvalidPath,
+            429: RateLimitExceeded,
+            500: InternalServerError,
+            501: VaultNotInitialized,
+            502: BadGateway,
+            503: VaultDown,
+        }
+
+        return _STATUS_EXCEPTION_MAP.get(status_code, UnexpectedError)(*args, **kwargs)
+
 
 class InvalidRequest(VaultError):
     pass

--- a/hvac/utils.py
+++ b/hvac/utils.py
@@ -12,7 +12,9 @@ import urllib
 from hvac import exceptions
 
 
-def raise_for_error(method, url, status_code, message=None, errors=None):
+def raise_for_error(
+    method, url, status_code, message=None, errors=None, text=None, json=None
+):
     """Helper method to raise exceptions based on the status code of a response received back from Vault.
 
     :param method: HTTP method of a request to Vault.
@@ -25,6 +27,10 @@ def raise_for_error(method, url, status_code, message=None, errors=None):
     :type message: str
     :param errors: Optional errors to include in a resulting exception.
     :type errors: list | str
+    :param text: Optional text of the response.
+    :type text: str
+    :param json: Optional deserialized version of a JSON response (object)
+    :type json: object
 
     :raises: hvac.exceptions.InvalidRequest | hvac.exceptions.Unauthorized | hvac.exceptions.Forbidden |
         hvac.exceptions.InvalidPath | hvac.exceptions.RateLimitExceeded | hvac.exceptions.InternalServerError |
@@ -32,32 +38,15 @@ def raise_for_error(method, url, status_code, message=None, errors=None):
         hvac.exceptions.UnexpectedError
 
     """
-    if status_code == 400:
-        raise exceptions.InvalidRequest(message, errors=errors, method=method, url=url)
-    elif status_code == 401:
-        raise exceptions.Unauthorized(message, errors=errors, method=method, url=url)
-    elif status_code == 403:
-        raise exceptions.Forbidden(message, errors=errors, method=method, url=url)
-    elif status_code == 404:
-        raise exceptions.InvalidPath(message, errors=errors, method=method, url=url)
-    elif status_code == 429:
-        raise exceptions.RateLimitExceeded(
-            message, errors=errors, method=method, url=url
-        )
-    elif status_code == 500:
-        raise exceptions.InternalServerError(
-            message, errors=errors, method=method, url=url
-        )
-    elif status_code == 501:
-        raise exceptions.VaultNotInitialized(
-            message, errors=errors, method=method, url=url
-        )
-    elif status_code == 502:
-        raise exceptions.BadGateway(message, errors=errors, method=method, url=url)
-    elif status_code == 503:
-        raise exceptions.VaultDown(message, errors=errors, method=method, url=url)
-    else:
-        raise exceptions.UnexpectedError(message or errors, method=method, url=url)
+    raise exceptions.VaultError.from_status(
+        status_code,
+        message,
+        errors=errors,
+        method=method,
+        url=url,
+        text=text,
+        json=json,
+    )
 
 
 def generate_method_deprecation_message(

--- a/tests/integration_tests/api/secrets_engines/test_kv_v2.py
+++ b/tests/integration_tests/api/secrets_engines/test_kv_v2.py
@@ -276,7 +276,7 @@ class TestKvV2(HvacIntegrationTestCase, TestCase):
 
     @parameterized.expand(
         [
-            ("successful delete one version written", "hvac"),
+            ("successful delete one version written", "hvac", 1),
             ("successful delete two versions written", "hvac", 2),
             ("successful delete three versions written", "hvac", 3),
             ("nonexistent path", "no-secret-here", 0, exceptions.InvalidPath),
@@ -286,7 +286,7 @@ class TestKvV2(HvacIntegrationTestCase, TestCase):
         self,
         test_label,
         path,
-        write_secret_before_test=1,
+        write_secret_before_test,
         raises=None,
         exception_message="",
     ):
@@ -360,7 +360,8 @@ class TestKvV2(HvacIntegrationTestCase, TestCase):
             )
             self.assertEqual(
                 first=read_secret_version_result["data"]["metadata"]["version"],
-                second=str(num),
+                second=write_secret_before_test,
+                msg=repr(read_secret_version_result),
             )
 
     @parameterized.expand(

--- a/tests/integration_tests/api/secrets_engines/test_kv_v2.py
+++ b/tests/integration_tests/api/secrets_engines/test_kv_v2.py
@@ -345,15 +345,11 @@ class TestKvV2(HvacIntegrationTestCase, TestCase):
                     ],
                     second="",
                 )
-            read_secret_version_result = (
-                self.client.secrets.kv.v2.read_secret_version(
-                    path=path,
-                    mount_point=self.DEFAULT_MOUNT_POINT,
-                )
+            read_secret_version_result = self.client.secrets.kv.v2.read_secret_version(
+                path=path,
+                mount_point=self.DEFAULT_MOUNT_POINT,
             )
-            logging.debug(
-                "read_secret_version_result: %s" % read_secret_version_result
-            )
+            logging.debug("read_secret_version_result: %s" % read_secret_version_result)
             self.assertEqual(
                 first=read_secret_version_result["data"]["data"],
                 second=None,

--- a/tests/integration_tests/api/secrets_engines/test_kv_v2.py
+++ b/tests/integration_tests/api/secrets_engines/test_kv_v2.py
@@ -345,6 +345,27 @@ class TestKvV2(HvacIntegrationTestCase, TestCase):
                     ],
                     second="",
                 )
+            read_secret_version_result = (
+                self.client.secrets.kv.v2.read_secret_version(
+                    path=path,
+                    mount_point=self.DEFAULT_MOUNT_POINT,
+                )
+            )
+            logging.debug(
+                "read_secret_version_result: %s" % read_secret_version_result
+            )
+            self.assertEqual(
+                first=read_secret_version_result["data"]["data"],
+                second=None,
+            )
+            self.assertNotEqual(
+                first=read_secret_version_result["data"]["metadata"]["deletion_time"],
+                second="",
+            )
+            self.assertEqual(
+                first=read_secret_version_result["data"]["metadata"]["version"],
+                second=str(num),
+            )
 
     @parameterized.expand(
         [

--- a/tests/unit_tests/api/secrets_engines/test_kv.py
+++ b/tests/unit_tests/api/secrets_engines/test_kv.py
@@ -93,8 +93,10 @@ class TestKv2:
 
                 if raise_on_del is None:
                     assert w.call_count == 1
-                    assert "category" in w.mock_calls[0].kwargs
-                    assert w.mock_calls[0].kwargs["category"] == DeprecationWarning
+                    assert "category" in w.call_args[1]
+                    assert w.call_args[1]["category"] == DeprecationWarning
+                    # TODO: in py3.8+: assert "category" in w.call_args.kwargs
+                    # TODO: in py3.8+: assert w.call_args.kwargs["category"] == DeprecationWarning
                 else:
                     assert w.assert_not_called
 

--- a/tests/unit_tests/api/secrets_engines/test_kv.py
+++ b/tests/unit_tests/api/secrets_engines/test_kv.py
@@ -1,11 +1,16 @@
+import pytest
+
 from unittest import TestCase
 
-from unittest.mock import MagicMock
+from unittest import mock
+from unittest.mock import MagicMock, Mock
 from parameterized import parameterized
 
 from hvac.api.secrets_engines.kv import Kv
 from hvac.api.secrets_engines.kv_v1 import KvV1
 from hvac.api.secrets_engines.kv_v2 import KvV2
+
+from hvac import exceptions
 
 
 class TestKv(TestCase):
@@ -67,3 +72,61 @@ class TestKv(TestCase):
         kv._default_kv_version = 0
         with self.assertRaises(AttributeError):
             assert kv.read_secret
+
+
+class TestKv2:
+    # TODO: v3.0.0 - remove this (there should be no more warning, the default will be set statically)
+    @pytest.mark.parametrize("raise_on_del", [None, True, False])
+    def test_kv2_raise_on_deleted_warning(self, raise_on_del):
+        mock_adapter = MagicMock()
+        kv = Mock(wraps=Kv(adapter=mock_adapter, default_kv_version="2"))
+
+        for method in [
+            kv.read_secret,
+            kv.read_secret_version,
+            kv.v2.read_secret,
+            kv.v2.read_secret_version,
+        ]:
+            with mock.patch("warnings.warn") as w:
+                p = "secret_path"
+                method(p, raise_on_deleted_version=raise_on_del)
+
+                if raise_on_del is None:
+                    assert w.call_count == 1
+                    assert "category" in w.mock_calls[0].kwargs
+                    assert w.mock_calls[0].kwargs["category"] == DeprecationWarning
+                else:
+                    assert w.assert_not_called
+
+    @pytest.mark.parametrize(
+        ("json", "recoverable"),
+        [
+            (None, False),
+            ({}, False),
+            ({"data": {"metadata": {"deletion_time": ""}}}, False),
+            ({"data": {"metadata": {"deletion_time": "anything"}}}, True),
+        ],
+    )
+    @pytest.mark.parametrize("raise_on_del", [True, False])
+    def test_kv2_raise_on_deleted(self, raise_on_del, json, recoverable):
+        def _getem(*args, **kwargs):
+            raise exceptions.InvalidPath(json=json)
+
+        mock_adapter = MagicMock(get=_getem)
+        kv = Mock(wraps=Kv(adapter=mock_adapter, default_kv_version="2"))
+
+        for method in [
+            kv.read_secret,
+            kv.read_secret_version,
+            kv.v2.read_secret,
+            kv.v2.read_secret_version,
+        ]:
+            p = "secret_path"
+            should_raise = raise_on_del or not recoverable
+
+            if should_raise:
+                with pytest.raises(exceptions.InvalidPath):
+                    method(p, raise_on_deleted_version=raise_on_del)
+            else:
+                r = method(p, raise_on_deleted_version=raise_on_del)
+                assert r is json

--- a/tests/unit_tests/test_adapters.py
+++ b/tests/unit_tests/test_adapters.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python
+import pytest
 import logging
 from unittest import TestCase
+from unittest import mock
 
 import requests_mock
+from requests_mock.response import create_response
 from parameterized import parameterized, param
 from hvac.constants.client import DEFAULT_URL
+from hvac import exceptions
 from hvac import adapters
 
 
@@ -105,3 +109,67 @@ class TestRequest(TestCase):
             second=response.status_code,
         )
         self.assertEqual(first=mock_response, second=response.json())
+
+
+@pytest.fixture
+def raw_adapter():
+    return mock.Mock(wraps=adapters.RawAdapter())
+
+
+class TestRawAdapter:
+    @pytest.mark.parametrize("headers", [{}, {"Content-Type": "application/json"}])
+    @pytest.mark.parametrize("json_get", [None, Exception])
+    @pytest.mark.parametrize("text_get", [None, Exception])
+    @pytest.mark.parametrize(
+        "bytes", [None, b"", b"a", b"{}", b'{"errors": ["err"]}', b"\x80\x81", b"\0"]
+    )
+    @pytest.mark.parametrize("code", [404, 500])
+    def test_raise_for_error(
+        self, raw_adapter, headers, bytes, code, json_get, text_get
+    ):
+        url = "throwaway"
+        method = "GET"
+
+        resp = create_response(
+            mock.Mock(url=url), status_code=code, content=bytes, headers=headers
+        )
+
+        # if json_get is not None and issubclass(json_get, Exception):
+        resp.json = mock.Mock(wraps=resp.json, side_effect=json_get)
+
+        # mock_text =
+        # mock.patch.object(resp, 'text.getter', mock.Mock(wraps=resp.text.fget, side_effect=text_get))
+
+        text = errors = json = None
+
+        if headers:
+            try:
+                json = resp.json()
+            except Exception:
+                pass
+            else:
+                errors = json.get("errors")
+
+        try:
+            text = resp.text
+        except Exception:
+            pass
+
+        from hvac.utils import raise_for_error
+
+        with mock.patch(
+            "hvac.utils.raise_for_error", mock.Mock(wraps=raise_for_error)
+        ) as r:
+            with pytest.raises(exceptions.VaultError) as e:
+                raw_adapter._raise_for_error(method, url, resp)
+
+            e_msg = None if errors else text
+            expected = mock.call(
+                method, url, code, e_msg, errors=errors, text=text, json=json
+            )
+
+            assert r.call_count == 1
+            r.assert_has_calls([expected])
+            assert e.value.text == text
+            assert e.value.json == json
+            assert e.value.errors == errors

--- a/tests/unit_tests/test_adapters.py
+++ b/tests/unit_tests/test_adapters.py
@@ -134,11 +134,10 @@ class TestRawAdapter:
             mock.Mock(url=url), status_code=code, content=bytes, headers=headers
         )
 
-        # if json_get is not None and issubclass(json_get, Exception):
         resp.json = mock.Mock(wraps=resp.json, side_effect=json_get)
 
-        # mock_text =
-        # mock.patch.object(resp, 'text.getter', mock.Mock(wraps=resp.text.fget, side_effect=text_get))
+        mock_text = mock.PropertyMock(wraps=resp.text, side_effect=text_get)
+        mock.patch.object(resp, 'text', new=mock_text)
 
         text = errors = json = None
 

--- a/tests/unit_tests/test_adapters.py
+++ b/tests/unit_tests/test_adapters.py
@@ -137,7 +137,7 @@ class TestRawAdapter:
         resp.json = mock.Mock(wraps=resp.json, side_effect=json_get)
 
         mock_text = mock.PropertyMock(wraps=resp.text, side_effect=text_get)
-        mock.patch.object(resp, 'text', new=mock_text)
+        mock.patch.object(resp, "text", new=mock_text)
 
         text = errors = json = None
 


### PR DESCRIPTION
Fixes #906 

### Here's the final state of this PR
- `VaultError` (the base class for all the Vault exceptions) has been updated as follows:
  - constructor accepts optional `text` and `json` arguments and populates them as fields
  - [nicety] a new class method `from_status` is added to return an instance of a specific Vault exception, based on the given status code; this replaces the logic in `raise_for_error` to something a little cleaner
- `utils.raise_for_error` now accepts `text` and `json` fields to pass along to the exception classes, and is reduced to just calling `VaultError.from_status`
- `RawAdapter` (the only current place where `raise_for_status` is used) has been updated to populate the `text` and `json` fields as best it can from its `requests.Response`

All of the above now enables methods to remain Adapter-agnostic, but gain some additional information in the exceptions raised which can allow for handling of some conditions. With that:
- kv_v2's `read_secret_version` can catch the `InvalidPath` exception, inspect the `json` field to try to determine if the cause was due to a deleted secret version, and if so, can respond by returning the data instead of allowing the exception to be raised.
- that functionality is a (slightly) breaking change though, so it's controlled by a new parameter `raise_on_deleted_version`
  - Currently this parameter defaults to `None`
  - A value of `None` will default to `True` **(preserving the old behavior)** with a warning explaining that the default will change to `False` in `v3.0.0`
  - In `v3.0.0` we'll change the actual default to `False` and remove the warning code and the test for it

Since clients also gain from the new exception fields, sophisticated clients can decide how to handle a deleted version result in their application (whether by setting the new parameter, or catching exceptions), including:
* using additional calls to determine the next newest non-deleted secret (if they have permission to make those calls)
* "brute-forcing" the finding of a non-deleted version, by using the version number _V_ returned in the metadata, and requesting version _V-1_ until a non-deleted version is encountered or they get to `0`
* reporting a more appropriate status relevant to their use case

At this time, I don't think we should look to implement these workarounds in `hvac` itself.

Tests have also been added or improved, and all of the changes here have 100% test coverage.