### PR TITLE
add `Client.write_data` method

### DIFF
--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -265,6 +265,23 @@ class Client:
         """
         return self._adapter.post(f"/v1/{path}", json=kwargs, wrap_ttl=wrap_ttl)
 
+    def write_fix_path(self, path, data={}, wrap_ttl=None):
+        """Same as write() method but fix issue #133 (you can pass `path` key in POST data)
+        
+        Supported methods:
+            POST /<path>
+
+        :param path:
+        :type path:
+        :param data:
+        :type dict:
+        :param wrap_ttl:
+        :type wrap_ttl:
+        :return:
+        :rtype:
+        """
+        return self._adapter.post(f"/v1/{path}", json=data, wrap_ttl=wrap_ttl)
+
     def delete(self, path):
         """DELETE /<path>
 

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -256,7 +256,7 @@ class Client:
 
         Write data to a path. Because this method uses kwargs for the data to write, "path" and "wrap_ttl" data keys cannot be used.
         If these names are needed, or if the key names are not known at design time, consider using the write_data method.
-        
+
         :param path:
         :type path:
         :param wrap_ttl:

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -267,7 +267,7 @@ class Client:
 
     def write_fix_path(self, path, data={}, wrap_ttl=None):
         """Same as write() method but fix issue #133 (you can pass `path` key in POST data)
-        
+
         Supported methods:
             POST /<path>
 

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -254,6 +254,9 @@ class Client:
     def write(self, path, wrap_ttl=None, **kwargs):
         """POST /<path>
 
+        Write data to a path. Because this method uses kwargs for the data to write, "path" and "wrap_ttl" data keys cannot be used.
+        If these names are needed, or if the key names are not known at design time, consider using the write_data method.
+        
         :param path:
         :type path:
         :param wrap_ttl:
@@ -265,8 +268,8 @@ class Client:
         """
         return self._adapter.post(f"/v1/{path}", json=kwargs, wrap_ttl=wrap_ttl)
 
-    def write_fix_path(self, path, data={}, wrap_ttl=None):
-        """Same as write() method but fix issue #133 (you can pass `path` key in POST data)
+    def write_data(self, path, *, data={}, wrap_ttl=None):
+        """Write data to a path. Similar to write() without restrictions on data keys.
 
         Supported methods:
             POST /<path>

--- a/tests/integration_tests/v1/test_integration.py
+++ b/tests/integration_tests/v1/test_integration.py
@@ -143,18 +143,12 @@ class IntegrationTest(HvacIntegrationTestCase, TestCase):
         self.client.sys.disable_auth_method("userpass")
 
     def test_write_fix_path(self):
-        self.client.write_fix_path(
-            "secret/foo",
-            data={
-                "path": "foo1",
-                "foo": "foo2"
-            }
-        )
+        self.client.write_fix_path("secret/foo", data={"path": "foo1", "foo": "foo2"})
         result = self.client.read("secret/foo")
 
         assert result["data"]["path"] == "foo1"
         assert result["data"]["foo"] == "foo2"
-        
+
         self.client.delete("secret/foo")
 
     def test_missing_token(self):

--- a/tests/integration_tests/v1/test_integration.py
+++ b/tests/integration_tests/v1/test_integration.py
@@ -142,8 +142,8 @@ class IntegrationTest(HvacIntegrationTestCase, TestCase):
         self.client.token = self.manager.root_token
         self.client.sys.disable_auth_method("userpass")
 
-    def test_write_fix_path(self):
-        self.client.write_fix_path("secret/foo", data={"path": "foo1", "foo": "foo2"})
+    def test_write_data(self):
+        self.client.write_data("secret/foo", data={"path": "foo1", "foo": "foo2"})
         result = self.client.read("secret/foo")
 
         assert result["data"]["path"] == "foo1"

--- a/tests/integration_tests/v1/test_integration.py
+++ b/tests/integration_tests/v1/test_integration.py
@@ -142,6 +142,21 @@ class IntegrationTest(HvacIntegrationTestCase, TestCase):
         self.client.token = self.manager.root_token
         self.client.sys.disable_auth_method("userpass")
 
+    def test_write_fix_path(self):
+        self.client.write_fix_path(
+            "secret/foo",
+            data={
+                "path": "foo1",
+                "foo": "foo2"
+            }
+        )
+        result = self.client.read("secret/foo")
+
+        assert result["data"]["path"] == "foo1"
+        assert result["data"]["foo"] == "foo2"
+        
+        self.client.delete("secret/foo")
+
     def test_missing_token(self):
         client = utils.create_client()
         assert not client.is_authenticated()


### PR DESCRIPTION
## If you are here to understand the changes as a user, please see:
- https://github.com/hvac/hvac/issues/1034

---

Hello,

This PR fix #133.

I suggest this implementation (name can be changed but i've avoided `write_v2` to not lead confusion with kv v1 and v2) to handle backward compatibility.

V2 : We add this function
V3 : We replace the old one and delete this function
or
V2 : We add this function
V3 : We replace the old one and redirect this function (to keep both for a certain time, for example until v4)
VX: We remove this function

Regards,


