### PR TITLE
Database Secrets Engine - add `rotate_static_credentials` method, docs updates, unit tests

### DIFF
--- a/docs/usage/secrets_engines/database.rst
+++ b/docs/usage/secrets_engines/database.rst
@@ -201,7 +201,7 @@ Deletes a role definition:
 
 
 Rotate Root Credentials
------------------------
+------------------------
 
 :py:meth:`hvac.api.secrets_engines.Database.rotate_root_credentials()`
 
@@ -251,3 +251,84 @@ Returns the current credentials based on the named static role:
         name='role-name',
         mount_point='my-database'
     )
+
+Create Static Role
+--------------------
+
+:py:meth:`hvac.api.secrets_engines.Database.create_static_role`
+
+Creates or updates a static role:
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    rotation_statement = ["ALTER USER \"{{name}}\" WITH PASSWORD '{{password}}';"]
+
+    credentials = client.secrets.database.create_static_role(
+        name='role-name',
+        db_name='db-connection-name',
+        username='static-role-username'
+        rotation_statements=rotation_statement,
+        rotation_period=86400,
+        mount_point='my-database'
+    )
+
+.. note::
+    The ``username`` referenced above needs to be pre-created in the database prior to calling this method as Vault will be referencing this username to rotate its password.
+
+
+Read Static Role
+-----------------
+
+:py:meth:`hvac.api.secrets_engines.Database.read_static_role`
+
+Queries a static role definition:
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    client.secrets.database.read_static_role(
+        name='role-name',
+        mount_point='my-database'
+    )
+
+
+List Static Roles
+-------------------
+
+:py:meth:`hvac.api.secrets_engines.Database.list_static_roles`
+
+Returns a list of available static roles:
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    static_roles = client.secrets.database.list_static_roles(
+        mount_point='my-database'
+    )
+
+
+Rotate Static Role Credentials
+------------------------------
+
+:py:meth:`hvac.api.secrets_engines.Database.rotate_static_role_credentials`
+
+This endpoint is used to rotate the Static Role credentials stored for a given role name. While Static Roles are rotated automatically by Vault at configured rotation periods, users can use this endpoint to manually trigger a rotation to change the stored password and reset the TTL of the Static Role's password.
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    client.secrets.database.rotate_static_role_credentials(
+        name='role-name',
+        mount_point='my-database'
+    )
+
+

--- a/hvac/api/secrets_engines/database.py
+++ b/hvac/api/secrets_engines/database.py
@@ -381,3 +381,25 @@ class Database(VaultApiBase):
         return self._adapter.get(
             url=api_path,
         )
+
+    def rotate_static_role_credentials(self, name, mount_point=DEFAULT_MOUNT_POINT):
+        """This endpoint is used to rotate the Static Role credentials stored for a given role name.
+        While Static Roles are rotated automatically by Vault at configured rotation periods,
+        users can use this endpoint to manually trigger a rotation to change the stored password and
+        reset the TTL of the Static Role's password.
+
+        :param name: Specifies the name of the role to create credentials against
+        :type name: str | unicode
+        :param mount_point: The "path" the method/backend was mounted on.
+        :type mount_point: str | unicode
+        :return: The response of the request.
+        :rtype: requests.Response
+        """
+
+        api_path = utils.format_url(
+            "/v1/{mount_point}/rotate-role/{name}", mount_point=mount_point, name=name
+        )
+
+        return self._adapter.post(
+            url=api_path,
+        )

--- a/tests/unit_tests/api/secrets_engines/test_database.py
+++ b/tests/unit_tests/api/secrets_engines/test_database.py
@@ -1,0 +1,88 @@
+import logging
+import requests_mock
+from unittest import TestCase
+
+from hvac.api.secrets_engines.database import Database
+from hvac.api.secrets_engines.database import DEFAULT_MOUNT_POINT
+from hvac.adapters import JSONAdapter
+
+
+class TestDatabase(TestCase):
+    def setUp(self):
+        self.database = Database(adapter=JSONAdapter())
+        self.expected_status_code = 200
+
+    def mock_request(self, method, mock_url, mock_response):
+        with requests_mock.mock() as requests_mocker:
+            requests_mocker.register_uri(
+                method=method,
+                url=mock_url,
+                status_code=self.expected_status_code,
+                json=mock_response,
+            )
+            return requests_mocker
+
+    def test_configure(self):
+        name = "test_db"
+        plugin_name = "test_plugin"
+        verify_connection = None
+        allowed_roles = None
+        root_rotation_statements = None
+        mount_point = DEFAULT_MOUNT_POINT
+
+        mock_url = f"http://localhost:8200/v1/{mount_point}/config/{name}"
+        mock_response = {"status_code": 204}  # no response other than status code
+        expected_status_code = 204
+
+        with self.mock_request("POST", mock_url, mock_response):
+            configure_response = self.database.configure(
+                name=name,
+                plugin_name=plugin_name,
+                verify_connection=verify_connection,
+                allowed_roles=allowed_roles,
+                root_rotation_statements=root_rotation_statements,
+                mount_point=mount_point,
+            )
+        logging.debug("configure_response: %s" % configure_response)
+
+        self.assertEqual(configure_response["status_code"], expected_status_code)
+
+    def test_rotate_root_credentials(self):
+        name = "test_db"
+        mount_point = DEFAULT_MOUNT_POINT
+
+        mock_url = f"http://localhost:8200/v1/{mount_point}/rotate-root/{name}"
+        mock_response = {"status_code": 204}  # no response other than status code
+        expected_status_code = 204
+
+        with self.mock_request("POST", mock_url, mock_response):
+            rotate_root_credentials_response = self.database.rotate_root_credentials(
+                name=name, mount_point=mount_point
+            )
+        logging.debug(
+            "rotate_root_credentials_response: %s" % rotate_root_credentials_response
+        )
+        self.assertEqual(
+            rotate_root_credentials_response["status_code"], expected_status_code
+        )
+
+    def test_rotate_static_role_credentials(self):
+        name = "test_role"
+        mount_point = DEFAULT_MOUNT_POINT
+
+        mock_url = f"http://localhost:8200/v1/{mount_point}/rotate-role/{name}"
+        mock_response = {
+            "data": {"last_vault_rotation": "2023-09-25T19:02:38.347994635Z"}
+        }
+
+        with self.mock_request("POST", mock_url, mock_response):
+            rotate_static_credentials_response = (
+                self.database.rotate_static_role_credentials(
+                    name=name, mount_point=mount_point
+                )
+            )
+        logging.debug(
+            "rotate_static_credentials_response: %s"
+            % rotate_static_credentials_response
+        )
+        self.assertEqual(rotate_static_credentials_response, mock_response)


### PR DESCRIPTION
Hellooo @briantist, it's me again :) ! A few updates for the db secrets engine, again:

- Code: added the [rotate_static_credentials method](https://developer.hashicorp.com/vault/api-docs/secret/databases#rotate-static-role-credentials) to the db secrets engine api
- Docs: added the remaining static role related documentation
- Unit test: attempted to add some unit tests... it doesn't cover all the methods but it's something? 😅

If it all goes well, the code and docs should now cover the complete set of db secrets engine API methods. 