### PR TITLE
retain build compat with py3.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,5 +66,5 @@ packaging = "<23"
 bump2version = "^1.0.1"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.0.0,<1.1"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,5 +66,5 @@ packaging = "<23"
 bump2version = "^1.0.1"
 
 [build-system]
-requires = ["poetry-core>=1.0.0,<1.1"]
+requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ python = "^3.6.2"
 pyhcl = "^0.4.4"
 requests = "^2.27.1"
 
-[tool.poetry.group.dev.dependencies]
+[tool.poetry.dev-dependencies]
 Werkzeug = "2.0.3"
 Authlib = "^1.0.1"
 black = "22.6.0"


### PR DESCRIPTION
CI is failing now after merging #1015 , only on python 3.6, even though CI was passing with the PR contents. I believe this might have something to do with changes made in #1016 which was merged shortly before. The CI on that one was also passing, but the sdsist installation tests didn't exist then, so I think this failure is a combination of the issues.

Failure:
- https://github.com/hvac/hvac/actions/runs/5393829500/jobs/9794479959

The error looks like what's described here:
- https://github.com/python-poetry/poetry/issues/7477

that despite poetry supporting python 3.6, poetry-core had already dropped it. I don't really see _how_ the changes in #1016 affected that, since it didn't change the poetry core version, but I'm attempting to fix it for this one release that we're doing before [we drop Python 3.6](https://github.com/hvac/hvac/issues/877) in 2.0 soon.