### PR TITLE
use anonymous references in changelog conversion

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,6 +33,13 @@ extensions = [
     "autodocsumm",
 ]
 
+# https://github.com/CrossNox/m2r2/blob/0408d7acea843485d9ff42ee08a105a79f045493/m2r2.py#L675C27-L675C51
+# https://github.com/CrossNox/m2r2/issues/30
+# We use m2r primarily to convert the markdown changelog to RST, so we don't need named references.
+# Since we may have multiple changelog entries refer to the same GitHub issue, and we use the same text
+# to anchor it (GH-###), it would result in duplicate explicit target names.
+m2r_anonymous_references = True
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 


### PR DESCRIPTION
We use m2r primarily to convert the markdown changelog to RST, so we don't need named references. Since we may have multiple changelog entries refer to the same GitHub issue, and we use the same text to anchor it (GH-###), it would result in duplicate explicit target names.
- https://github.com/CrossNox/m2r2/issues/30

For an example, see the error from #1035 :
- https://github.com/hvac/hvac/actions/runs/5992125579/job/16251211029?pr=1035#step:8:75

I tested locally to ensure that this fixes the issue.