### PR TITLE
Remove old deprecated `client` attributes

### DIFF
--- a/hvac/api/auth_methods/__init__.py
+++ b/hvac/api/auth_methods/__init__.py
@@ -1,7 +1,5 @@
 """Collection of classes for various Vault auth methods."""
 
-import warnings
-
 from hvac.api.auth_methods.approle import AppRole
 from hvac.api.auth_methods.azure import Azure
 from hvac.api.auth_methods.gcp import Gcp
@@ -18,7 +16,6 @@ from hvac.api.auth_methods.token import Token
 from hvac.api.auth_methods.aws import Aws
 from hvac.api.auth_methods.cert import Cert
 from hvac.api.vault_api_category import VaultApiCategory
-from hvac.utils import generate_method_deprecation_message
 
 __all__ = (
     "AuthMethods",
@@ -65,23 +62,3 @@ class AuthMethods(VaultApiCategory):
         "AliCloud",
         "Mfa",
     ]
-
-    def __call__(self, *args, **kwargs):
-        """Implement callable magic method for backwards compatibility.
-
-        Older versions of hvac.Client had an auth method that has now been replaced with an "auth" property pointing to
-        this class.
-        """
-        deprecation_message = generate_method_deprecation_message(
-            to_be_removed_in_version="0.9.0",
-            old_method_name="auth",
-            method_name="login",
-            module_name="adapters.Request",
-        )
-        warnings.warn(
-            message=deprecation_message,
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-
-        return self._adapter.login(*args, **kwargs)

--- a/hvac/constants/client.py
+++ b/hvac/constants/client.py
@@ -3,20 +3,23 @@
 
 from os import getenv
 
-DEPRECATED_PROPERTIES = {
-    "github": dict(
-        to_be_removed_in_version="0.9.0",
-        client_property="auth",
-    ),
-    "ldap": dict(
-        to_be_removed_in_version="0.9.0",
-        client_property="auth",
-    ),
-    "kv": dict(
-        to_be_removed_in_version="0.9.0",
-        client_property="secrets",
-    ),
-}
+DEPRECATED_PROPERTIES = {}
+# ^ this follows the format defined in utils.getattr_with_deprecated_properties
+# example:
+#   {
+#       "old_property_one": {
+#           "to_be_removed_in_version": "99.0.0",
+#           "client_property": "auth",
+#       },
+#       "old_property_two": {
+#           "to_be_removed_in_version": "99.0.0",
+#           "client_property": "secrets",
+#           "new_property": "new_property_two",
+#       },
+#   }
+#
+# Result is that `client.old_property_one` will return the value of `client.auth.old_property_one`,
+# and `client.old_property_two` will return `client.secrets.new_property_two`.
 
 DEFAULT_URL = "http://localhost:8200"
 VAULT_CACERT = getenv("VAULT_CACERT")


### PR DESCRIPTION
Resolves #549 

Several attributes that were marked deprecated years ago are finally being removed. They were originally planned to be removed in `v0.9.0`.

The affected attributes and their replacements are:
- `client.github -> client.auth.github`
- `client.ldap -> client.auth.ldap`
- `client.kv -> client.secrets.kv`
- `client.auth` : this one was marked to use `adapters.Request.login` as a replacement method, but `adapters.Request` is an old name that's kept working for backward compatibility. Instead, choose a specific adapter, like `adapter.JSONAdapter().login`.