### PR TITLE
fix asset publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Upload Python Package
+name: Release
 
 on:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
       with:
         name: package
         path: dist/
-        retention-days: 1
+        retention-days: 7
         if-no-files-found: error
 
   pypi:
@@ -83,6 +83,7 @@ jobs:
       - name: Add release asset
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
         with:
+          tag_name: ${{ github.event.release.tag_name }}
           fail_on_unmatched_files: true
           files: |
             dist/*


### PR DESCRIPTION
Fixes #1044 (hopefully)

Also renames the workflow to something more appropriate, since it's not just for pypi publishing anymore.

This workflow used to work. [According to GitHub documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release), a release event should set `GITHUB_REF` to the tag name:

> Tag ref of release `refs/tags/<tag_name>`

And according to the source code of the action, when the `tag_name` input is not set, it uses `github_ref` to calculate the value: 
- https://github.com/softprops/action-gh-release/blob/de2c0eb89ae2a093876385947365aca7b0e5f844/src/github.ts#L193-L197
- https://github.com/softprops/action-gh-release/blob/master/src/github.ts#L193-L197

So, I don't know exactly what happened, maybe GitHub changed their API or something. In any case the event payload that contains the release information should still have the tag name: https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=published#release