### PR TITLE
Fix typos, add `typos` linter to CI

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -62,6 +62,9 @@ jobs:
     - name: Lint with `flake8`
       run: poetry run flake8 . --count --statistics
 
+    - name: Check for typos
+      run: poetry run typos --color always
+
   docs-tests:
     name: Documentation Tests
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@ This is the last expected release before `v2.0.0`.
 ### 🐛 Bug Fixes
 
 - Allow for reading deleted secret versions (kv2) without an exception ([GH-907](https://github.com/hvac/hvac/pull/907))
-- fix vault client certificates loaded from envirnoment variables ([GH-943](https://github.com/hvac/hvac/pull/943))
+- fix vault client certificates loaded from environment variables ([GH-943](https://github.com/hvac/hvac/pull/943))
 - approle - fix metadata for generated secret IDs, re-add `wrap_ttl` ([GH-782](https://github.com/hvac/hvac/pull/782))
 - AWS secret engine - fix `generate_credentials` for STS endpoint ([GH-934](https://github.com/hvac/hvac/pull/934))
 - Propagate client's adapter to API categories ([GH-939](https://github.com/hvac/hvac/pull/939))
@@ -93,7 +93,7 @@ This is the last expected release before `v2.0.0`.
 - Update Azure guideline with proper client variable ([GH-935](https://github.com/hvac/hvac/pull/935))
 - Update wrapping.rst - example for unauthenticated unwrap ([GH-789](https://github.com/hvac/hvac/pull/789))
 - Fix typo in the AWS auth method docs ([GH-911](https://github.com/hvac/hvac/pull/911))
-- Replace Azure docs occurence to Kubernetes ([GH-904](https://github.com/hvac/hvac/pull/904))
+- Replace Azure docs occurrence to Kubernetes ([GH-904](https://github.com/hvac/hvac/pull/904))
 
 ### 🧰 Miscellaneous
 
@@ -180,7 +180,7 @@ Breakfix release to revert some unintended post-1.0 requirements changes.
 
 - **Note**: This is _actually and truly_ (😝)  intended to by the last hvac release supporting Python 2.7.
 
-  **Starting with hvac version `1.0.0`, Python versions `>=3.6` will be the only explictly supported versions.**
+  **Starting with hvac version `1.0.0`, Python versions `>=3.6` will be the only explicitly supported versions.**
 - Requirements - Cleanup & Upgrades (`install_requires` => `requests>=2.25.1` ). GH-741
 
 ### 🚀 Features
@@ -204,7 +204,7 @@ Thanks to @Tylerlhess, @anhdat, @ayav09, @bobmshannon, @bpatterson971, @briantis
 
 - **Note**: This is intended to by the last hvac release supporting Python 2.7.
 
-  **Starting with hvac version `1.0.0`, Python versions `>=3.6` will be the only explictly supported versions.**
+  **Starting with hvac version `1.0.0`, Python versions `>=3.6` will be the only explicitly supported versions.**
 - Userpass: Add `use_token` param on `login()`, Accept passthrough `**kwargs` on create user . GH-733
 
 ### 🚀 Features
@@ -668,7 +668,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
-* Fix for comparision `recovery_threshold` and `recovery_shares` during initialization. [GH-398](https://github.com/hvac/hvac/pull/398)
+* Fix for comparison `recovery_threshold` and `recovery_shares` during initialization. [GH-398](https://github.com/hvac/hvac/pull/398)
 * Fix request method for AWS secrets engine `generate_credentials()` method. [GH-403](https://github.com/hvac/hvac/pull/403)
 * Fix request parameter (`n_bytes` -> `bytes`) for Transit secrets engine `generate_random_bytes()` method. [GH-377](https://github.com/hvac/hvac/pull/377)
 
@@ -780,7 +780,7 @@ Thanks to @otakup0pe, @FabianFrank, @andrewheald for their lovely contributions.
 
 BACKWARDS COMPATIBILITY NOTICE:
 
-* With the newly added `hvac.adapters.Request` class, request kwargs can no longer be directly modified via the `_kwargs` attribute on the `Client` class. If runtime modifications to this dictionary are required, callers either need to explicitly pass in a new `adapter` instance with the desired settings via the `adapter` propery on the `Client` class *or* access the `_kwargs` property via the `adapter` property on the `Client` class.
+* With the newly added `hvac.adapters.Request` class, request kwargs can no longer be directly modified via the `_kwargs` attribute on the `Client` class. If runtime modifications to this dictionary are required, callers either need to explicitly pass in a new `adapter` instance with the desired settings via the `adapter` property on the `Client` class *or* access the `_kwargs` property via the `adapter` property on the `Client` class.
 
 See the [Advanced Usage](https://hvac.readthedocs.io/en/latest/advanced_usage.html#custom-requests-http-adapter) section of this module's documentation for additional details.
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PYTHON_IMAGE		?= wpengine/python
 REQUIREMENTS_FILES	:= requirements requirements-dev
 
-.PHONY: clean package publish test update-all-requirements $(addsuffix .txt, $(REQUIREMENTS_FILES)) docs/requirements.txt
+.PHONY: clean package publish test update-all-requirements typos $(addsuffix .txt, $(REQUIREMENTS_FILES)) docs/requirements.txt
 
 test:
 	pytest --cov=hvac tests/
@@ -14,6 +14,9 @@ distclean: clean
 
 package:
 	python setup.py sdist bdist_wheel
+
+typos:
+	typos --format brief
 
 # Note, we breakout the docs/requirements target separately since its not reasonable to use filesystem paths in target names
 update-all-requirements: $(addprefix update-, $(REQUIREMENTS_FILES)) update-docs-requirements

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -32,7 +32,7 @@ You then use hvac's Client.session and requests.Session() to pass the new CA bun
 		Instantiates a hvac / vault client.
 		:param vault_url: string, protocol + address + port for the vault service
 		:param certs: tuple, Optional tuple of self-signed certs to use for verification
-			with hvac's requests adapater.
+			with hvac's requests adapter.
 		:return: hvac.Client
 		"""
 		logger.debug('Retrieving a vault (hvac) client...')
@@ -59,7 +59,7 @@ You then use hvac's Client.session and requests.Session() to pass the new CA bun
 
 If only using the certificate authority for trust, not authentication, SSL verification can be set using the `verify` parameter.
 
-This configures the client to trust the connection only if the certificate recieved is signed by a CA in that bundle:
+This configures the client to trust the connection only if the certificate received is signed by a CA in that bundle:
 
 .. code:: python
 

--- a/docs/usage/auth_methods/aws.rst
+++ b/docs/usage/auth_methods/aws.rst
@@ -228,7 +228,7 @@ Authentication using EC2 instance role credentials and the EC2 metadata service
         Helper method to authenticate to vault using the "auth_ec2" backend.
         :param vault_client: hvac.Client
         :param pkcs7: pkcs7-encoded identity document from the EC2 metadata service
-        :param nonce: string, the nonce retruned from the initial AWS EC2 auth request (if applicable)
+        :param nonce: string, the nonce returned from the initial AWS EC2 auth request (if applicable)
         :param role: string, the role/policy to request. Defaults to the current instance's AMI ID if not provided.
         :param mount_point: string, the path underwhich the AWS EC2 auth backend is provided
         :param store_nonce: bool, if True, store the nonce received in the auth_ec2 response on disk for later use.

--- a/docs/usage/secrets_engines/gcp.rst
+++ b/docs/usage/secrets_engines/gcp.rst
@@ -11,7 +11,7 @@ GCP
 
     client.sys.enable_secrets_engine('gcp')
 
-    # mock out external calls that are diffcult to support in test environments
+    # mock out external calls that are difficult to support in test environments
     mock_urls = {
         'https://127.0.0.1:8200/v1/gcp/rolesets': 'LIST',
         'https://127.0.0.1:8200/v1/gcp/roleset/hvac-doctest': ANY,

--- a/docs/usage/secrets_engines/identity.rst
+++ b/docs/usage/secrets_engines/identity.rst
@@ -20,7 +20,7 @@ Create Or Update Entity
 
 	create_response = client.secrets.identity.create_or_update_entity(
 			name='hvac-entity',
-			metadata=dict(extra_datas='yup'),
+			metadata=dict(extra_data='yup'),
 		)
 	entity_id = create_response['data']['id']
 	print('Entity ID for "hvac-entity" is: {id}'.format(id=entity_id))
@@ -38,7 +38,7 @@ Create Or Update Entity By Name
 
 	client.secrets.identity.create_or_update_entity_by_name(
 		name='hvac-entity',
-		metadata=dict(new_datas='uhuh'),
+		metadata=dict(new_data='uhuh'),
 	)
 
 
@@ -273,7 +273,7 @@ Create Or Update Group
 
 	create_response = client.secrets.identity.create_or_update_group(
 		name='hvac-group',
-		metadata=dict(extra_datas='we gots em'),
+		metadata=dict(extra_data='we gots em'),
 	)
 	group_id = create_response['data']['id']
 	print('Group ID for "hvac-group" is: {id}'.format(id=group_id))
@@ -373,7 +373,7 @@ Create Or Update Group By Name
 
 	client.secrets.identity.create_or_update_group_by_name(
 		name='hvac-group',
-		metadata=dict(new_datas='uhuh'),
+		metadata=dict(new_data='uhuh'),
 	)
 
 

--- a/hvac/adapters.py
+++ b/hvac/adapters.py
@@ -93,7 +93,7 @@ class Adapter(metaclass=ABCMeta):
         # fix for issue 991 using session verify if set
         else:
             if session.verify:
-                # need to set the variable and not assign it to self so it is propperly passed in kwargs
+                # need to set the variable and not assign it to self so it is properly passed in kwargs
                 verify = session.verify
             if session.cert:
                 cert = session.cert
@@ -214,13 +214,13 @@ class Adapter(metaclass=ABCMeta):
         """Perform a login request.
 
         Associated request is typically to a path prefixed with "/v1/auth") and optionally stores the client token sent
-            in the resulting Vault response for use by the :py:meth:`hvac.adapters.Adapter` instance under the _adapater
+            in the resulting Vault response for use by the :py:meth:`hvac.adapters.Adapter` instance under the _adapter
             Client attribute.
 
         :param url: Path to send the authentication request to.
         :type url: str | unicode
         :param use_token: if True, uses the token in the response received from the auth request to set the "token"
-            attribute on the the :py:meth:`hvac.adapters.Adapter` instance under the _adapater Client attribute.
+            attribute on the the :py:meth:`hvac.adapters.Adapter` instance under the _adapter Client attribute.
         :type use_token: bool
         :param kwargs: Additional keyword arguments to include in the params sent with the request.
         :type kwargs: dict

--- a/hvac/api/auth_methods/approle.py
+++ b/hvac/api/auth_methods/approle.py
@@ -492,7 +492,7 @@ class AppRole(VaultApiBase):
         :param secret_id: Secret ID of the role.
         :type secret_id: str | unicode
         :param use_token: if True, uses the token in the response received from the auth request to set the "token"
-            attribute on the the :py:meth:`hvac.adapters.Adapter` instance under the _adapater Client attribute.
+            attribute on the the :py:meth:`hvac.adapters.Adapter` instance under the _adapter Client attribute.
         :type use_token: bool
         :param mount_point: The "path" the method/backend was mounted on.
         :type mount_point: str | unicode

--- a/hvac/api/auth_methods/aws.py
+++ b/hvac/api/auth_methods/aws.py
@@ -738,7 +738,7 @@ class Aws(VaultApiBase):
         :param role: Name of the role against which the login is being attempted.
         :type role: str
         :param use_token: if True, uses the token in the response received from the auth request to set the "token"
-            attribute on the the :py:meth:`hvac.adapters.Adapter` instance under the _adapater Client attribute.
+            attribute on the the :py:meth:`hvac.adapters.Adapter` instance under the _adapter Client attribute.
         :type use_token: bool
         :param mount_point: The path the AWS auth method was mounted on.
         :type mount_point: str
@@ -786,7 +786,7 @@ class Aws(VaultApiBase):
         :param role: Name of the role against which the login is being attempted.
         :type role: str
         :param use_token: if True, uses the token in the response received from the auth request to set the "token"
-            attribute on the the :py:meth:`hvac.adapters.Adapter` instance under the _adapater Client attribute.
+            attribute on the the :py:meth:`hvac.adapters.Adapter` instance under the _adapter Client attribute.
         :type use_token: bool
         :param mount_point: The path the AWS auth method was mounted on.
         :type mount_point: str

--- a/hvac/api/auth_methods/azure.py
+++ b/hvac/api/auth_methods/azure.py
@@ -312,7 +312,7 @@ class Azure(VaultApiBase):
             information can be obtained through instance metadata.
         :type vmss_name: str | unicode
         :param use_token: if True, uses the token in the response received from the auth request to set the "token"
-            attribute on the the :py:meth:`hvac.adapters.Adapter` instance under the _adapater Client attribute.
+            attribute on the the :py:meth:`hvac.adapters.Adapter` instance under the _adapter Client attribute.
         :type use_token: bool
         :param mount_point: The "path" the azure auth method was mounted on.
         :type mount_point: str | unicode

--- a/hvac/api/auth_methods/gcp.py
+++ b/hvac/api/auth_methods/gcp.py
@@ -442,7 +442,7 @@ class Gcp(VaultApiBase):
         :param jwt: A signed JSON web token
         :type jwt: str | unicode
         :param use_token: if True, uses the token in the response received from the auth request to set the "token"
-            attribute on the the :py:meth:`hvac.adapters.Adapter` instance under the _adapater Client attribute.
+            attribute on the the :py:meth:`hvac.adapters.Adapter` instance under the _adapter Client attribute.
         :type use_token: bool
         :param mount_point: The "path" the method/backend was mounted on.
         :type mount_point: str | unicode

--- a/hvac/api/auth_methods/github.py
+++ b/hvac/api/auth_methods/github.py
@@ -221,7 +221,7 @@ class Github(VaultApiBase):
         :param token: GitHub personal API token.
         :type token: str | unicode
         :param use_token: if True, uses the token in the response received from the auth request to set the "token"
-            attribute on the the :py:meth:`hvac.adapters.Adapter` instance under the _adapater Client attribute.
+            attribute on the the :py:meth:`hvac.adapters.Adapter` instance under the _adapter Client attribute.
         :type use_token: bool
         :param mount_point: The "path" the method/backend was mounted on.
         :type mount_point: str | unicode

--- a/hvac/api/auth_methods/kubernetes.py
+++ b/hvac/api/auth_methods/kubernetes.py
@@ -285,7 +285,7 @@ class Kubernetes(VaultApiBase):
         :param jwt: Signed JSON Web Token (JWT) from Kubernetes service account.
         :type jwt: str | unicode
         :param use_token: if True, uses the token in the response received from the auth request to set the "token"
-            attribute on the the :py:meth:`hvac.adapters.Adapter` instance under the _adapater Client attribute.
+            attribute on the the :py:meth:`hvac.adapters.Adapter` instance under the _adapter Client attribute.
         :type use_token: bool
         :param mount_point: The "path" the kubernetes auth method was mounted on.
         :type mount_point: str | unicode

--- a/hvac/api/auth_methods/ldap.py
+++ b/hvac/api/auth_methods/ldap.py
@@ -519,7 +519,7 @@ class Ldap(VaultApiBase):
         :param password: The password for the LDAP user
         :type password: str | unicode
         :param use_token: if True, uses the token in the response received from the auth request to set the "token"
-            attribute on the the :py:meth:`hvac.adapters.Adapter` instance under the _adapater Client attribute.
+            attribute on the the :py:meth:`hvac.adapters.Adapter` instance under the _adapter Client attribute.
         :type use_token: bool
         :param mount_point: The "path" the method/backend was mounted on.
         :type mount_point: str | unicode

--- a/hvac/api/auth_methods/okta.py
+++ b/hvac/api/auth_methods/okta.py
@@ -309,7 +309,7 @@ class Okta(VaultApiBase):
         :param password: Password for the authenticating user.
         :type password: str | unicode
         :param use_token: if True, uses the token in the response received from the auth request to set the "token"
-            attribute on the the :py:meth:`hvac.adapters.Adapter` instance under the _adapater Client attribute.
+            attribute on the the :py:meth:`hvac.adapters.Adapter` instance under the _adapter Client attribute.
         :type use_token: bool
         :param mount_point: The "path" the method/backend was mounted on.
         :type mount_point: str | unicode

--- a/hvac/api/auth_methods/radius.py
+++ b/hvac/api/auth_methods/radius.py
@@ -215,7 +215,7 @@ class Radius(VaultApiBase):
         :param password: The password for the RADIUS user
         :type password: str | unicode
         :param use_token: if True, uses the token in the response received from the auth request to set the "token"
-            attribute on the the :py:meth:`hvac.adapters.Adapter` instance under the _adapater Client attribute.
+            attribute on the the :py:meth:`hvac.adapters.Adapter` instance under the _adapter Client attribute.
         :type use_token: bool
         :param mount_point: The "path" the method/backend was mounted on.
         :type mount_point: str | unicode

--- a/hvac/api/secrets_engines/ssh.py
+++ b/hvac/api/secrets_engines/ssh.py
@@ -127,7 +127,7 @@ class Ssh(VaultApiBase):
         :param allowed_users: If only certain usernames are to be allowed, then this list enforces it.
         :type allowed_users: str | unicode
         :param allowed_users_template: If set, allowed_users can be specified using identity template policies.
-            (default: flase)
+            (default: false)
         :type allowed_users_template: bool
         :param allowed_domains: The list of domains for which a client can request a host certificate.
         :type allowed_domains: str | unicode

--- a/hvac/api/secrets_engines/transform.py
+++ b/hvac/api/secrets_engines/transform.py
@@ -399,7 +399,7 @@ class Transform(VaultApiBase):
         :param name: the name of the template to create.
         :type name: str | unicode
         :param template_type: Specifies the type of pattern matching to perform.
-            The ony type currently supported by this backend is regex.
+            The only type currently supported by this backend is regex.
         :type template_type: str | unicode
         :param pattern: the pattern used to match a particular value. For regex type
             matching, capture group determines the set of character that should be matched

--- a/hvac/api/system_backend/auth.py
+++ b/hvac/api/system_backend/auth.py
@@ -50,7 +50,7 @@ class Auth(SystemBackendMixin):
               the request data object.
             * **audit_non_hmac_response_keys**: Comma-separated list of keys that will not be HMAC'd by audit devices in
               the response data object.
-            * **listing_visibility**: Speficies whether to show this mount in the UI-specific listing endpoint.
+            * **listing_visibility**: Specifies whether to show this mount in the UI-specific listing endpoint.
             * **passthrough_request_headers**: Comma-separated list of headers to whitelist and pass from the request to
               the backend.
         :type config: dict

--- a/hvac/api/system_backend/init.py
+++ b/hvac/api/system_backend/init.py
@@ -50,7 +50,7 @@ class Init(SystemBackendMixin):
         :type secret_shares: int
         :param secret_threshold: Specifies the number of shares required to reconstruct the master key. This must be
             less than or equal secret_shares. If using Vault HSM with auto-unsealing, this value must be the same as
-            secret_shares, or ommitted, depending on the version of Vault and the seal type.
+            secret_shares, or omitted, depending on the version of Vault and the seal type.
         :type secret_threshold: int
         :param pgp_keys: List of PGP public keys used to encrypt the output unseal keys.
             Ordering is preserved. The keys must be base64-encoded from their original binary representation.

--- a/hvac/api/system_backend/mount.py
+++ b/hvac/api/system_backend/mount.py
@@ -171,7 +171,7 @@ class Mount(SystemBackendMixin):
         :param audit_non_hmac_response_keys: Specifies the comma-separated list of keys that will not be HMAC'd by audit
             devices in the response data object.
         :type audit_non_hmac_response_keys: list
-        :param listing_visibility: Speficies whether to show this mount in the UI-specific listing endpoint. Valid
+        :param listing_visibility: Specifies whether to show this mount in the UI-specific listing endpoint. Valid
             values are "unauth" or "".
         :type listing_visibility: str
         :param passthrough_request_headers: Comma-separated list of headers to whitelist and pass from the request

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -440,7 +440,7 @@ class Client:
         """Perform a login request with a wrapped token.
 
         Stores the unwrapped token in the resulting Vault response for use by the :py:meth:`hvac.adapters.Adapter`
-            instance under the _adapater Client attribute.
+            instance under the _adapter Client attribute.
 
         :param token: Wrapped token
         :type token: str | unicode
@@ -454,13 +454,13 @@ class Client:
         """Perform a login request.
 
         Associated request is typically to a path prefixed with "/v1/auth") and optionally stores the client token sent
-            in the resulting Vault response for use by the :py:meth:`hvac.adapters.Adapter` instance under the _adapater
+            in the resulting Vault response for use by the :py:meth:`hvac.adapters.Adapter` instance under the _adapter
             Client attribute.
 
         :param url: Path to send the authentication request to.
         :type url: str | unicode
         :param use_token: if True, uses the token in the response received from the auth request to set the "token"
-            attribute on the the :py:meth:`hvac.adapters.Adapter` instance under the _adapater Client attribute.
+            attribute on the the :py:meth:`hvac.adapters.Adapter` instance under the _adapter Client attribute.
         :type use_token: bool
         :param kwargs: Additional keyword arguments to include in the params sent with the request.
         :type kwargs: dict

--- a/poetry.lock
+++ b/poetry.lock
@@ -1360,6 +1360,25 @@ files = [
 ]
 
 [[package]]
+name = "typos"
+version = "1.16.11"
+description = "Source Code Spelling Correction"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "typos-1.16.11-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:5996c347cab149904c2f2a3f6194982f03c20c5302f9ee4ab866f4e5be0efed8"},
+    {file = "typos-1.16.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:05edd33a13ef6a6a88016e6f367f3a4158989f397371bc1ca07d5b4c38c94262"},
+    {file = "typos-1.16.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b208f42c939a348802e26a45a45cac7200ee6225643106ba27fb91aee418be85"},
+    {file = "typos-1.16.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:89f7c99b48ba34166a94e94d8e7e50c0fea503380e2e9bc8bb62bc6bb0d1a2fd"},
+    {file = "typos-1.16.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad94da00878fd53e9442ca3986f2d3edc1eb9321b54f41fcecaa1cec0a8b3dcb"},
+    {file = "typos-1.16.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7282151b26d1c84c47b9bef2d91179ac0eb9ebc58c431ffbd7ec8fbfd2bdbd83"},
+    {file = "typos-1.16.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:63b8ee9d45f147acb68070ea0ca46a2a2f8b8e7fcc09cb39d1977fa6db3d1959"},
+    {file = "typos-1.16.11-py3-none-win32.whl", hash = "sha256:b64d6f0b77ca9389a3793a9758783670daa7e85e38b8391a98d1870c0b063519"},
+    {file = "typos-1.16.11-py3-none-win_amd64.whl", hash = "sha256:0c36c0b940a9d288edc25cea085b437df0e9dea1b2eb14bfc7a85b6984538f69"},
+    {file = "typos-1.16.11.tar.gz", hash = "sha256:44e94672544f811cb07e753a57468e4a1bd828868b2b25a5a86b1d0f06de9b23"},
+]
+
+[[package]]
 name = "urllib3"
 version = "2.0.4"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -1498,4 +1517,4 @@ parser = ["pyhcl"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "925d77e78d31845963740602b50d456251150d0a030155b8381c8a21899ef374"
+content-hash = "fa1b708c82458573f90c2b6331dab75cdb03ca3a68a7648d197169ebaff83de1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,13 @@ docutils = "<0.18"
 packaging = "<24"
 jinja2 = "<3.1.0"
 jwcrypto = "^1.5.0"
+typos = "^1.16.11"
+
+[tool.typos.default.extend-words]
+Hashi = "Hashi"
+
+[tool.typos.files]
+extend-exclude = ["*.csr", "tests/config_files/ssh-key"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ typos = "^1.16.11"
 
 [tool.typos.default.extend-words]
 Hashi = "Hashi"
+saftey = "saftey"
 
 [tool.typos.files]
 extend-exclude = ["*.csr", "tests/config_files/ssh-key"]

--- a/tests/integration_tests/api/auth_methods/test_gcp.py
+++ b/tests/integration_tests/api/auth_methods/test_gcp.py
@@ -300,15 +300,15 @@ class TestGcp(HvacIntegrationTestCase, TestCase):
                 container=str(cm.exception),
             )
         else:
-            edit_labled_response = self.client.auth.gcp.edit_labels_on_gce_role(
+            edit_labeled_response = self.client.auth.gcp.edit_labels_on_gce_role(
                 name=role_name,
                 add=add,
                 remove=remove,
                 mount_point=self.TEST_MOUNT_POINT,
             )
-            logging.debug("create_role_response: %s" % edit_labled_response)
+            logging.debug("create_role_response: %s" % edit_labeled_response)
             self.assertEqual(
-                first=bool(edit_labled_response),
+                first=bool(edit_labeled_response),
                 second=True,
             )
 

--- a/tests/integration_tests/api/auth_methods/test_legacy_mfa.py
+++ b/tests/integration_tests/api/auth_methods/test_legacy_mfa.py
@@ -274,7 +274,7 @@ class TestLegacyMfa(HvacIntegrationTestCase, TestCase):
         self.client.auth.userpass.create_or_update_user(
             username=username,
             password=password,
-            policies=["defaut"],
+            policies=["default"],
             mount_point=TEST_AUTH_PATH,
         )
         if raises:

--- a/tests/integration_tests/api/secrets_engines/test_identity.py
+++ b/tests/integration_tests/api/secrets_engines/test_identity.py
@@ -57,7 +57,7 @@ class TestIdentity(HvacIntegrationTestCase, TestCase):
             entity_ids = list_entities_response["data"]["keys"]
         except exceptions.InvalidPath:
             logging.debug(
-                "InvalidPath raised when calling list_entites_by_id in tearDown..."
+                "InvalidPath raised when calling list_entities_by_id in tearDown..."
             )
             entity_ids = []
         for entity_id in entity_ids:
@@ -81,7 +81,7 @@ class TestIdentity(HvacIntegrationTestCase, TestCase):
             alias_ids = list_entity_aliases_response["keys"]
         except exceptions.InvalidPath:
             logging.debug(
-                "InvalidPath raised when calling list_entites_by_id in tearDown..."
+                "InvalidPath raised when calling list_entities_by_id in tearDown..."
             )
             alias_ids = []
         for alias_id in alias_ids:

--- a/tests/integration_tests/api/secrets_engines/test_kv_v2.py
+++ b/tests/integration_tests/api/secrets_engines/test_kv_v2.py
@@ -690,7 +690,7 @@ class TestKvV2(HvacIntegrationTestCase, TestCase):
         test_label,
         path,
         write_secret_before_test=1,
-        destoryed_versions=None,
+        destroyed_versions=None,
         raises=None,
         exception_message="",
     ):
@@ -708,7 +708,7 @@ class TestKvV2(HvacIntegrationTestCase, TestCase):
             with self.assertRaises(raises) as cm:
                 self.client.secrets.kv.v2.destroy_secret_versions(
                     path=path,
-                    versions=destoryed_versions,
+                    versions=destroyed_versions,
                     mount_point=self.DEFAULT_MOUNT_POINT,
                 )
             self.assertIn(
@@ -719,7 +719,7 @@ class TestKvV2(HvacIntegrationTestCase, TestCase):
             destroy_secret_versions_result = (
                 self.client.secrets.kv.v2.destroy_secret_versions(
                     path=path,
-                    versions=destoryed_versions,
+                    versions=destroyed_versions,
                     mount_point=self.DEFAULT_MOUNT_POINT,
                 )
             )
@@ -735,29 +735,29 @@ class TestKvV2(HvacIntegrationTestCase, TestCase):
             logging.debug(
                 "read_secret_metadata_result: %s" % read_secret_metadata_result
             )
-            for destoryed_version in destoryed_versions:
+            for destroyed_version in destroyed_versions:
                 if (
-                    str(destoryed_version)
+                    str(destroyed_version)
                     in read_secret_metadata_result["data"]["versions"]
                 ):
                     self.assertTrue(
                         expr=read_secret_metadata_result["data"]["versions"][
-                            str(destoryed_version)
+                            str(destroyed_version)
                         ]["destroyed"],
-                        msg='Version "{num}" should be destoryed but is not. Full read metadata response versions: {metadata}'.format(
-                            num=destoryed_version,
+                        msg='Version "{num}" should be destroyed but is not. Full read metadata response versions: {metadata}'.format(
+                            num=destroyed_version,
                             metadata=read_secret_metadata_result["data"]["versions"],
                         ),
                     )
-            for nondestoryed_version in set(
+            for nondestroyed_version in set(
                 range(1, write_secret_before_test + 1)
-            ) - set(destoryed_versions):
+            ) - set(destroyed_versions):
                 self.assertFalse(
                     expr=read_secret_metadata_result["data"]["versions"][
-                        str(nondestoryed_version)
+                        str(nondestroyed_version)
                     ]["destroyed"],
-                    msg='Version "{num}" should not be destoryed but is. Full read metadata response versions: {metadata}'.format(
-                        num=nondestoryed_version,
+                    msg='Version "{num}" should not be destroyed but is. Full read metadata response versions: {metadata}'.format(
+                        num=nondestroyed_version,
                         metadata=read_secret_metadata_result["data"]["versions"],
                     ),
                 )

--- a/tests/unit_tests/api/auth_methods/test_legacy_mfa.py
+++ b/tests/unit_tests/api/auth_methods/test_legacy_mfa.py
@@ -135,7 +135,7 @@ class TestLegacyMfa(TestCase):
         ]
     )
     @requests_mock.Mocker()
-    def test_read_duo_behvaior_configuration(
+    def test_read_duo_behavior_configuration(
         self, test_label, mount_point, requests_mocker
     ):
         expected_status_code = 200

--- a/tests/utils/mock_oauth_provider/app.py
+++ b/tests/utils/mock_oauth_provider/app.py
@@ -15,7 +15,7 @@ def create_app(config=None):
     if "WEBSITE_CONF" in os.environ:
         app.config.from_envvar("WEBSITE_CONF")
 
-    # load app sepcified configuration
+    # load app specified configuration
     if config is not None:
         if isinstance(config, dict):
             app.config.update(config)

--- a/tests/utils/server_manager.py
+++ b/tests/utils/server_manager.py
@@ -185,7 +185,7 @@ class ServerManager:
                 )
             except KeyError as error:
                 logger.debug(
-                    "Unable to find explict Vault address in config file {path}: {err}".format(
+                    "Unable to find explicit Vault address in config file {path}: {err}".format(
                         path=config_path,
                         err=error,
                     )


### PR DESCRIPTION
[`typos`](https://github.com/crate-ci/typos) is a great tool for finding typos in a varietry of file formats.

I have not tested these changes, though most changes are in the documentation and the docstrings. There are 2 potential API changes: The `saftey_buffer` arguments for `tidy_blacklist_tags` and `tidy_identity_whitelist_entries` have been changed to `safety_buffer`. If we want to maintain compatibility we could use kwargs and check for the new flag, then the old one.