### PR TITLE
feat: add support for disable_local_ca_jwt in kubernetes auth method

### DIFF
--- a/hvac/api/auth_methods/kubernetes.py
+++ b/hvac/api/auth_methods/kubernetes.py
@@ -25,6 +25,7 @@ class Kubernetes(VaultApiBase):
         pem_keys=None,
         issuer=None,
         mount_point=DEFAULT_MOUNT_POINT,
+        disable_local_ca_jwt=False,
     ):
         """Configure the connection parameters for Kubernetes.
 
@@ -50,6 +51,8 @@ class Kubernetes(VaultApiBase):
         :type token_reviewer_jwt: str | unicode
         :param mount_point: The "path" the method/backend was mounted on.
         :type mount_point: str | unicode
+        :param disable_local_ca_jwt: Disable defaulting to the local CA cert and service account JWT
+        :type disable_local_ca_jwt: bool
         :return: The response of the configure_method request.
         :rtype: requests.Response
         """
@@ -66,6 +69,7 @@ class Kubernetes(VaultApiBase):
 
         params = {
             "kubernetes_host": kubernetes_host,
+            "disable_local_ca_jwt": disable_local_ca_jwt,
         }
         params.update(
             utils.remove_nones(

--- a/tests/integration_tests/api/auth_methods/test_kubernetes.py
+++ b/tests/integration_tests/api/auth_methods/test_kubernetes.py
@@ -59,6 +59,14 @@ class TestKubernetes(HvacIntegrationTestCase, TestCase):
                 if utils.vault_version_lt("1.11.0")
                 else "compact JWS format must have three parts",
             ),
+            param(
+                "missing kubernetes_ca_cert",
+                disable_local_ca_jwt=True,
+                raises=exceptions.InvalidRequest,
+                exception_message="one of pem_keys or kubernetes_ca_cert must be set"
+                if utils.vault_version_lt("1.10.0")
+                else "kubernetes_ca_cert must be given",
+            ),
         ]
     )
     def test_configure(
@@ -68,6 +76,7 @@ class TestKubernetes(HvacIntegrationTestCase, TestCase):
         token_reviewer_jwt=None,
         pem_keys=None,
         issuer=None,
+        disable_local_ca_jwt=False,
         raises=None,
         exception_message="",
     ):
@@ -80,6 +89,7 @@ class TestKubernetes(HvacIntegrationTestCase, TestCase):
                     token_reviewer_jwt=token_reviewer_jwt,
                     pem_keys=pem_keys,
                     mount_point=self.TEST_MOUNT_POINT,
+                    disable_local_ca_jwt=disable_local_ca_jwt,
                 )
             self.assertIn(member=exception_message, container=str(cm.exception))
         else:
@@ -88,6 +98,7 @@ class TestKubernetes(HvacIntegrationTestCase, TestCase):
                 kubernetes_ca_cert="-----BEGIN CERTIFICATE-----\\n.....\\n-----END CERTIFICATE-----",
                 mount_point=self.TEST_MOUNT_POINT,
                 issuer="bob",
+                disable_local_ca_jwt=disable_local_ca_jwt,
             )
             logging.debug("configure_response: %s" % configure_response)
             self.assertEqual(


### PR DESCRIPTION
Add support for `disable_local_ca_jwt` in the Kubernetes auth method.