### PR TITLE
Drop 3.6 from CI jobs

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
     defaults:
       run:
@@ -37,7 +37,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-        cache: ${{ matrix.python-version != '3.6' && 'poetry' || !startsWith(matrix.os, 'windows') && 'poetry' || '' }}
+        cache: poetry
 
     - name: Install dependencies
       run: poetry install --no-interaction --no-root

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -17,7 +17,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"
@@ -67,11 +66,11 @@ jobs:
         virtualenvs-create: true
         virtualenvs-in-project: true
 
-    - name: Set up Python 3.6
+    - name: Set up Python 3.7
       id: python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.6
+        python-version: 3.7
         cache: poetry
 
     - name: Install dependencies
@@ -111,7 +110,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"


### PR DESCRIPTION
Drops 3.6 from CI as it is not supported by the latest os images. Since 3.6 will soon be dropped, now is as good of a time as any to update the jobs.

An alternative is #933 ; we will only use or the other, so: Closes #933

Signed-off-by: Colin McAllister <colinmca242@gmail.com>