### PR TITLE
Add new argument (conflicting_alias_ids_to_keep) to merge_entities method

### DIFF
--- a/hvac/api/secrets_engines/identity.py
+++ b/hvac/api/secrets_engines/identity.py
@@ -364,7 +364,7 @@ class Identity(VaultApiBase):
             requiring this parameter must have only one from-Entity.
             Requires Vault 1.12 or higher
         :type conflicting_alias_ids_to_keep: list
-       :return: The response of the request.
+        :return: The response of the request.
         :rtype: requests.Response
         """
         params = utils.remove_nones(

--- a/hvac/api/secrets_engines/identity.py
+++ b/hvac/api/secrets_engines/identity.py
@@ -335,7 +335,12 @@ class Identity(VaultApiBase):
         return response
 
     def merge_entities(
-        self, from_entity_ids, to_entity_id, force=None, mount_point=DEFAULT_MOUNT_POINT
+        self, 
+        from_entity_ids, 
+        to_entity_id, 
+        force=None, 
+        conflicting_alias_ids_to_keep=None,
+        mount_point=DEFAULT_MOUNT_POINT
     ):
         """Merge many entities into one entity.
 
@@ -351,6 +356,11 @@ class Identity(VaultApiBase):
             secrets in the destination will be unaltered. If not set, this API will throw an error containing all the
             conflicts.
         :type force: bool
+        :param conflicting_alias_ids_to_keep: A list of entity aliases to keep in the case where the to-Entity and
+            from-Entity have aliases with the same mount accessor. In the case where alias share mount accessors, the
+            alias ID given in this list will be kept or merged, and the other alias will be deleted. Note that merges
+            requiring this parameter must have only one from-Entity.
+        :type conflicting_alias_ids_to_keep: array
         :param mount_point: The "path" the method/backend was mounted on.
         :type mount_point: str | unicode
         :return: The response of the request.
@@ -361,6 +371,7 @@ class Identity(VaultApiBase):
                 "from_entity_ids": from_entity_ids,
                 "to_entity_id": to_entity_id,
                 "force": force,
+                "conflicting_alias_ids_to_keep": conflicting_alias_ids_to_keep
             }
         )
         api_path = utils.format_url(

--- a/hvac/api/secrets_engines/identity.py
+++ b/hvac/api/secrets_engines/identity.py
@@ -335,10 +335,10 @@ class Identity(VaultApiBase):
         return response
 
     def merge_entities(
-        self, 
-        from_entity_ids, 
-        to_entity_id, 
-        force=None, 
+        self,
+        from_entity_ids,
+        to_entity_id,
+        force=None,
         mount_point=DEFAULT_MOUNT_POINT,
         conflicting_alias_ids_to_keep=None,
     ):

--- a/hvac/api/secrets_engines/identity.py
+++ b/hvac/api/secrets_engines/identity.py
@@ -339,8 +339,8 @@ class Identity(VaultApiBase):
         from_entity_ids, 
         to_entity_id, 
         force=None, 
+        mount_point=DEFAULT_MOUNT_POINT,
         conflicting_alias_ids_to_keep=None,
-        mount_point=DEFAULT_MOUNT_POINT
     ):
         """Merge many entities into one entity.
 
@@ -356,14 +356,15 @@ class Identity(VaultApiBase):
             secrets in the destination will be unaltered. If not set, this API will throw an error containing all the
             conflicts.
         :type force: bool
+        :param mount_point: The "path" the method/backend was mounted on.
+        :type mount_point: str | unicode
         :param conflicting_alias_ids_to_keep: A list of entity aliases to keep in the case where the to-Entity and
             from-Entity have aliases with the same mount accessor. In the case where alias share mount accessors, the
             alias ID given in this list will be kept or merged, and the other alias will be deleted. Note that merges
             requiring this parameter must have only one from-Entity.
-        :type conflicting_alias_ids_to_keep: array
-        :param mount_point: The "path" the method/backend was mounted on.
-        :type mount_point: str | unicode
-        :return: The response of the request.
+            Requires Vault 1.12 or higher
+        :type conflicting_alias_ids_to_keep: list
+       :return: The response of the request.
         :rtype: requests.Response
         """
         params = utils.remove_nones(
@@ -371,7 +372,7 @@ class Identity(VaultApiBase):
                 "from_entity_ids": from_entity_ids,
                 "to_entity_id": to_entity_id,
                 "force": force,
-                "conflicting_alias_ids_to_keep": conflicting_alias_ids_to_keep
+                "conflicting_alias_ids_to_keep": conflicting_alias_ids_to_keep,
             }
         )
         api_path = utils.format_url(

--- a/tests/integration_tests/api/secrets_engines/test_identity.py
+++ b/tests/integration_tests/api/secrets_engines/test_identity.py
@@ -610,7 +610,7 @@ class TestIdentity(HvacIntegrationTestCase, TestCase):
             name="%s2" % self.TEST_ENTITY_NAME,
             mount_point=self.TEST_MOUNT_POINT,
         )
-        logging.debug("create_response2: %s" % create_response)
+        logging.debug("create_response2: %s" % create_response2)
         to_entity_id = create_response["data"]["id"]
         from_entity_ids = [create_response2["data"]["id"]]
         if raises:
@@ -635,6 +635,72 @@ class TestIdentity(HvacIntegrationTestCase, TestCase):
                 first=bool(merge_entities_response),
                 second=True,
             )
+
+    @parameterized.expand(
+        [
+            param(
+                "merge success",
+            ),
+            param(
+                "merge failure",
+            ),
+        ]
+    )
+    @skipIf(
+        utils.vault_version_lt("1.12.0"), '"conflicting_alias_ids_to_keep" added in Vault v1.12.0'
+    )
+    def test_merge_entities_conflicting(self, label, raises=None, exception_message=""):
+        create_response = self.client.secrets.identity.create_or_update_entity(
+            name=self.TEST_ENTITY_NAME,
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug("create_response: %s" % create_response)
+        create_response2 = self.client.secrets.identity.create_or_update_entity(
+            name="%s2" % self.TEST_ENTITY_NAME,
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug("create_response2: %s" % create_response2)
+        create_response3 = self.client.secrets.identity.create_or_update_entity(
+            name="%s3" % self.TEST_ENTITY_NAME,
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug("create_response3: %s" % create_response3)
+        parent_id = create_response["data"]["id"]
+        merge_id1 = create_response2["data"]["id"]
+        merge_id2 = create_response3["data"]["id"]
+
+        merge_entities_response = self.client.secrets.identity.merge_entities(
+            from_entity_ids=[merge_id1],
+            to_entity_id=parent_id,
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+        logging.debug("merge_entities_response: %s" % merge_entities_response)
+
+        if raises:
+            with self.assertRaises(raises) as cm:
+                self.client.secrets.identity.merge_entities(
+                    from_entity_ids=merge_id2,
+                    to_entity_id=parent_id,
+                    mount_point=self.TEST_MOUNT_POINT,
+                    conflicting_alias_ids_to_keep=[merge_id1]
+                )
+            self.assertIn(
+                member=exception_message,
+                container=str(cm.exception),
+            )
+        else:
+            merge_conflicting_entities_response = self.client.secrets.identity.merge_entities(
+                from_entity_ids=merge_id2,
+                to_entity_id=parent_id,
+                mount_point=self.TEST_MOUNT_POINT,
+                conflicting_alias_ids_to_keep=[merge_id1]
+            )
+            logging.debug("merge_conflicting_entities_response: %s" % merge_conflicting_entities_response)
+            self.assertEqual(
+                first=bool(merge_conflicting_entities_response),
+                second=True,
+            )
+
 
     @parameterized.expand(
         [

--- a/tests/integration_tests/api/secrets_engines/test_identity.py
+++ b/tests/integration_tests/api/secrets_engines/test_identity.py
@@ -647,7 +647,8 @@ class TestIdentity(HvacIntegrationTestCase, TestCase):
         ]
     )
     @skipIf(
-        utils.vault_version_lt("1.12.0"), '"conflicting_alias_ids_to_keep" added in Vault v1.12.0'
+        utils.vault_version_lt("1.12.0"),
+        '"conflicting_alias_ids_to_keep" added in Vault v1.12.0',
     )
     def test_merge_entities_conflicting(self, label, raises=None, exception_message=""):
         create_response = self.client.secrets.identity.create_or_update_entity(
@@ -682,25 +683,29 @@ class TestIdentity(HvacIntegrationTestCase, TestCase):
                     from_entity_ids=merge_id2,
                     to_entity_id=parent_id,
                     mount_point=self.TEST_MOUNT_POINT,
-                    conflicting_alias_ids_to_keep=[merge_id1]
+                    conflicting_alias_ids_to_keep=[merge_id1],
                 )
             self.assertIn(
                 member=exception_message,
                 container=str(cm.exception),
             )
         else:
-            merge_conflicting_entities_response = self.client.secrets.identity.merge_entities(
-                from_entity_ids=merge_id2,
-                to_entity_id=parent_id,
-                mount_point=self.TEST_MOUNT_POINT,
-                conflicting_alias_ids_to_keep=[merge_id1]
+            merge_conflicting_entities_response = (
+                self.client.secrets.identity.merge_entities(
+                    from_entity_ids=merge_id2,
+                    to_entity_id=parent_id,
+                    mount_point=self.TEST_MOUNT_POINT,
+                    conflicting_alias_ids_to_keep=[merge_id1],
+                )
             )
-            logging.debug("merge_conflicting_entities_response: %s" % merge_conflicting_entities_response)
+            logging.debug(
+                "merge_conflicting_entities_response: %s"
+                % merge_conflicting_entities_response
+            )
             self.assertEqual(
                 first=bool(merge_conflicting_entities_response),
                 second=True,
             )
-
 
     @parameterized.expand(
         [


### PR DESCRIPTION
As of Vault v1.12, a new argument was added to the /identity/entity/merge endpoint.
This commit add the conflicting_alias_ids_to_keep argument to Identity.merge_entities() method in hvac/api/secrets_engines/identity.py

References:
https://developer.hashicorp.com/vault/api-docs/secret/identity/entity#merge-entities
https://github.com/hashicorp/vault/pull/16539
