### PR TITLE
docs: make OIDC Authorization URL Request example work again.

### DIFF
--- a/docs/usage/auth_methods/jwt-oidc.rst
+++ b/docs/usage/auth_methods/jwt-oidc.rst
@@ -142,36 +142,81 @@ OIDC Authorization URL Request
 
 :py:meth:`hvac.api.auth_methods.JWT.oidc_authorization_url_request`
 
+This is equivalent to `vault login -method=oidc`
+
 .. code:: python
 
     import webbrowser
     import http.server
     import hvac
-    client = hvac.Client()
+    import urllib.parse
 
-    auth_url_response = client.auth.oidc.oidc_authorization_url_request(
-        role='hvac',
-        redirect_uri='http://localhost:8250/oidc/callback'
-    )
-    auth_url = auth_url_response['data']['auth_url']
-    if auth_url == '':
-        return None
+    # CHANGEME: these params might have to be changed to match your Vault configuration.
+    # Specifically
+    # 1. auth/oidc/role/XXX allowed_redirect_uris must contain the
+    #    OIDC_REDIRECT_URI string used below.
+    # 2. Role must match your environment's role for this client.
+    OIDC_CALLBACK_PORT = 8250
+    OIDC_REDIRECT_URI = f'http://localhost:{OIDC_CALLBACK_PORT}/oidc/callback'
+    ROLE = 'hvac' # Use None (not empty string) for the default Role
+    SELF_CLOSING_PAGE = '''
+    <!doctype html>
+    <html>
+    <head>
+    <script>
+    // Closes IE, Edge, Chrome, Brave
+    window.onload = function load() {
+      window.open('', '_self', '');
+      window.close();
+    };
+    </script>
+    </head>
+    <body>
+      <p>Authentication successful, you can close the browser now.</p>
+      <script>
+        // Needed for Firefox security
+        setTimeout(function() {
+              window.close()
+        }, 5000);
+      </script>
+    </body>
+    </html>
+    '''
 
-    params = parse.parse_qs(auth_url.split('?')[1])
-    auth_url_nonce = params['nonce'][0]
-    auth_url_state = params['state'][0]
+    def main():
+        client = hvac.Client()
 
-    webbrowser.open(auth_url)
-    token = login_odic_get_token()
+        auth_url_response = client.auth.oidc.oidc_authorization_url_request(
+            role=ROLE,
+            redirect_uri=OIDC_REDIRECT_URI,
+        )
+        auth_url = auth_url_response['data']['auth_url']
+        if auth_url == '':
+            return None # TODO: throw a nicer error
 
-    auth_result = client.auth.oidc.oidc_callback(
-        code=token, path='oidc', nonce=auth_url_nonce, state=auth_url_state
-    )
+        params = urllib.parse.parse_qs(auth_url.split('?')[1])
+        auth_url_nonce = params['nonce'][0]
+        auth_url_state = params['state'][0]
 
-    print('Client token returned: %s' % auth_result['auth']['client_token'])
+        webbrowser.open(auth_url)
+        token = login_oidc_get_token()
+
+        auth_result = client.auth.oidc.oidc_callback(
+            code=token,
+            path='oidc',
+            nonce=auth_url_nonce,
+            state=auth_url_state,
+        )
+        new_token = auth_result['auth']['client_token']
+        print(f'Client token returned: {new_token}')
+
+        # If you want to continue using the client here
+        # update the client to use the new token
+        client.token = new_token
+        return client
 
     # handles the callback
-    def login_odic_get_token(self):
+    def login_oidc_get_token():
         from http.server import BaseHTTPRequestHandler, HTTPServer
 
         class HttpServ(HTTPServer):
@@ -183,16 +228,22 @@ OIDC Authorization URL Request
             token = ''
 
             def do_GET(self):
-                params = parse.parse_qs(self.path.split('?')[1])
+                params = urllib.parse.parse_qs(self.path.split('?')[1])
                 self.server.token = params['code'][0]
                 self.send_response(200)
                 self.end_headers()
-                self.wfile.write(str.encode('<div>Authentication successful, you can close the browser now.</div>'))
+                self.wfile.write(str.encode(SELF_CLOSING_PAGE))
 
-        server_address = ('', 8250)
+        server_address = ('', OIDC_CALLBACK_PORT)
         httpd = HttpServ(server_address, AuthHandler)
         httpd.handle_request()
         return httpd.token
+
+    if __name__ == '__main__':
+        client = main()
+        if client and client.is_authenticated():
+            # Do something
+            pass
 
 
 JWT Login


### PR DESCRIPTION
- Import `urllib.parse` so parse works.
- Document how this interacts with OIDC allowed_redirect_uris & roles.
- Python used a `return` outside of any function, add a `main()` function to keep the code clean.
- Fix `odic` mis-spelling.
- Add a nicer HTML redirect page

Signed-off-by: Robin H. Johnson <rjohnson@coreweave.com>