### PR TITLE
PyPI publish follow-up

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -58,6 +58,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: package
+          path: dist
 
       - name: Publish
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -72,6 +73,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: package
+          path: dist
 
       - name: Add release asset
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -60,6 +60,9 @@ jobs:
           name: package
           path: dist
 
+      - name: Show tree
+        run: tree
+
       - name: Publish
         uses: pypa/gh-action-pypi-publish@release/v1
 
@@ -74,6 +77,9 @@ jobs:
         with:
           name: package
           path: dist
+
+      - name: Show tree
+        run: tree
 
       - name: Add release asset
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -84,5 +84,6 @@ jobs:
       - name: Add release asset
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
         with:
+          fail_on_unmatched_files: true
           files: |
             dist/*


### PR DESCRIPTION
Follow-up to #1002 

* Artifact download path was not set, so publishing and asset attachment did not work; fixed that
* Added a tree output to help diagnose these things better in the future
* The asset job "succeeded" with a warning when it couldn't match files, not it will fail

Just as before, this can't be tested in PR form. Will merge, then re-release.
