### PR TITLE
Remove deprecated python syntax

### DIFF
--- a/hvac/adapters.py
+++ b/hvac/adapters.py
@@ -11,10 +11,8 @@ from hvac import utils
 from hvac.constants.client import DEFAULT_URL
 
 
-class Adapter:
+class Adapter(metaclass=ABCMeta):
     """Abstract base class used when constructing adapters for use with the Client class."""
-
-    __metaclass__ = ABCMeta
 
     def __init__(
         self,

--- a/hvac/api/system_backend/system_backend_mixin.py
+++ b/hvac/api/system_backend/system_backend_mixin.py
@@ -7,7 +7,5 @@ from hvac.api.vault_api_base import VaultApiBase
 logger = logging.getLogger(__name__)
 
 
-class SystemBackendMixin(VaultApiBase):
+class SystemBackendMixin(VaultApiBase, metaclass=ABCMeta):
     """Base class for System Backend API endpoints."""
-
-    __metaclass__ = ABCMeta

--- a/hvac/api/vault_api_base.py
+++ b/hvac/api/vault_api_base.py
@@ -5,10 +5,8 @@ from abc import ABCMeta
 logger = logging.getLogger(__name__)
 
 
-class VaultApiBase:
+class VaultApiBase(metaclass=ABCMeta):
     """Base class for API endpoints."""
-
-    __metaclass__ = ABCMeta
 
     def __init__(self, adapter):
         """Default api class constructor.

--- a/hvac/api/vault_api_category.py
+++ b/hvac/api/vault_api_category.py
@@ -1,6 +1,6 @@
 """Base class used by all hvac api "category" classes."""
 import logging
-from abc import ABCMeta, abstractproperty
+from abc import ABCMeta, abstractmethod
 
 from hvac.api.vault_api_base import VaultApiBase
 
@@ -66,7 +66,8 @@ class VaultApiCategory(VaultApiBase, metaclass=ABCMeta):
             class_name = implemented_class.__name__.lower()
             getattr(self, self.get_private_attr_name(class_name)).adapter = adapter
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def implemented_classes(self):
         """List of implemented classes under this category.
 

--- a/hvac/api/vault_api_category.py
+++ b/hvac/api/vault_api_category.py
@@ -7,10 +7,8 @@ from hvac.api.vault_api_base import VaultApiBase
 logger = logging.getLogger(__name__)
 
 
-class VaultApiCategory(VaultApiBase):
+class VaultApiCategory(VaultApiBase, metaclass=ABCMeta):
     """Base class for API categories."""
-
-    __metaclass__ = ABCMeta
 
     def __init__(self, adapter):
         """API Category class constructor.


### PR DESCRIPTION
this PR removes older/deprecated python syntax from the code base
specifically:
- updates metaclass https://docs.python.org/3/library/2to3.html#to3fixer-metaclass
- remove old `abc.abstractproperty` decorator https://docs.python.org/3/library/abc.html#abc.abstractproperty