### PR TITLE
docs(secrets-engines): Add database secrets engine docs

### DIFF
--- a/docs/usage/secrets_engines/database.rst
+++ b/docs/usage/secrets_engines/database.rst
@@ -1,0 +1,251 @@
+Database
+==============
+
+.. note::
+    Every method under the :py:attr:`Database class attribute<hvac.api.secrets_engines.Database>` includes a `mount_point` parameter that can be used to address the Database secret engine under a custom mount path. E.g., If enabling the Database secret engine using Vault's CLI commands via `vault secrets enable -path=my-database database`", the `mount_point` parameter in :py:meth:`hvac.api.secrets_engines.Database()` methods would be set to "my-database".
+
+
+Enable Database Secrets Engine
+------------------------------
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    client.sys.enable.secrets_engine(
+        backend_type='database',
+        path='my-database'
+    )
+
+.. note::
+    Example code below are for configuring and connecting to Postgres. See the `official developer docs`_ for a list of supported database plugins and detailed configuration requirements.
+
+.. _official developer docs: https://developer.hashicorp.com/vault/docs/secrets/databases#database-capabilities
+
+Configuration
+-------------
+
+:py:meth:`hvac.api.secrets_engines.Database.configure`
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    client.secrets.database.configure(
+        name='db-connection-name',
+        plugin_name='postgresql-database-plugin',
+        allowed_roles='role-name',
+        connection_url=f'postgresql://{{{{username}}}}:{{{{password}}}}@postgres:5432/postgres?sslmode=disable',
+        username='db-username',
+        password='db-password',
+    )
+
+.. note::
+    The database needs to be created and available to connect before you can configure the database secrets engine using the above configure method
+
+
+Read Configuration
+-------------------
+
+:py:meth:`hvac.api.secrets_engines.Database.read_connection`
+
+Returns the configuration settings for a connection mounted under a path of `my-database`:
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    connection_config = client.secrets.database.read_connection(
+        name='db-connection-name', 
+        mount_point='my-database'
+    )
+
+
+List Connections
+----------------
+
+:py:meth:`hvac.api.secrets_engines.Database.list_connections`
+
+returns a list of available connections:
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    connections = client.secrets.database.list_connections(
+        mount_point='my-database'
+    )
+
+
+Delete Connection
+-----------------
+
+:py:meth:`hvac.api.secrets_engines.Database.delete_connection`
+
+Deletes a connection
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    client.secrets.database.delete_connection(
+        name='db-connection-name', 
+        mount_point='my-database'
+    )
+
+
+Reset Connection
+----------------
+
+:py:meth:`hvac.api.secrets_engines.Database.reset_connection`
+
+Closes a connection and its underlying plugin and restarts it with the configuration stored
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    client.secrets.database.reset_connection(
+        name='db-connection-name',
+        mount_point='my-database'
+    )
+
+
+Create Role
+------------
+
+:py:meth:`hvac.api.secrets_engines.Database.create_role`
+
+Creates or updates a role definition
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    # SQL to create a new user with read only role to public schema
+        creation_statements = [
+            "CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}';",
+            "GRANT SELECT ON ALL TABLES IN SCHEMA public TO \"{{name}}\";"
+        ]
+
+    # Create a new role for the PostgreSQL connection
+        client.secrets.database.create_role(
+            name='role-name',
+            db_name='db-connection-name',
+            creation_statements=creation_statements,
+            default_ttl='1h',
+            max_ttl='24h',
+            mount_point='my-database'
+        )
+
+
+Read A Role
+-----------
+
+:py:meth:`hvac.api.secrets_engines.Database.read_role`
+
+Creates or updates a role definition
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    role = client.secrets.database.read_role(
+        name='role-name', 
+        mount_point='my-database'
+    )
+
+
+List All The Roles
+------------------
+
+:py:meth:`hvac.api.secrets_engines.Database.list_roles`
+
+Returns a list of available roles
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    roles = client.secrets.database.list_roles(
+        mount_point='my-database'
+    )
+
+Delete A Role
+--------------
+
+:py:meth:`hvac.api.secrets_engines.Database.delete_role`
+
+Deletes a role definition
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    client.secrets.database.delete_role(
+        name='role-name', 
+        mount_point='my-database'
+    )
+
+
+
+Rotate Root Credentials
+-----------------------
+
+:py:meth:`hvac.api.secrets_engines.Database.rotate_root_credentials()`
+
+Rotates the root credentials stored for the database connection.
+This user must have permissions to update its own password
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    client.secrets.database.rotate_root_credentials(
+        name='db-connection-name',
+        mount_point='my-database'
+    )
+
+Generate Credentials
+---------------------
+
+:py:meth:`hvac.api.secrets_engines.Database.generate_credentials`
+
+Generates a new set of dynamic credentials based on the named role
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    credentials = client.secrets.database.generate_credentials(
+        name='role-name',
+        mount_point='my-database'
+    )
+
+Get Static Credentials
+-----------------------
+
+:py:meth:`hvac.api.secrets_engines.Database.get_static_credentials`
+
+Returns the current credentials based on the named static role
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    credentials = client.secrets.database.get_static_credentials(
+        name='role-name',
+        mount_point='my-database'
+    )

--- a/docs/usage/secrets_engines/database.rst
+++ b/docs/usage/secrets_engines/database.rst
@@ -2,7 +2,7 @@ Database
 ==============
 
 .. note::
-    Every method under the :py:attr:`Database class attribute<hvac.api.secrets_engines.Database>` includes a `mount_point` parameter that can be used to address the Database secret engine under a custom mount path. E.g., If enabling the Database secret engine using Vault's CLI commands via `vault secrets enable -path=my-database database`", the `mount_point` parameter in :py:meth:`hvac.api.secrets_engines.Database()` methods would be set to "my-database".
+    Every method under the :py:attr:`Database class<hvac.api.secrets_engines.Database>` includes a ``mount_point`` parameter that can be used to address the Database secret engine under a custom mount path. E.g., If enabling the Database secret engine using Vault's CLI commands via ``vault secrets enable -path=my-database database``, the ``mount_point`` parameter in :py:meth:`hvac.api.secrets_engines.Database()` methods would be set to ``my-database``.
 
 
 Enable Database Secrets Engine
@@ -27,6 +27,8 @@ Configuration
 
 :py:meth:`hvac.api.secrets_engines.Database.configure`
 
+Configures the database engine:
+
 .. code:: python
 
     import hvac
@@ -42,7 +44,7 @@ Configuration
     )
 
 .. note::
-    The database needs to be created and available to connect before you can configure the database secrets engine using the above configure method
+    The database needs to be created and available to connect before you can configure the database secrets engine using the above configure method.
 
 
 Read Configuration
@@ -50,7 +52,7 @@ Read Configuration
 
 :py:meth:`hvac.api.secrets_engines.Database.read_connection`
 
-Returns the configuration settings for a connection mounted under a path of `my-database`:
+Returns the configuration settings for a connection mounted under a path of ``my-database``:
 
 .. code:: python
 
@@ -68,7 +70,7 @@ List Connections
 
 :py:meth:`hvac.api.secrets_engines.Database.list_connections`
 
-returns a list of available connections:
+Returns a list of available connections:
 
 .. code:: python
 
@@ -85,7 +87,7 @@ Delete Connection
 
 :py:meth:`hvac.api.secrets_engines.Database.delete_connection`
 
-Deletes a connection
+Deletes a connection:
 
 .. code:: python
 
@@ -103,7 +105,7 @@ Reset Connection
 
 :py:meth:`hvac.api.secrets_engines.Database.reset_connection`
 
-Closes a connection and its underlying plugin and restarts it with the configuration stored
+Closes a connection and its underlying plugin and restarts it with the configuration stored:
 
 .. code:: python
 
@@ -121,7 +123,7 @@ Create Role
 
 :py:meth:`hvac.api.secrets_engines.Database.create_role`
 
-Creates or updates a role definition
+Creates or updates a role definition:
 
 .. code:: python
 
@@ -150,7 +152,7 @@ Read A Role
 
 :py:meth:`hvac.api.secrets_engines.Database.read_role`
 
-Creates or updates a role definition
+Creates or updates a role definition:
 
 .. code:: python
 
@@ -168,7 +170,7 @@ List All The Roles
 
 :py:meth:`hvac.api.secrets_engines.Database.list_roles`
 
-Returns a list of available roles
+Returns a list of available roles:
 
 .. code:: python
 
@@ -184,7 +186,7 @@ Delete A Role
 
 :py:meth:`hvac.api.secrets_engines.Database.delete_role`
 
-Deletes a role definition
+Deletes a role definition:
 
 .. code:: python
 
@@ -204,7 +206,7 @@ Rotate Root Credentials
 :py:meth:`hvac.api.secrets_engines.Database.rotate_root_credentials()`
 
 Rotates the root credentials stored for the database connection.
-This user must have permissions to update its own password
+This user must have permissions to update its own password.
 
 .. code:: python
 
@@ -221,7 +223,7 @@ Generate Credentials
 
 :py:meth:`hvac.api.secrets_engines.Database.generate_credentials`
 
-Generates a new set of dynamic credentials based on the named role
+Generates a new set of dynamic credentials based on the named role:
 
 .. code:: python
 
@@ -238,7 +240,7 @@ Get Static Credentials
 
 :py:meth:`hvac.api.secrets_engines.Database.get_static_credentials`
 
-Returns the current credentials based on the named static role
+Returns the current credentials based on the named static role:
 
 .. code:: python
 

--- a/docs/usage/secrets_engines/index.rst
+++ b/docs/usage/secrets_engines/index.rst
@@ -7,6 +7,7 @@ Secrets Engines
    activedirectory
    aws
    azure
+   database
    gcp
    identity
    pki


### PR DESCRIPTION
Add docs for the database secrets engine  - https://github.com/hvac/hvac/issues/453

I've added docs/code examples for the majority of methods but missing the static role related methods. I plan on adding them at a later time once I test them.

