### PR TITLE
Add alias_name_source for Kubernetes Auth create_role

### DIFF
--- a/hvac/api/auth_methods/kubernetes.py
+++ b/hvac/api/auth_methods/kubernetes.py
@@ -119,7 +119,7 @@ class Kubernetes(VaultApiBase):
         policies=None,
         token_type="",
         mount_point=DEFAULT_MOUNT_POINT,
-        alias_name_source="serviceaccount_uid",
+        alias_name_source="",
     ):
         """Create a role in the method.
 
@@ -179,8 +179,10 @@ class Kubernetes(VaultApiBase):
             "bound_service_account_namespaces": comma_delimited_to_list(
                 bound_service_account_namespaces
             ),
-            "alias_name_source": alias_name_source,
         }
+        if alias_name_source:
+            params["alias_name_source"] = alias_name_source
+
         params.update(
             utils.remove_nones(
                 {

--- a/hvac/api/auth_methods/kubernetes.py
+++ b/hvac/api/auth_methods/kubernetes.py
@@ -180,7 +180,7 @@ class Kubernetes(VaultApiBase):
                 bound_service_account_namespaces
             ),
         }
-        if alias_name_source:
+        if alias_name_source is not None:
             params["alias_name_source"] = alias_name_source
 
         params.update(

--- a/hvac/api/auth_methods/kubernetes.py
+++ b/hvac/api/auth_methods/kubernetes.py
@@ -119,6 +119,7 @@ class Kubernetes(VaultApiBase):
         policies=None,
         token_type="",
         mount_point=DEFAULT_MOUNT_POINT,
+        alias_name_source="serviceaccount_uid",
     ):
         """Create a role in the method.
 
@@ -154,6 +155,9 @@ class Kubernetes(VaultApiBase):
         :type token_type: str
         :param mount_point: The "path" the kubernetes auth method was mounted on.
         :type mount_point: str | unicode
+        :param alias_name_source: Configures how identity aliases are generated.
+            Valid choices are: serviceaccount_uid, serviceaccount_name.
+        :type alias_name_source: str | unicode
         :return: The response of the request.
         :rtype: requests.Response
         """
@@ -175,6 +179,7 @@ class Kubernetes(VaultApiBase):
             "bound_service_account_namespaces": comma_delimited_to_list(
                 bound_service_account_namespaces
             ),
+            "alias_name_source": alias_name_source,
         }
         params.update(
             utils.remove_nones(

--- a/hvac/api/auth_methods/kubernetes.py
+++ b/hvac/api/auth_methods/kubernetes.py
@@ -119,7 +119,7 @@ class Kubernetes(VaultApiBase):
         policies=None,
         token_type="",
         mount_point=DEFAULT_MOUNT_POINT,
-        alias_name_source="",
+        alias_name_source=None,
     ):
         """Create a role in the method.
 

--- a/tests/integration_tests/api/auth_methods/test_kubernetes.py
+++ b/tests/integration_tests/api/auth_methods/test_kubernetes.py
@@ -151,17 +151,36 @@ class TestKubernetes(HvacIntegrationTestCase, TestCase):
                 "success",
                 bound_service_account_names=["vault-auth"],
                 bound_service_account_namespaces=["default"],
+                alias_name_source="serviceaccount_uid",
             ),
             param(
                 "both bounds wildcard permitted",
                 bound_service_account_names=["*"],
                 bound_service_account_namespaces=["*"],
+                alias_name_source="serviceaccount_uid",
             ),
             param(
                 "token type",
                 bound_service_account_names=["vault-auth"],
                 bound_service_account_namespaces=["default"],
+                alias_name_source="serviceaccount_uid",
                 token_type="service",
+            ),
+            param(
+                "serviceaccount name for alias",
+                bound_service_account_names=["vault-auth"],
+                bound_service_account_namespaces=["default"],
+                alias_name_source="serviceaccount_name",
+                token_type="service",
+            ),
+            param(
+                "raises with invalid alias",
+                bound_service_account_names=["vault-auth"],
+                bound_service_account_namespaces=["default"],
+                alias_name_source="serviceaccount_blah",
+                token_type="service",
+                raises=exceptions.InvalidRequest,
+                exception_message="invalid alias_name_source",
             ),
         ]
     )
@@ -171,6 +190,7 @@ class TestKubernetes(HvacIntegrationTestCase, TestCase):
         bound_service_account_names=None,
         bound_service_account_namespaces=None,
         token_type=None,
+        alias_name_source="",
         raises=None,
         exception_message="",
     ):
@@ -182,6 +202,7 @@ class TestKubernetes(HvacIntegrationTestCase, TestCase):
                     bound_service_account_names=bound_service_account_names,
                     bound_service_account_namespaces=bound_service_account_namespaces,
                     token_type=token_type,
+                    alias_name_source=alias_name_source,
                     mount_point=self.TEST_MOUNT_POINT,
                 )
             self.assertIn(
@@ -194,6 +215,7 @@ class TestKubernetes(HvacIntegrationTestCase, TestCase):
                 bound_service_account_names=bound_service_account_names,
                 bound_service_account_namespaces=bound_service_account_namespaces,
                 token_type=token_type,
+                alias_name_source=alias_name_source,
                 mount_point=self.TEST_MOUNT_POINT,
             )
             logging.debug("create_role_response: %s" % create_role_response)

--- a/tests/integration_tests/api/auth_methods/test_kubernetes.py
+++ b/tests/integration_tests/api/auth_methods/test_kubernetes.py
@@ -178,7 +178,7 @@ class TestKubernetes(HvacIntegrationTestCase, TestCase):
         bound_service_account_names=None,
         bound_service_account_namespaces=None,
         token_type=None,
-        alias_name_source="",
+        alias_name_source=None,
         raises=None,
         exception_message="",
     ):

--- a/tests/integration_tests/api/auth_methods/test_kubernetes.py
+++ b/tests/integration_tests/api/auth_methods/test_kubernetes.py
@@ -151,19 +151,16 @@ class TestKubernetes(HvacIntegrationTestCase, TestCase):
                 "success",
                 bound_service_account_names=["vault-auth"],
                 bound_service_account_namespaces=["default"],
-                alias_name_source="serviceaccount_uid",
             ),
             param(
                 "both bounds wildcard permitted",
                 bound_service_account_names=["*"],
                 bound_service_account_namespaces=["*"],
-                alias_name_source="serviceaccount_uid",
             ),
             param(
                 "token type",
                 bound_service_account_names=["vault-auth"],
                 bound_service_account_namespaces=["default"],
-                alias_name_source="serviceaccount_uid",
                 token_type="service",
             ),
             param(
@@ -172,15 +169,6 @@ class TestKubernetes(HvacIntegrationTestCase, TestCase):
                 bound_service_account_namespaces=["default"],
                 alias_name_source="serviceaccount_name",
                 token_type="service",
-            ),
-            param(
-                "raises with invalid alias",
-                bound_service_account_names=["vault-auth"],
-                bound_service_account_namespaces=["default"],
-                alias_name_source="serviceaccount_blah",
-                token_type="service",
-                raises=exceptions.InvalidRequest,
-                exception_message="invalid alias_name_source",
             ),
         ]
     )

--- a/tests/unit_tests/api/auth_methods/test_kubernetes.py
+++ b/tests/unit_tests/api/auth_methods/test_kubernetes.py
@@ -175,8 +175,22 @@ class TestKubernetes(TestCase):
 
     @parameterized.expand(
         [
-            ("default mount point", None, "application1", "*", "some-namespace", "serviceaccount_uid"),
-            ("custom mount point", "k8s", "application2", "some-service-account", "*", "serviceaccount_name"),
+            (
+                "default mount point",
+                None,
+                "application1",
+                "*",
+                "some-namespace",
+                "serviceaccount_uid",
+            ),
+            (
+                "custom mount point",
+                "k8s",
+                "application2",
+                "some-service-account",
+                "*",
+                "serviceaccount_name",
+            ),
         ]
     )
     @requests_mock.Mocker()

--- a/tests/unit_tests/api/auth_methods/test_kubernetes.py
+++ b/tests/unit_tests/api/auth_methods/test_kubernetes.py
@@ -175,8 +175,8 @@ class TestKubernetes(TestCase):
 
     @parameterized.expand(
         [
-            ("default mount point", None, "application1", "*", "some-namespace"),
-            ("custom mount point", "k8s", "application2", "some-service-account", "*"),
+            ("default mount point", None, "application1", "*", "some-namespace", "serviceaccount_uid"),
+            ("custom mount point", "k8s", "application2", "some-service-account", "*", "serviceaccount_name"),
         ]
     )
     @requests_mock.Mocker()
@@ -187,6 +187,7 @@ class TestKubernetes(TestCase):
         role_name,
         bound_service_account_names,
         bound_service_account_namespaces,
+        alias_name_source,
         requests_mocker,
     ):
         expected_status_code = 204
@@ -205,6 +206,7 @@ class TestKubernetes(TestCase):
             name=role_name,
             bound_service_account_names=bound_service_account_names,
             bound_service_account_namespaces=bound_service_account_namespaces,
+            alias_name_source=alias_name_source,
         )
         if mount_point:
             test_arguments["mount_point"] = mount_point


### PR DESCRIPTION
For the Kubernetes auth method, Vault's create role API endpoint accepts `alias_name_source` as part of the payload ([https://developer.hashicorp.com/vault/api-docs/auth/kubernetes#alias_name_source](https://developer.hashicorp.com/vault/api-docs/auth/kubernetes#alias_name_source)). This PR adds that as an optional argument to the `create_role` python method. Defaults to not set so no change to existing behaviour (as this param was only added in Vault 1.9)