### PR TITLE
fix wrapped response for `auth.token.create`

### DIFF
--- a/hvac/api/auth_methods/token.py
+++ b/hvac/api/auth_methods/token.py
@@ -111,17 +111,11 @@ class Token(VaultApiBase):
             }
         )
 
-        if role_name is not None:
-            api_path = "/v1/auth/{mount_point}/create/{role_name}".format(
-                mount_point=mount_point,
-                role_name=role_name,
-            )
-            return self._adapter.post(
-                url=api_path,
-                json=params,
-            )
-
         api_path = f"/v1/auth/{mount_point}/create"
+
+        if role_name is not None:
+            api_path = f"{api_path}/{role_name}"
+
         return self._adapter.post(
             url=api_path,
             json=params,

--- a/tests/integration_tests/api/auth_methods/test_token.py
+++ b/tests/integration_tests/api/auth_methods/test_token.py
@@ -168,7 +168,8 @@ class TestToken(HvacIntegrationTestCase, TestCase):
         response = self.client.auth.token.create(period="30m", wrap_ttl="15m")
 
         assert "wrap_info" in response, repr(response)
-        assert response["auth"] is None
+        assert response["wrap_info"] is not None, repr(response)
+        assert response["auth"] is None, repr(response)
         assert response["wrap_info"]["ttl"] == 900
         assert "token" in response["wrap_info"]
 
@@ -229,7 +230,8 @@ class TestToken(HvacIntegrationTestCase, TestCase):
             )
 
             assert "wrap_info" in response, repr(response)
-            assert response["auth"] is None
+            assert response["wrap_info"] is not None, repr(response)
+            assert response["auth"] is None, repr(response)
             assert response["wrap_info"]["ttl"] == 900
             assert "token" in response["wrap_info"]
 

--- a/tests/integration_tests/api/auth_methods/test_token.py
+++ b/tests/integration_tests/api/auth_methods/test_token.py
@@ -168,18 +168,21 @@ class TestToken(HvacIntegrationTestCase, TestCase):
         with self.assertRaises(exceptions.InvalidPath):
             self.client.auth.token.list_roles()
 
-        # Create token role
-        assert (
-            self.client.auth.token.create_or_update_role("testrole").status_code == 204
-        )
+        try:
+            # Create token role
+            assert (
+                self.client.auth.token.create_or_update_role("testrole").status_code
+                == 204
+            )
 
-        # List token roles
-        during = self.client.auth.token.list_roles()["data"]["keys"]
-        assert len(during) == 1
-        assert during[0] == "testrole"
+            # List token roles
+            during = self.client.auth.token.list_roles()["data"]["keys"]
+            assert len(during) == 1
+            assert during[0] == "testrole"
 
-        # Delete token role
-        self.client.auth.token.delete_role("testrole")
+        finally:
+            # Delete token role
+            self.client.auth.token.delete_role("testrole")
 
         # No roles, list_token_roles == None
         with self.assertRaises(exceptions.InvalidPath):


### PR DESCRIPTION
Fixes #965 

- Adds tests for wrapped responses
- Ensures role-based tokens can be wrapped

(first run expected to fail: test added to catch the condition, fix not applied yet)