### PR TITLE
don't cache on py3.6 windows combo

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -37,7 +37,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-        cache: ${{ matrix.python-version == '3.6' && startsWith(matrix.os, 'windows') && '' || 'poetry' }}
+        cache: ${{ matrix.python-version == '3.6' && startsWith(matrix.os, 'windows') || 'poetry' && '' }}
 
     - name: Install dependencies
       run: poetry install --no-interaction --no-root

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -37,11 +37,11 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-        cache: poetry
+        cache: ${{ matrix.python-version == "3.6" && startsWith(matrix.os, "windows") && "poetry" || "" }}
 
     - name: Install dependencies
       run: poetry install --no-interaction --no-root
-    
+
     - name: Build and install wheel
       run: |
         poetry build

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -37,7 +37,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-        cache: ${{ matrix.python-version == '3.6' && startsWith(matrix.os, 'windows') || 'poetry' && '' }}
+        cache: ${{ matrix.python-version != '3.6' || !startsWith(matrix.os, 'windows') && 'poetry' || '' }}
 
     - name: Install dependencies
       run: poetry install --no-interaction --no-root

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -37,7 +37,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-        cache: ${{ matrix.python-version != '3.6' || !startsWith(matrix.os, 'windows') && 'poetry' || '' }}
+        cache: ${{ matrix.python-version != '3.6' && 'poetry' || !startsWith(matrix.os, 'windows') && 'poetry' || '' }}
 
     - name: Install dependencies
       run: poetry install --no-interaction --no-root

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -37,7 +37,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-        cache: ${{ matrix.python-version == "3.6" && startsWith(matrix.os, "windows") && "poetry" || "" }}
+        cache: ${{ matrix.python-version == '3.6' && startsWith(matrix.os, 'windows') && 'poetry' || '' }}
 
     - name: Install dependencies
       run: poetry install --no-interaction --no-root

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -37,7 +37,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-        cache: ${{ matrix.python-version == '3.6' && startsWith(matrix.os, 'windows') && 'poetry' || '' }}
+        cache: ${{ matrix.python-version == '3.6' && startsWith(matrix.os, 'windows') && '' || 'poetry' }}
 
     - name: Install dependencies
       run: poetry install --no-interaction --no-root


### PR DESCRIPTION
Follow up to 
- #913 

For some reason this cache restores corrupted somehow and we keep having to delete it to get successful runs. Python 3.6 is getting removed soon, for now we'll just skip the cache on this one combo.