### PR TITLE
expand Vault CI matrix, announce deprecation of Vault dynamic SSH keys

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -165,14 +165,17 @@ jobs:
         python-version:
           - 3.7
         vault-version:
-          - "vault-enterprise=1.6.5+ent"
-          - "vault-enterprise=1.7.2+ent"
-          - "vault=1.6.5"
-          - "vault=1.7.2"
-          - "vault=1.8.0"
-          - "vault=1.9.0"
-          - "vault=1.10.0"
-          - "vault=1.11.0-1"
+          - "vault-enterprise=1.6.*+ent"
+          - "vault-enterprise=1.7.*+ent"
+          - "vault=1.6.*"
+          - "vault=1.7.*"
+          - "vault=1.8.*"
+          - "vault=1.9.*"
+          - "vault=1.10.*"
+          - "vault=1.11.*"
+          - "vault=1.12.*"
+          - "vault=1.13.*"
+          - "vault=1.14.*"
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -11,6 +11,9 @@ on:
 permissions:
   contents: read
 
+env:
+  PYTEST_ADDOPTS: '--color=yes'
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -173,14 +173,15 @@ jobs:
         vault-version:
           - "vault-enterprise=1.6.*+ent"
           - "vault-enterprise=1.7.*+ent"
-          - "vault-enterprise=1.8.*+ent"
-          - "vault-enterprise=1.9.*+ent"
-          - "vault-enterprise=1.10.*+ent"
-          - "vault-enterprise=1.11.*+ent"
-          - "vault-enterprise=1.12.*+ent"
-          - "vault-enterprise=1.13.*+ent"
-          - "vault-enterprise=1.14.*+ent"
-          - "vault=1.*"
+          - "vault=1.6.*"
+          - "vault=1.7.*"
+          - "vault=1.8.*"
+          - "vault=1.9.*"
+          - "vault=1.10.*"
+          - "vault=1.11.*"
+          - "vault=1.12.*"
+          - "vault=1.13.*"
+          - "vault=1.14.*"
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -173,15 +173,14 @@ jobs:
         vault-version:
           - "vault-enterprise=1.6.*+ent"
           - "vault-enterprise=1.7.*+ent"
-          - "vault=1.6.*"
-          - "vault=1.7.*"
-          - "vault=1.8.*"
-          - "vault=1.9.*"
-          - "vault=1.10.*"
-          - "vault=1.11.*"
-          - "vault=1.12.*"
-          - "vault=1.13.*"
-          - "vault=1.14.*"
+          - "vault-enterprise=1.8.*+ent"
+          - "vault-enterprise=1.9.*+ent"
+          - "vault-enterprise=1.10.*+ent"
+          - "vault-enterprise=1.11.*+ent"
+          - "vault-enterprise=1.12.*+ent"
+          - "vault-enterprise=1.13.*+ent"
+          - "vault-enterprise=1.14.*+ent"
+          - "vault=1.*"
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -16,6 +16,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - "3.6"
@@ -110,6 +111,7 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - "3.6"
@@ -161,6 +163,7 @@ jobs:
     name: Integration Tests
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - 3.7

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -151,7 +151,7 @@ jobs:
       run: |
         poetry run pytest \
           --cov=hvac \
-          --cov-report=xml:reports/coverage_py${{ matrix.python-version }}.xml \
+          --cov-report=xml:reports/coverage_units_py${{ matrix.python-version }}.xml \
           tests/unit_tests
 
     - name: Upload unit tests coverage artifacts
@@ -229,7 +229,7 @@ jobs:
 
     - name: pytest tests/integration_tests
       env:
-        COVFILE: coverage_py${{ matrix.python-version }}_${{ matrix.vault-version }}.xml
+        COVFILE: coverage_integration_py${{ matrix.python-version }}_${{ matrix.vault-version }}.xml
       run: |
         poetry run pytest \
           --cov=hvac \

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,10 +1,9 @@
 comment:
   layout: "diff, files"
   behavior: default
-  require_changes: true
-  require_base: yes
-  require_head: yes
-  branches: null
+  require_changes: false
+  require_base: true
+  require_head: true
 
 coverage:
   status:

--- a/hvac/api/secrets_engines/ssh.py
+++ b/hvac/api/secrets_engines/ssh.py
@@ -14,13 +14,14 @@ class Ssh(VaultApiBase):
     Reference: https://www.vaultproject.io/api-docs/secret/ssh
     """
 
+    # TODO: deprecate all dynamic SSH keys methods from hvac
     def create_or_update_key(
         self,
         name="",
         key="",
         mount_point=DEFAULT_MOUNT_POINT,
     ):
-        """This endpoint updates a named key.
+        """This endpoint updates a named key. This method uses deprecated functionality that was removed in Vault 1.13.0.
 
         :param name: Specifies the name of the key to create.
         :type name: str | unicode
@@ -46,12 +47,13 @@ class Ssh(VaultApiBase):
             json=params,
         )
 
+    # TODO: deprecate all dynamic SSH keys methods from hvac
     def delete_key(
         self,
         name="",
         mount_point=DEFAULT_MOUNT_POINT,
     ):
-        """This endpoint deletes a named key.
+        """This endpoint deletes a named key. This method uses deprecated functionality that was removed in Vault 1.13.0.
 
         :param name: Specifies the name of the key to delete.
         :type name: str | unicode

--- a/tests/integration_tests/api/auth_methods/test_kubernetes.py
+++ b/tests/integration_tests/api/auth_methods/test_kubernetes.py
@@ -64,7 +64,9 @@ class TestKubernetes(HvacIntegrationTestCase, TestCase):
                 disable_local_ca_jwt=True,
                 raises=exceptions.InvalidRequest,
                 exception_message="one of pem_keys or kubernetes_ca_cert must be set"
-                if utils.vault_version_lt("1.10.0")
+                if utils.vault_version_lt(
+                    "1.9.5"
+                )  # guessing based on 1.9.4 changelog touching kubernetes auth
                 else "kubernetes_ca_cert must be given",
             ),
         ]

--- a/tests/integration_tests/api/secrets_engines/test_azure.py
+++ b/tests/integration_tests/api/secrets_engines/test_azure.py
@@ -111,7 +111,7 @@ class TestAzure(HvacIntegrationTestCase, TestCase):
         }
         if utils.vault_version_ge("1.9.0"):
             read_expected_response["root_password_ttl"] = 0
-            if utils.vault_version_lt("1.13.0"):
+            if utils.vault_version_lt("1.12.0"):
                 read_expected_response["use_microsoft_graph_api"] = False
         self.assertEqual(
             first=read_expected_response,

--- a/tests/integration_tests/api/secrets_engines/test_azure.py
+++ b/tests/integration_tests/api/secrets_engines/test_azure.py
@@ -111,7 +111,8 @@ class TestAzure(HvacIntegrationTestCase, TestCase):
         }
         if utils.vault_version_ge("1.9.0"):
             read_expected_response["root_password_ttl"] = 0
-            read_expected_response["use_microsoft_graph_api"] = False
+            if utils.vault_version_lt("1.13.0"):
+                read_expected_response["use_microsoft_graph_api"] = False
         self.assertEqual(
             first=read_expected_response,
             second=read_configuration_response,

--- a/tests/integration_tests/api/secrets_engines/test_identity.py
+++ b/tests/integration_tests/api/secrets_engines/test_identity.py
@@ -1064,7 +1064,10 @@ class TestIdentity(HvacIntegrationTestCase, TestCase):
                     member_entity_ids
                     if member_entity_ids is not None
                     else []
-                    if group_type == "external" and utils.vault_version_lt("1.11.1")
+                    if group_type == "external"
+                    and (
+                        utils.vault_version_lt("1.9.9")
+                    )  # https://github.com/hashicorp/vault/pull/16088
                     else None
                 )
                 self.assertEqual(

--- a/tests/integration_tests/api/secrets_engines/test_ssh.py
+++ b/tests/integration_tests/api/secrets_engines/test_ssh.py
@@ -24,7 +24,9 @@ class TestPki(HvacIntegrationTestCase, TestCase):
         super().tearDown()
 
     # TODO: deprecate all dynamic SSH keys methods from hvac
-    @skipIf(utils.vault_version_ge("1.13.0"), reason="Vault 1.13.0 dropped this feature.")
+    @skipIf(
+        utils.vault_version_ge("1.13.0"), reason="Vault 1.13.0 dropped this feature."
+    )
     @parameterized.expand(
         [
             param(
@@ -48,7 +50,9 @@ class TestPki(HvacIntegrationTestCase, TestCase):
         )
 
     # TODO: deprecate all dynamic SSH keys methods from hvac
-    @skipIf(utils.vault_version_ge("1.13.0"), reason="Vault 1.13.0 dropped this feature.")
+    @skipIf(
+        utils.vault_version_ge("1.13.0"), reason="Vault 1.13.0 dropped this feature."
+    )
     @parameterized.expand(
         [
             param(

--- a/tests/integration_tests/api/secrets_engines/test_ssh.py
+++ b/tests/integration_tests/api/secrets_engines/test_ssh.py
@@ -24,15 +24,15 @@ class TestPki(HvacIntegrationTestCase, TestCase):
         super().tearDown()
 
     # TODO: deprecate all dynamic SSH keys methods from hvac
-    @skipIf(
-        utils.vault_version_ge("1.13.0"), reason="Vault 1.13.0 dropped this feature."
-    )
     @parameterized.expand(
         [
             param(
                 "success",
             ),
         ]
+    )
+    @skipIf(
+        utils.vault_version_ge("1.13.0"), reason="Vault 1.13.0 dropped this feature."
     )
     def test_create_key(self, label, raises=False, exception_message=""):
         with open(self.PRIVATE_SSH_KEY) as key_file:
@@ -50,15 +50,15 @@ class TestPki(HvacIntegrationTestCase, TestCase):
         )
 
     # TODO: deprecate all dynamic SSH keys methods from hvac
-    @skipIf(
-        utils.vault_version_ge("1.13.0"), reason="Vault 1.13.0 dropped this feature."
-    )
     @parameterized.expand(
         [
             param(
                 "success",
             ),
         ]
+    )
+    @skipIf(
+        utils.vault_version_ge("1.13.0"), reason="Vault 1.13.0 dropped this feature."
     )
     def test_delete_key(self, label, raises=False, exception_message=""):
         with open(self.PRIVATE_SSH_KEY) as key_file:

--- a/tests/integration_tests/api/secrets_engines/test_ssh.py
+++ b/tests/integration_tests/api/secrets_engines/test_ssh.py
@@ -24,7 +24,7 @@ class TestPki(HvacIntegrationTestCase, TestCase):
         super().tearDown()
 
     # TODO: deprecate all dynamic SSH keys methods from hvac
-    @skipIf(utils.vault_version_ge("1.13.0"))
+    @skipIf(utils.vault_version_ge("1.13.0"), reason="Vault 1.13.0 dropped this feature.")
     @parameterized.expand(
         [
             param(
@@ -48,7 +48,7 @@ class TestPki(HvacIntegrationTestCase, TestCase):
         )
 
     # TODO: deprecate all dynamic SSH keys methods from hvac
-    @skipIf(utils.vault_version_ge("1.13.0"))
+    @skipIf(utils.vault_version_ge("1.13.0"), reason="Vault 1.13.0 dropped this feature.")
     @parameterized.expand(
         [
             param(

--- a/tests/integration_tests/api/secrets_engines/test_ssh.py
+++ b/tests/integration_tests/api/secrets_engines/test_ssh.py
@@ -1,9 +1,10 @@
 import logging
-from unittest import TestCase
+from unittest import TestCase, skipIf
 
 from parameterized import parameterized, param
 
 from tests.utils.hvac_integration_test_case import HvacIntegrationTestCase
+from tests import utils
 
 
 class TestPki(HvacIntegrationTestCase, TestCase):
@@ -22,6 +23,8 @@ class TestPki(HvacIntegrationTestCase, TestCase):
         self.client.sys.disable_secrets_engine(path=self.TEST_MOUNT_POINT)
         super().tearDown()
 
+    # TODO: deprecate all dynamic SSH keys methods from hvac
+    @skipIf(utils.vault_version_ge("1.13.0"))
     @parameterized.expand(
         [
             param(
@@ -44,6 +47,8 @@ class TestPki(HvacIntegrationTestCase, TestCase):
             second=204,
         )
 
+    # TODO: deprecate all dynamic SSH keys methods from hvac
+    @skipIf(utils.vault_version_ge("1.13.0"))
     @parameterized.expand(
         [
             param(


### PR DESCRIPTION
# Vault Dynamic SSH Keys

This feature was deprecated in Vault and was removed in Vault 1.13.0. Although we have not decided a version for removal yet, the support for it in `hvac` will be removed at some point; likely at the same time we decide to drop support for older versions of Vault. 

Once we have a decision and timeline for supported versions of Vault, a more specific announcement can be made.

---

Thanks to @Tylerlhess for pointing out that our Vault integration matrix is quite a bit behind.

In this PR I'm attempting to expand it.

- use a wildcard for the patch version component
- adding 1.12.x-1.14x
- turns off fail-fast on lint, unit, and integration tests (we want to know if failures only exist in a certain combination)
- turn on colorized output for pytest in CI
- fixing breakages due to backports of changes into new minor versions
- skipping SSH tests for features removed in later Vault versions
- some minor coverage changes following on the heels of #1024 


~I will also look at expanding the enterprise versions, since those are really old...~
Using newer enterprise versions is a more complicated matter which I'll try to address in a different PR.