### PR TITLE
first draft PR docs build workflow

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -1,0 +1,156 @@
+# based on:
+# - https://github.com/ansible-community/github-docs-build/blob/main/.github/workflows/_shared-docs-build-pr.yml
+# - https://github.com/ansible-community/github-docs-build/blob/main/samples/pr-with-publish-to-gh-pages.yml
+---
+name: Docs PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, closed]
+
+env:
+  GHP_BASE_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
+  DOCS_BUILD_CMD: make -C docs html
+  DOCS_BUILD_HTML: docs/_build/html
+  DOCS_BUILD_BASE: docs/_build/html_base
+  DOCS_BUILD_HEAD: docs/_build/html_head
+  DOCS_BUILD_ARTIFACT_NAME: hvac_docs
+
+jobs:
+  build-docs:
+    permissions:
+      contents: read
+    name: Build Docs
+    runs-on: ubuntu-latest
+    outputs:
+      artifact-url: ${{ steps.build-head.outputs.artifact-url }}
+      artifact-name: ${{ steps.vars.outputs.artifact-name }}
+      changed: ${{ steps.build-base.outputs.hash != steps.build-head.outputs.hash }}
+      diff: ${{ steps.diff.outputs.diff }}
+      diff-truncated: ${{ steps.diff.outputs.truncated }}
+      diff-rendered: ${{ steps.diff.outputs.diff-rendered }}
+      diff-files: ${{ steps.diff.outputs.files-raw }}
+      diff-files-trimmed: ${{ steps.diff.outputs.files-trimmed }}
+      diff-files-rendered: ${{ steps.diff.outputs.files-rendered }}
+    steps:
+      - name: Variable setup
+        id: vars
+        uses: actions/github-script@v6
+        with:
+          script: |
+            // set this as an output for other things
+            core.setOutput('artifact-name', process.env.DOCS_BUILD_ARTIFACT_NAME)
+
+            // The merge branch is what we want, but it doesn't exist
+            // on closed events. The merge SHA does exist though and
+            // should be correct. The merge SHA does not exist when a
+            // PR is first opened, and on subsequent updates it is
+            // tricky to use; used directly it is probably stale, and
+            // would need additional API calls to get the correct value.
+            // See also:
+            // - https://github.com/ansible-community/github-docs-build/issues/36
+
+            if ('${{ github.event.action }}' == 'closed') {
+                core.setOutput('pr-checkout-ref', '${{ github.event.pull_request.merge_commit_sha }}')
+            } else {
+                core.setOutput('pr-checkout-ref', 'refs/pull/${{ github.event.number }}/merge')
+            }
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Checkout BASE
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - name: Build BASE
+        id: build-base
+        uses: ansible-community/github-docs-build/actions/ansible-docs-build-html@main
+        with:
+          build-script: ${{ env.DOCS_BUILD_CMD }}
+          build-html: ${{ github.workspace}}/${{ env.DOCS_BUILD_HTML }}
+          copy-build: ${{ github.workspace }}/${{ env.DOCS_BUILD_BASE }}
+          artifact-upload: 'false'
+
+      - name: Checkout HEAD
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ steps.vars.outputs.pr-checkout-ref }}
+
+      - name: Build HEAD
+        id: build-head
+        uses: ansible-community/github-docs-build/actions/ansible-docs-build-html@main
+        with:
+          build-script: ${{ env.DOCS_BUILD_CMD }}
+          build-html: ${{ github.workspace}}/${{ env.DOCS_BUILD_HTML }}
+          copy-build: ${{ github.workspace }}/${{ env.DOCS_BUILD_HEAD }}
+          artifact-name: ${{ steps.vars.outputs.artifact-name }}
+
+      - name: Get a diff of the changes
+        if: steps.build-base.outputs.hash != steps.build-head.outputs.hash
+        id: diff
+        uses: ansible-community/github-docs-build/actions/ansible-docs-build-diff@main
+        with:
+          build-html-a: ${{ steps.build-base.outputs.build-html }}
+          build-html-b: ${{ steps.build-head.outputs.build-html }}
+          render-file-line: '> * `$<status>` [$<path_tail>](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr/${{ github.event.number }}/$<path_tail>)'
+
+  publish-docs-gh-pages:
+    # use to prevent running on forks
+    if: github.repository == 'hvac/hvac'
+    permissions:
+      contents: write
+    needs: [build-docs]
+    name: Publish PR Docs
+    uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-publish-gh-pages.yml@main
+    with:
+      artifact-name: ${{ needs.build-docs.outputs.artifact-name }}
+      action: ${{ (github.event.action == 'closed' || needs.build-docs.outputs.changed != 'true') && 'teardown' || 'publish' }}
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  comment:
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    needs: [publish-docs-gh-pages, build-docs]
+    name: PR comments
+    steps:
+      - name: PR comment
+        uses: ansible-community/github-docs-build/actions/ansible-docs-build-comment@main
+        with:
+          body-includes: '## Docs Build'
+          reactions: heart
+          action: ${{ needs.build-docs.outputs.changed != 'true' && 'remove' || '' }}
+          on-closed-action: remove
+          on-merged-body: |
+            ## Docs Build 📝
+
+            Thank you for contribution!✨
+
+            This PR has been merged and the docs are now incorporated into `main`:
+            ${{ env.GHP_BASE_URL }}/branch/main
+          body: |
+            ## Docs Build 📝
+
+            Thank you for contribution!✨
+
+            The docs for **this PR** have been published here:
+            ${{ env.GHP_BASE_URL }}/pr/${{ github.event.number }}
+
+            You can compare to the docs for the `main` branch here:
+            ${{ env.GHP_BASE_URL }}/branch/main
+
+            The docsite for **this PR** is also available for download as an artifact from this run:
+            ${{ needs.build-docs.outputs.artifact-url }}
+
+            File changes:
+
+            ${{ needs.build-docs.outputs.diff-files-rendered }}
+
+            ${{ needs.build-docs.outputs.diff-rendered }}


### PR DESCRIPTION
This PR adds a workflow that allows for building documentation in PRs. We already have publishing with RTD for releases (tags) and pushes to `main`, and we have a CI job that runs `doctest` (which implicitly also ensures that docs are valid since they need to be built).

This workflow is a little different. On a PR, it builds the HTML docsite for both the PR contents and for the target branch (for example `main`), and then diffs them. If there are any changes, it:
- publishes a temporary version of the docsite on GH pages (so PR authors and reviewers can see it rendered)
- posts a comment to PR that contains the list of changed files, diff output, and links to the rendered versions

This workflow uses the `pull_request_target` trigger which has a few caveats and things to know:
- the workflow itself is always loaded from the PR's target branch (like `main`), so the workflow that gets executed is never from the PR itself (this is a necessary security decision)
- development of the workflow (like in this PR) then is a little tricky: 
  - the PR branch should be pushed up to this repo, and not to a fork (so it must be done by a maintainer)
  - then, you can open a new PR (this one can be from a fork) against the first PR's branch as the target, and that will allow the "modified" version of the workflow to run
  - the test PR can be closed when it's done
- because a PR author without write access can't modify the workflow, that also means that on PRs from new users, these workflows run without someone needing to approve them, which is nice since the feedback is fast
