### PR TITLE
support "user_claim_json_pointer" in create_role() for JWT auth method

### DIFF
--- a/hvac/api/auth_methods/jwt.py
+++ b/hvac/api/auth_methods/jwt.py
@@ -179,7 +179,7 @@ class JWT(VaultApiBase):
         :type bound_audiences: list
         :param user_claim: The claim to use to uniquely identify the user; this will be used as the name for the
             Identity entity alias created due to a successful login. The interpretation of the user claim
-            is configured with user_claim_json_pointer. If set to True, user_claim supports JSON pointer syntax 
+            is configured with user_claim_json_pointer. If set to True, user_claim supports JSON pointer syntax
             for referencing a claim. The claim value must be a string.
         :type user_claim: str | unicode
         :param clock_skew_leeway: Only applicable with "jwt" roles.
@@ -243,9 +243,9 @@ class JWT(VaultApiBase):
         :type token_type: str
         :param path: The "path" the method/backend was mounted on.
         :type path: str | unicode
-        :param user_claim_json_pointer: Specifies if the user_claim value uses JSON pointer syntax for referencing claims. 
-            By default, the user_claim value will not use JSON pointer. 
-        :type user_claim_json_pointer: bool | str
+        :param user_claim_json_pointer: Specifies if the user_claim value uses JSON pointer syntax for referencing claims.
+            By default, the user_claim value will not use JSON pointer.
+        :type user_claim_json_pointer: bool
         :return: The response of the create_role request.
         :rtype: dict
         """

--- a/hvac/api/auth_methods/jwt.py
+++ b/hvac/api/auth_methods/jwt.py
@@ -159,6 +159,7 @@ class JWT(VaultApiBase):
         token_period=None,
         token_type=None,
         path=None,
+        user_claim_json_pointer=False,
     ):
         """Register a role in the JWT method.
 
@@ -177,7 +178,9 @@ class JWT(VaultApiBase):
             Required for "jwt" roles, optional for "oidc" roles.
         :type bound_audiences: list
         :param user_claim: The claim to use to uniquely identify the user; this will be used as the name for the
-            Identity entity alias created due to a successful login. The claim value must be a string.
+            Identity entity alias created due to a successful login. The interpretation of the user claim
+            is configured with user_claim_json_pointer. If set to True, user_claim supports JSON pointer syntax 
+            for referencing a claim. The claim value must be a string.
         :type user_claim: str | unicode
         :param clock_skew_leeway: Only applicable with "jwt" roles.
         :type clock_skew_leeway: int
@@ -240,6 +243,9 @@ class JWT(VaultApiBase):
         :type token_type: str
         :param path: The "path" the method/backend was mounted on.
         :type path: str | unicode
+        :param user_claim_json_pointer: Specifies if the user_claim value uses JSON pointer syntax for referencing claims. 
+            By default, the user_claim value will not use JSON pointer. 
+        :type user_claim_json_pointer: bool | str
         :return: The response of the create_role request.
         :rtype: dict
         """
@@ -269,6 +275,7 @@ class JWT(VaultApiBase):
                 "token_num_uses": token_num_uses,
                 "token_period": token_period,
                 "token_type": token_type,
+                "user_claim_json_pointer": user_claim_json_pointer,
             }
         )
         api_path = utils.format_url(

--- a/hvac/api/auth_methods/oidc.py
+++ b/hvac/api/auth_methods/oidc.py
@@ -65,7 +65,7 @@ class OIDC(JWT):
         :type bound_audiences: list
         :param user_claim: The claim to use to uniquely identify the user; this will be used as the name for the
             Identity entity alias created due to a successful login. The interpretation of the user claim
-            is configured with user_claim_json_pointer. If set to True, user_claim supports JSON pointer syntax 
+            is configured with user_claim_json_pointer. If set to True, user_claim supports JSON pointer syntax
             for referencing a claim. The claim value must be a string.
         :type user_claim: str | unicode
         :param clock_skew_leeway: Only applicable with "jwt" roles.
@@ -129,9 +129,9 @@ class OIDC(JWT):
         :type token_type: str
         :param path: The "path" the method/backend was mounted on.
         :type path: str | unicode
-        :param user_claim_json_pointer: Specifies if the user_claim value uses JSON pointer syntax for referencing claims. 
-            By default, the user_claim value will not use JSON pointer. 
-        :type user_claim_json_pointer: bool | str
+        :param user_claim_json_pointer: Specifies if the user_claim value uses JSON pointer syntax for referencing claims.
+            By default, the user_claim value will not use JSON pointer.
+        :type user_claim_json_pointer: bool
         :return: The response of the create_role request.
         :rtype: dict
         """

--- a/hvac/api/auth_methods/oidc.py
+++ b/hvac/api/auth_methods/oidc.py
@@ -45,6 +45,7 @@ class OIDC(JWT):
         token_period=None,
         token_type=None,
         path=None,
+        user_claim_json_pointer=False,
     ):
         """Register a role in the OIDC method.
 
@@ -63,7 +64,9 @@ class OIDC(JWT):
             Required for "jwt" roles, optional for "oidc" roles.
         :type bound_audiences: list
         :param user_claim: The claim to use to uniquely identify the user; this will be used as the name for the
-            Identity entity alias created due to a successful login. The claim value must be a string.
+            Identity entity alias created due to a successful login. The interpretation of the user claim
+            is configured with user_claim_json_pointer. If set to True, user_claim supports JSON pointer syntax 
+            for referencing a claim. The claim value must be a string.
         :type user_claim: str | unicode
         :param clock_skew_leeway: Only applicable with "jwt" roles.
         :type clock_skew_leeway: int
@@ -126,6 +129,9 @@ class OIDC(JWT):
         :type token_type: str
         :param path: The "path" the method/backend was mounted on.
         :type path: str | unicode
+        :param user_claim_json_pointer: Specifies if the user_claim value uses JSON pointer syntax for referencing claims. 
+            By default, the user_claim value will not use JSON pointer. 
+        :type user_claim_json_pointer: bool | str
         :return: The response of the create_role request.
         :rtype: dict
         """
@@ -156,4 +162,5 @@ class OIDC(JWT):
             token_period=token_period,
             token_type=token_type,
             path=path,
+            user_claim_json_pointer=user_claim_json_pointer,
         )


### PR DESCRIPTION
When creating a role for the JWT auth method, the optional parameter "user_claim_json_pointer" is missing.
See documentation here: 

https://developer.hashicorp.com/vault/api-docs/auth/jwt#user_claim_json_pointer

The parameter is a bool value which defaults to false.
This pull request adds the missing parameter. I tested it for JWT auth and it works.
The parameter can be bool or a str containing "true" or "false".
If a wrong parameter is given, the server returns a corresponding error message.

The OIDC auth mehod inherits create_role() from JWT. 
So, I also added this parameter to ODIC.create_role(). 
The OIDC use case was not tested.

Documentation was updated.
