### PR TITLE
Release drafter/updates

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -35,3 +35,5 @@ version-resolver:
 template: |
 
   $CHANGES
+
+  Thanks to $CONTRIBUTORS for their lovely contributions.

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -20,7 +20,7 @@ categories:
   - title: '🧰 Miscellaneous'
     labels:
       - 'misc'
-change-template: '- $TITLE. GH-$NUMBER'
+change-template: '- $TITLE (GH-$NUMBER)'
 version-resolver:
   major:
     labels:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -8,6 +8,10 @@ categories:
   - title: '💥 Breaking Changes'
     labels:
       - 'breaking-change'
+  - title: '📢 Deprecations / Announcements'
+    labels:
+      - 'deprecation'
+      - 'announcement'
   - title: '🚀 Features'
     labels:
       - 'enhancement'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -25,6 +25,7 @@ version-resolver:
   major:
     labels:
       - 'major'
+      - 'breaking-change'
   minor:
     labels:
       - 'minor'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -13,7 +13,8 @@ jobs:
   update_release_draft:
     permissions:
       contents: write
-    runs-on: ubuntu-20.04
+      pull-requests: read
+    runs-on: ubuntu-latest
     steps:
       - name: Run release-drafter action
         id: release-drafter


### PR DESCRIPTION
Make some updates to release drafter:
- ensure that the https://github.com/hvac/hvac/labels/breaking-change label results in a major version in the auto-resolver (https://github.com/hvac/hvac/commit/bc3d01a4ad821720b87054f870565e947c9bcee9)
- added https://github.com/hvac/hvac/labels/announcement and https://github.com/hvac/hvac/labels/deprecation labels to the repository, and added a new "📢 Deprecations / Announcements" section to release drafter tied to them (https://github.com/hvac/hvac/commit/df8971d016e4943419e3431af365dd5a9d8fd1c6)
  - basically, we should have a way to announce upcoming breaking changes ahead of time, that isn't _only_ posting an issue or discussion
  - unfortunately since release drafter doesn't seem to support adding issue links automatically, I think there are some cases where we will still want to add links to open/pinned issues (like #914) into the changelog, which we'll have to do manually on release
  - but this will at least ensure that PRs that seek to deprecate something or make future breaking changes, will be included
- slightly update change title format (https://github.com/hvac/hvac/commit/92ab8e144d4f6f5ac79116f149a54f8665bb4e45)
- make the workflow job permission slightly more explicit (https://github.com/hvac/hvac/commit/7f34ea41f0ca97fcb5b6f1dac37bd2703f9c5338)
- re-add contributor mentions to releases (https://github.com/hvac/hvac/commit/13ab79d5848a7940e65b41bda3dee4d13dd7389a)
  - this was removed in this commit (https://github.com/hvac/hvac/commit/3ef2b59ec036beebc173e3694cdb6707c8f5047c) but it's unclear why
  - re-adding it makes for a nice contributor experience, and by mentioning, GitHub will automatically add the avatar list, as can be seen in this older release https://github.com/hvac/hvac/releases/tag/v0.11.1

