### PR TITLE
update publishing workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -5,10 +5,10 @@ on:
     types: [published]
 
 jobs:
-  deploy:
-
-    runs-on: ubuntu-20.04
-
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v3
 
@@ -34,8 +34,47 @@ jobs:
       run: poetry install --no-interaction
 
     - name: Build and publish
-      env:
-        PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        poetry publish --build --username "${PYPI_USERNAME}" --password "${PYPI_PASSWORD}"
+        poetry build
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: package
+        path: dist/
+        retention-days: 1
+        if-no-files-found: error
+
+  pypi:
+    needs: [build]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment:
+        name: pypi-publishing
+        url: https://pypi.org/project/hvac/
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: package
+
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  asset:
+    needs: [build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: package
+
+      - name: Add release asset
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
+        with:
+          files: |
+            dist/*


### PR DESCRIPTION
This is a re-submission of #1000, after updating the default branch of the project from `develop` to `main`, due to #980 .

Original content follows.

---


The [recent release of `v1.1.1`](https://github.com/hvac/hvac/releases/tag/v1.1.1) has [failed to upload to PyPI](https://github.com/hvac/hvac/actions/runs/5299352706/jobs/9592255392), due to issues with the credentials we're using.

Rather than replace the existing credentials with an API token, it seemed like a good opportunity to revisit our publishing workflow and use the new [OIDC support for publishing to PyPI](https://docs.pypi.org/trusted-publishers/).

I have:
* added updated our PyPI to add our GitHub publishing workflow as a trusted publisher.
* added a new deployment environment in GitHub called `pypi-publishing` for running the workflow; it limits the branch that it can run against and has some additional restrictions which we can tweak in the future.

This PR changes the publishing workflow in the following ways:
* the single job has been split into 3 jobs
* the `build` job is responsible for publishing the package itself; it has access only to the repository contents and it produces a build artifact
* the `asset` job is new; it downloads the artifact and adds it as a release asset, that way our package is directly downloadable from the releases page (this is a nice-to-have)
* the `publish` job downloads the artifact, and then publishes it to PyPI. It has no access to repository contents and it runs in the dedicated publish environment
* the latter two jobs can run in parallel because they don't depend on each other, but they both depend on the build job completing first
* `poetry` is no longer used to publish the artifact, in favor of using the official PyPI github action which directly supports the OIDC integration nicely
* the credentials we have stored in the repository are not used anymore, and once we have a working implementation with OIDC, they will be deleted

### Testing note
This workflow is triggered on release publishing, and as a result, it cannot be tested in this PR.