### PR TITLE
adapters: if `session` is user-supplied, do not overwrite session options with `Client`/`Adapter` options

### DIFF
--- a/hvac/adapters.py
+++ b/hvac/adapters.py
@@ -90,6 +90,15 @@ class Adapter(metaclass=ABCMeta):
         if not session:
             session = requests.Session()
             session.cert, session.verify, session.proxies = cert, verify, proxies
+        # fix for issue 991 using session verify if set
+        else:
+            if session.verify:
+                # need to set the variable and not assign it to self so it is propperly passed in kwargs
+                verify = session.verify
+            if session.cert:
+                cert = session.cert
+            if session.proxies:
+                proxies = session.proxies
 
         self.base_uri = base_uri
         self.token = token

--- a/tests/unit_tests/test_adapters.py
+++ b/tests/unit_tests/test_adapters.py
@@ -46,6 +46,11 @@ class TestAdapters:
         ],
     )
     def test_from_adapter(self, conargs):
+        session = requests.Session()
+        session.cert = conargs["cert"]
+        session.verify = conargs["verify"]
+        session.proxies = conargs["proxies"]
+        conargs["session"] = session
         expected = conargs.copy()
         for internal_kwarg in self.INTERNAL_KWARGS:
             expected.setdefault("_kwargs", {})[internal_kwarg] = expected.pop(

--- a/tests/unit_tests/test_adapters.py
+++ b/tests/unit_tests/test_adapters.py
@@ -262,3 +262,55 @@ class TestAdapterVerify(TestCase):
             c = Client()
         assert c._adapter.session.verify == verify
         assert c._adapter.session
+
+    @parameterized.expand(
+        [
+            param("Testing default", cert=None, use_session=False),
+            param("Testing default with session", cert=None, use_session=False),
+            param(
+                "use certificate for #991",
+                cert=utils.get_config_file_path("client-cert.pem"),
+                use_session=False,
+            ),
+            param(
+                "use certificate from session #991",
+                cert=utils.get_config_file_path("client-cert.pem"),
+                use_session=True,
+            ),
+        ]
+    )
+    def test_session_certificate_stickiness(self, label, cert, use_session):
+        if use_session:
+            s = requests.Session()
+            s.cert = cert
+            c = Client(session=s)
+        elif cert is not None:
+            c = Client(cert=cert)
+        else:
+            c = Client()
+        assert c._adapter.session.cert == cert
+        assert c._adapter.session
+
+    @parameterized.expand(
+        [
+            param("Testing default", proxies=None, use_session=False),
+            param(
+                "Testing default session",
+                proxies=None,
+                use_session=True,
+            ),
+            param("Testing Proxy", proxies="localhost:8080", use_session=False),
+            param("Testing Proxy session", proxies="localhost:8080", use_session=True),
+        ]
+    )
+    def test_session_proxies_stickiness(self, label, proxies, use_session):
+        if use_session:
+            s = requests.Session()
+            s.proxies = proxies
+            c = Client(session=s)
+        elif proxies is not None:
+            c = Client(proxies=proxies)
+        else:
+            c = Client()
+        assert c._adapter.session.proxies == proxies
+        assert c._adapter.session

--- a/tests/unit_tests/test_adapters.py
+++ b/tests/unit_tests/test_adapters.py
@@ -262,4 +262,3 @@ class TestAdapterVerify(TestCase):
             c = Client()
         assert c._adapter.session.verify == verify
         assert c._adapter.session
-

--- a/tests/unit_tests/test_adapters.py
+++ b/tests/unit_tests/test_adapters.py
@@ -46,11 +46,8 @@ class TestAdapters:
         ],
     )
     def test_from_adapter(self, conargs):
-        session = requests.Session()
-        session.cert = conargs["cert"]
-        session.verify = conargs["verify"]
-        session.proxies = conargs["proxies"]
-        conargs["session"] = session
+        # set session to None so that the adapter will create its own internally
+        conargs["session"] = None
         expected = conargs.copy()
         for internal_kwarg in self.INTERNAL_KWARGS:
             expected.setdefault("_kwargs", {})[internal_kwarg] = expected.pop(
@@ -59,6 +56,9 @@ class TestAdapters:
 
         # let's start with a JSONAdapter, and make a RawAdapter out of it
         json_adapter = adapters.JSONAdapter(**conargs)
+
+        # reset the expected session to to be the one created by the JSONAdapter
+        expected["session"] = json_adapter.session
 
         raw_adapter = adapters.RawAdapter.from_adapter(json_adapter)
 


### PR DESCRIPTION
Fixes: #991

# Breaking change
For more details see also:
- https://github.com/hvac/hvac/issues/1040

Before this change:
* if you do not use a custom `session`, a session is created for you with values for the `verify`, `cert`, and `proxies` settings that are set in the adapter, either explicitly or by default
* if you _do_ use a custom `session`:
  * the values in the `session` will always be overwritten with the adapter values, whether you specified them or not

After this change:
* if you do not use a custom `session`, a session is created for you with values for the `verify`, `cert`, and `proxies` settings that are set in the adapter, either explicitly or by default
* if you _do_ use a custom `session`:
  * if any value is set for the `verify`, `cert`, or `proxies` properties in your custom `session`, then that value will be kept and the adapter's value will be ignored, even if you set it on the adapter explicitly
  * if any of those properties _are not set_ then they will be set based on the adapter's value for those

The only case where this should cause breakage of existing code is where all of the following are true:
* you use a custom session
* you set any of the affected properties on the custom session
* the value(s) you set on those properties are actually invalid for your use case, and so your code relied on the adapter defaults overriding your values

