### PR TITLE
Fix invalid build and test status

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 [HashiCorp](https://hashicorp.com/) [Vault](https://www.vaultproject.io) API client for Python 3.x
 
-[![Test](https://github.com/hvac/hvac/workflows/Test/badge.svg)](https://github.com/hvac/hvac/actions?query=workflow%3ATest)
+[![Build](https://github.com/hvac/hvac/actions/workflows/build-test.yml/badge.svg)](https://github.com/hvac/hvac/actions/workflows/build-test.yml) 
+[![Lint](https://github.com/hvac/hvac/actions/workflows/lint-and-test.yml/badge.svg)](https://github.com/hvac/hvac/actions/workflows/lint-and-test.yml)
 [![codecov](https://codecov.io/gh/hvac/hvac/branch/main/graph/badge.svg)](https://codecov.io/gh/hvac/hvac)
 [![Documentation Status](https://readthedocs.org/projects/hvac/badge/)](https://hvac.readthedocs.io/en/latest/?badge=latest)
 [![PyPI version](https://badge.fury.io/py/hvac.svg)](https://badge.fury.io/py/hvac)


### PR DESCRIPTION
Added status for `build and test` and `lint and test`

**Before**:
<img width="692" alt="image" src="https://github.com/hvac/hvac/assets/10793628/a2d4a9e1-b605-439d-bf4e-1ec82a6fb7f9">

**After**:

<img width="770" alt="image" src="https://github.com/hvac/hvac/assets/10793628/e09b7d24-0e7e-42b6-a632-930fd39b6ed4">

