### PR TITLE
Make `plaintext` and `ciphertext` optional for batch operations

### DIFF
--- a/hvac/api/secrets_engines/transit.py
+++ b/hvac/api/secrets_engines/transit.py
@@ -314,7 +314,7 @@ class Transit(VaultApiBase):
     def encrypt_data(
         self,
         name,
-        plaintext,
+        plaintext=None,
         context=None,
         key_version=None,
         nonce=None,
@@ -335,7 +335,7 @@ class Transit(VaultApiBase):
 
         :param name: Specifies the name of the encryption key to encrypt against. This is specified as part of the URL.
         :type name: str | unicode
-        :param plaintext: Specifies base64 encoded plaintext to be encoded.
+        :param plaintext: Specifies base64 encoded plaintext to be encoded. Ignored if ``batch_input`` is set, otherwise required.
         :type plaintext: str | unicode
         :param context: Specifies the base64 encoded context for key derivation. This is required if key derivation is
             enabled for this key.
@@ -367,6 +367,8 @@ class Transit(VaultApiBase):
         :return: The JSON response of the request.
         :rtype: dict
         """
+        if plaintext is None and batch_input is None:
+            raise ValueError("plaintext must be specified unless batch_input is set")
         params = {
             "plaintext": plaintext,
         }
@@ -395,7 +397,7 @@ class Transit(VaultApiBase):
     def decrypt_data(
         self,
         name,
-        ciphertext,
+        ciphertext=None,
         context=None,
         nonce=None,
         batch_input=None,
@@ -408,7 +410,7 @@ class Transit(VaultApiBase):
 
         :param name: Specifies the name of the encryption key to decrypt against. This is specified as part of the URL.
         :type name: str | unicode
-        :param ciphertext: the ciphertext to decrypt.
+        :param ciphertext: The ciphertext to decrypt. Ignored if ``batch_input`` is set, otherwise required.
         :type ciphertext: str | unicode
         :param context: Specifies the base64 encoded context for key derivation. This is required if key derivation is
             enabled.
@@ -426,6 +428,8 @@ class Transit(VaultApiBase):
         :return: The JSON response of the request.
         :rtype: dict
         """
+        if ciphertext is None and batch_input is None:
+            raise ValueError("ciphertext must be specified unless batch_input is set")
         params = {
             "ciphertext": ciphertext,
         }

--- a/tests/integration_tests/api/secrets_engines/test_transit.py
+++ b/tests/integration_tests/api/secrets_engines/test_transit.py
@@ -989,3 +989,11 @@ class TestTransit(HvacIntegrationTestCase, TestCase):
                 first=bool(trim_key_response),
                 second=True,
             )
+
+    def test_encrypt_data_requires_plaintext_arg_if_not_in_batch_mode(self):
+        with self.assertRaises(ValueError, msg="plaintext must be specified"):
+            self.client.secrets.transit.encrypt_data(name="any-key")
+
+    def test_decrypt_data_requires_cipher_arg_if_not_in_batch_mode(self):
+        with self.assertRaises(ValueError, msg="ciphertext must be specified"):
+            self.client.secrets.transit.decrypt_data(name="any-key")


### PR DESCRIPTION
The Vault API requires setting `plaintext` and `ciphertext` for the encrypt/decrypt data API, even though the fields are ignored when `batch_input` is set. This means that end users have to include an empty argument when doing batch operations, which is a bit annoying.

While this works, it might be more ergonomic to have an `encrypt_data` and a `batch_encrypt_data` function as most of the `encrypt_data` args are ignored in batch mode anyways, which could potentially lead to bugs. This is a bit out of scope for this PR, just thought I would mention it here as an alternative.

Also, I could not test locally due to self-signed certificate errors. Is there a certificate I need to install for testing?