### PR TITLE
release_drafter - make issue links actual markdown links

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -24,7 +24,7 @@ categories:
   - title: '🧰 Miscellaneous'
     labels:
       - 'misc'
-change-template: '- $TITLE (GH-$NUMBER)'
+change-template: '- $TITLE ([GH-$NUMBER]($URL))'
 version-resolver:
   major:
     labels:


### PR DESCRIPTION
Kind of an add-on to #952 

Our current references to `GH-$NUMBER` in the release description automatically get converted into links to the PRs, but our release process at the moment has us copy/pasting this markdown into `CHANGELOG.md` in the root, and that file does _not_ render these links automatically, so we should have the drafter format these as proper markdown instead.