### PR TITLE
update coverage report locations, remove duplicate filenames

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -233,13 +233,12 @@ jobs:
   upload-to-codecov:
     name: Upload to Codecov
     runs-on: ubuntu-20.04
+    permissions:
+      contents: none
     needs:
       - unit-tests
       - integration-tests
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
       - name: Download artifacts
         uses: actions/download-artifact@v3
 

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -238,12 +238,13 @@ jobs:
   upload-to-codecov:
     name: Upload to Codecov
     runs-on: ubuntu-20.04
-    permissions:
-      contents: none
     needs:
       - unit-tests
       - integration-tests
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - name: Download artifacts
         uses: actions/download-artifact@v3
 

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -143,14 +143,14 @@ jobs:
       run: |
         poetry run pytest \
           --cov=hvac \
-          --cov-report=xml \
+          --cov-report=xml:reports/coverage_py${{ matrix.python-version }}.xml \
           tests/unit_tests
 
     - name: Upload unit tests coverage artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: unit_tests-coverage.xml
-        path: coverage.xml
+        name: coverage_reports
+        path: reports/*.xml
         if-no-files-found: error
 
   integration-tests:
@@ -215,17 +215,19 @@ jobs:
         sudo setcap cap_ipc_lock= /usr/bin/vault
 
     - name: pytest tests/integration_tests
+      env:
+        COVFILE: coverage_py${{ matrix.python-version }}_${{ matrix.vault-version }}.xml
       run: |
         poetry run pytest \
           --cov=hvac \
-          --cov-report=xml \
+          --cov-report=xml:reports/${COVFILE//[^A-Za-z0-9\-_\.]/_} \
           tests/integration_tests
 
     - name: Upload integration tests coverage artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: integration_tests-coverage.xml
-        path: coverage.xml
+        name: coverage_reports
+        path: reports/*.xml
         if-no-files-found: error
 
   upload-to-codecov:

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -152,6 +152,7 @@ jobs:
         name: coverage_reports
         path: reports/*.xml
         if-no-files-found: error
+        retention-days: 1
 
   integration-tests:
     name: Integration Tests
@@ -229,6 +230,7 @@ jobs:
         name: coverage_reports
         path: reports/*.xml
         if-no-files-found: error
+        retention-days: 1
 
   upload-to-codecov:
     name: Upload to Codecov

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 test/*.log
 /.coverage
 /cover
+/reports
 *~
 
 # sphinx build folder


### PR DESCRIPTION
Fixes: #1008

I think I finally figured out why our coverage has been borked: we are generating coverage reports as artifacts so we can upload them to codecov all at once. Problem is that we have matrixed tests and each of them generates the same coverage file name, so in the artifact upload, the last one uploaded wins. This would explain the intermittent and unpredictable coverage differences.

This PR: 
- ensures a unique report name based on the matrix parameters
- moves reports out of the root and ensures they are .gitignored
- drops token permissions on all jobs down to `contents: read` since they don't need anything else
