### PR TITLE
Propagate client's adapter to API categories

### DIFF
--- a/hvac/api/system_backend/__init__.py
+++ b/hvac/api/system_backend/__init__.py
@@ -75,9 +75,3 @@ class SystemBackend(
         Wrapping,
     ]
     unimplemented_classes = []
-
-    def __init__(self, adapter):
-        self._adapter = adapter
-
-    def __getattr__(self, item):
-        raise AttributeError

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -57,7 +57,7 @@ class Client:
         :param session: Optional session object to use when performing request.
         :type session: request.Session
         :param adapter: Optional class to be used for performing requests. If none is provided, defaults to
-            hvac.adapters.JSONRequest
+            hvac.adapters.JSONRequest.
         :type adapter: hvac.adapters.Adapter
         :param kwargs: Additional parameters to pass to the adapter constructor.
         :type kwargs: dict
@@ -115,11 +115,15 @@ class Client:
 
     @property
     def adapter(self):
+        """Adapter for all client's connections."""
         return self._adapter
 
     @adapter.setter
     def adapter(self, adapter):
         self._adapter = adapter
+        self._auth.adapter = adapter
+        self._secrets.adapter = adapter
+        self._sys.adapter = adapter
 
     @property
     def url(self):

--- a/tests/unit_tests/v1/test_client.py
+++ b/tests/unit_tests/v1/test_client.py
@@ -1,0 +1,20 @@
+from unittest import TestCase
+
+from hvac import Client
+from hvac.adapters import JSONAdapter
+
+
+class TestClient(TestCase):
+    """Unit tests providing coverage for client related methods."""
+
+    def test_setting_adapter_on_client_sets_adapter_of_endpoint_classes(self):
+        client = Client()
+        old_adapter = client.adapter
+
+        client.adapter = JSONAdapter()
+
+        self.assertIsNot(client.adapter, old_adapter)
+        self.assertSetEqual(
+            {client.adapter},
+            {client.secrets.adapter, client.sys.adapter, client.auth.adapter},
+        )


### PR DESCRIPTION
Propagate the adapter used by the client to all handlers registered on the client.

Previously, setting the adapter (and thus session/connection pool) on the client after initialization would only replace the adapter owned by the client, leaving the adapters of all API categories untouched. 

### Notes

- If the current behaviour was by design, I will extend the docstrings instead. The new behaviour seems more intuitive to me, also more in line with other methods (e.g. the URL setter on the client).
- Added a regression test.