### PR TITLE
Make `pyhcl` optional again

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,11 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-pyhcl = "^0.4.4"
+pyhcl = { version = "^0.4.4", optional = true }
 requests = "^2.27.1"
+
+[tool.poetry.extras]
+parser = ["pyhcl"]
 
 [tool.poetry.group.dev]
 optional = true
@@ -52,6 +55,7 @@ ipaddress = "^1.0.23"
 mock = "^4.0.3"
 nose = "^1.3.7"
 parameterized = "^0.8.1"
+pyhcl = "^0.4.4"
 pytest = "7.0.1"
 pytest-cov = "^3.0.0"
 python-ldap-test = "^0.3.1"


### PR DESCRIPTION
Resolves #1038 
See comment https://github.com/hvac/hvac/issues/1038#issuecomment-1703844682 .


This makes the `pyhcl` dependency installable via `pip install hvac[parser]` again like the README suggests.

The `pyhcl` dependency is also specified as a dev dependency so that it is always installed during testing.

Also, sorry for the PR spam, I've been in contribution mode the past few days!