### PR TITLE
update workflows and CI for new git/release process

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -5,7 +5,7 @@ updateDocsComment: >
   Thanks for opening this pull request!
   The maintainers of this repository would appreciate it if you would update some of our documentation based on your changes.
 
-  See: https://github.com/hvac/hvac/blob/develop/CONTRIBUTING.md#documentation
+  See: https://github.com/hvac/hvac/blob/main/CONTRIBUTING.md#documentation
 
 updateDocsWhiteList:
   - bug

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,6 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
-commitish: 'refs/heads/develop'
+commitish: 'refs/heads/main'
 exclude-labels:
   - 'release'
   - 'skip-changelog'

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -4,11 +4,9 @@ on:
   push:
     branches:
       - main
-      - develop
   pull_request:
     branches:
       - main
-      - develop
 
 jobs:
   build:

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -4,11 +4,9 @@ on:
   push:
     branches:
       - main
-      - develop
   pull_request:
     branches:
       - main
-      - develop
 
 jobs:
   lint:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,7 +3,7 @@ name: Release Drafter
 on:
   push:
     branches:
-      - develop
+      - main
   workflow_dispatch: {}
 
 permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,12 +94,15 @@ Due to the close connection between this module and HashiCorp Vault versions, br
 
 ## Creating / Publishing Releases
 
-- [ ] Checkout the `develop` branch:
+- [ ] Ensure your local `main` branch is up to date, and then checkout a new branch to create a release PR:
 
   ```
-  git checkout develop
+  git checkout main
   git pull
+  # git pull upstream main
+  git checkout -b release/vX.Y.Z
   ```
+
 - [ ] Update the version number using [Poetry](https://python-poetry.org/docs/). Releases typically just use the "patch" bumpversion option; but "minor" and "major" are available as needed. This will also add an appropriate git commit for the new version.
 
   ```
@@ -110,7 +113,7 @@ Due to the close connection between this module and HashiCorp Vault versions, br
   ```
   git commit CHANGELOG.md -m "Changelog updates for v$(grep -oP '(?<=current_version = ).*' .bumpversion.cfg)"
   ```
-- [ ] Git push the updated develop branch (`git push`) and open a PR to rebase merge the develop branch into main:  [https://github.com/hvac/hvac/compare/main...develop](https://github.com/hvac/hvac/compare/main...develop). Ensure the PR has the "release" label applied and then merge it.
+- [ ] Git push the release branch (`git push`) and open a PR. Ensure the PR has the "release" label applied and then merge it after review.
 
-- [ ] Publish the draft release on GitHub: [https://github.com/hvac/hvac/releases](https://github.com/hvac/hvac/releases). Ensure the tag is set to the release name (e.g., vX.X.X) and the target is the main branch.
+- [ ] Publish the draft release on GitHub: [https://github.com/hvac/hvac/releases](https://github.com/hvac/hvac/releases). Ensure the tag is set to the release name (e.g., vX.X.X) and the target is the `main` branch.
   NOTE: [release-drafter](https://github.com/toolmantim/release-drafter) sets the release name by default. If performing a minor or major update, these values will need to be manually updated before publishing the draft release subsequently.


### PR DESCRIPTION
Resolves #980 

This PR makes changes in support of the proposal in #980.

The default branch for the repository has already been updated to `main`.