### PR TITLE
update workflows

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -25,19 +25,19 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Python ${{ matrix.python-version }}
-      id: python
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-        cache: poetry
-
     - name: Install Poetry
       uses: snok/install-poetry@v1.3.1
       with:
         version: 1.1.14
         virtualenvs-create: true
         virtualenvs-in-project: true
+
+    - name: Set up Python ${{ matrix.python-version }}
+      id: python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: poetry
 
     - name: Install dependencies
       run: poetry install --no-interaction --no-root

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -26,9 +26,11 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
+      id: python
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: poetry
 
     - name: Install Poetry
       uses: snok/install-poetry@v1.3.1
@@ -36,13 +38,6 @@ jobs:
         version: 1.1.14
         virtualenvs-create: true
         virtualenvs-in-project: true
-
-    - name: Load cached venv
-      id: cached-pip-wheels
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache
-        key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
 
     - name: Install dependencies
       run: poetry install --no-interaction --no-root

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -27,9 +27,11 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
+      id: python
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: poetry
 
     - name: Install Poetry
       uses: snok/install-poetry@v1.3.1
@@ -38,15 +40,8 @@ jobs:
         virtualenvs-create: true
         virtualenvs-in-project: true
 
-    - name: Load cached venv
-      id: cached-poetry-dependencies
-      uses: actions/cache@v2
-      with:
-        path: .venv
-        key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
-
     - name: Install dependencies
-      if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+      if: steps.python.outputs.cache-hit != 'true'
       run: poetry install --no-interaction --no-root
 
     - name: Install library
@@ -66,9 +61,11 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python 3.6
+      id: python
       uses: actions/setup-python@v4
       with:
         python-version: 3.6
+        cache: poetry
 
     - name: Install Poetry
       uses: snok/install-poetry@v1.3.1
@@ -77,15 +74,8 @@ jobs:
         virtualenvs-create: true
         virtualenvs-in-project: true
 
-    - name: Load cached venv
-      id: cached-poetry-dependencies
-      uses: actions/cache@v2
-      with:
-        path: .venv
-        key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
-
     - name: Install dependencies
-      if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+      if: steps.python.outputs.cache-hit != 'true'
       run: poetry install --no-interaction --no-root
 
     - name: Install library
@@ -131,9 +121,11 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
+      id: python
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: poetry
 
     - name: Install Poetry
       uses: snok/install-poetry@v1.3.1
@@ -142,15 +134,8 @@ jobs:
         virtualenvs-create: true
         virtualenvs-in-project: true
 
-    - name: Load cached venv
-      id: cached-poetry-dependencies
-      uses: actions/cache@v2
-      with:
-        path: .venv
-        key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
-
     - name: Install dependencies
-      if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+      if: steps.python.outputs.cache-hit != 'true'
       run: poetry install --no-interaction --no-root
 
     - name: Install library
@@ -164,7 +149,7 @@ jobs:
           tests/unit_tests
 
     - name: Upload unit tests coverage artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: unit_tests-coverage.xml
         path: coverage.xml
@@ -191,9 +176,11 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
+      id: python
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: poetry
 
     - name: Install Poetry
       uses: snok/install-poetry@v1.3.1
@@ -202,15 +189,8 @@ jobs:
         virtualenvs-create: true
         virtualenvs-in-project: true
 
-    - name: Load cached venv
-      id: cached-poetry-dependencies
-      uses: actions/cache@v2
-      with:
-        path: .venv
-        key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
-
     - name: Install dependencies
-      if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+      if: steps.python.outputs.cache-hit != 'true'
       run: poetry install --no-interaction --no-root
 
     - name: Install library
@@ -244,7 +224,7 @@ jobs:
           tests/integration_tests
 
     - name: Upload integration tests coverage artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: integration_tests-coverage.xml
         path: coverage.xml
@@ -261,7 +241,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -26,19 +26,19 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Python ${{ matrix.python-version }}
-      id: python
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-        cache: poetry
-
     - name: Install Poetry
       uses: snok/install-poetry@v1.3.1
       with:
         version: 1.1.14
         virtualenvs-create: true
         virtualenvs-in-project: true
+
+    - name: Set up Python ${{ matrix.python-version }}
+      id: python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: poetry
 
     - name: Install dependencies
       if: steps.python.outputs.cache-hit != 'true'
@@ -60,19 +60,19 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Python 3.6
-      id: python
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.6
-        cache: poetry
-
     - name: Install Poetry
       uses: snok/install-poetry@v1.3.1
       with:
         version: 1.1.14
         virtualenvs-create: true
         virtualenvs-in-project: true
+
+    - name: Set up Python 3.6
+      id: python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.6
+        cache: poetry
 
     - name: Install dependencies
       if: steps.python.outputs.cache-hit != 'true'
@@ -120,19 +120,19 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Python ${{ matrix.python-version }}
-      id: python
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-        cache: poetry
-
     - name: Install Poetry
       uses: snok/install-poetry@v1.3.1
       with:
         version: 1.1.14
         virtualenvs-create: true
         virtualenvs-in-project: true
+
+    - name: Set up Python ${{ matrix.python-version }}
+      id: python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: poetry
 
     - name: Install dependencies
       if: steps.python.outputs.cache-hit != 'true'
@@ -175,19 +175,19 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Python ${{ matrix.python-version }}
-      id: python
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-        cache: poetry
-
     - name: Install Poetry
       uses: snok/install-poetry@v1.3.1
       with:
         version: 1.1.14
         virtualenvs-create: true
         virtualenvs-in-project: true
+
+    - name: Set up Python ${{ matrix.python-version }}
+      id: python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: poetry
 
     - name: Install dependencies
       if: steps.python.outputs.cache-hit != 'true'

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -11,10 +11,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+
     - name: Set up Python
+      id: python
       uses: actions/setup-python@v4
       with:
         python-version: '3.x'
+        cache: poetry
 
     - name: Install Poetry
       uses: snok/install-poetry@v1.3.1
@@ -23,15 +26,8 @@ jobs:
         virtualenvs-create: true
         virtualenvs-in-project: true
 
-    - name: Load cached venv
-      id: cached-poetry-dependencies
-      uses: actions/cache@v2
-      with:
-        path: .venv
-        key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
-
     - name: Install dependencies
-      if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+      if: steps.python.outputs.cache-hit != 'true'
       run: poetry install --no-interaction --no-root
 
     - name: Install library

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -12,19 +12,19 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Python
-      id: python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.x'
-        cache: poetry
-
     - name: Install Poetry
       uses: snok/install-poetry@v1.3.1
       with:
         version: 1.1.14
         virtualenvs-create: true
         virtualenvs-in-project: true
+
+    - name: Set up Python
+      id: python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+        cache: poetry
 
     - name: Install dependencies
       if: steps.python.outputs.cache-hit != 'true'


### PR DESCRIPTION
Our venv caching was not quite doing the right thing. It was intended to include the python version in the cache key, but we incorrectly referenced the setup-python step when trying to get its outputs because we didn't assign that step an ID.

Figured it might also be a good time to switch to the action's built-in caching.

- update versions of some actions
- remove manual caching
- use setup-python action's built-in caching for poetry

Updating the versions also removes all warnings from the GHA runs.