### PR TITLE
Drop support for Vault 1.6-1.10

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -184,15 +184,11 @@ jobs:
         vault-version:
           - "vault-enterprise=1.6.*+ent"
           - "vault-enterprise=1.7.*+ent"
-          - "vault=1.6.*"
-          - "vault=1.7.*"
-          - "vault=1.8.*"
-          - "vault=1.9.*"
-          - "vault=1.10.*"
           - "vault=1.11.*"
           - "vault=1.12.*"
           - "vault=1.13.*"
           - "vault=1.14.*"
+          - "vault=1.15.*"
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -188,7 +188,8 @@ jobs:
           - "vault=1.12.*"
           - "vault=1.13.*"
           - "vault=1.14.*"
-          - "vault=1.15.*"
+          # - "vault=1.15.*"
+          # https://github.com/hvac/hvac/issues/1075
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
# Breaking changes
- Drop unsupported Vault versions 1.6 through 1.10 in CI (https://endoflife.date/hashicorp-vault)
  - 1.6 and 1.7 remain tested as enterprise versions, mostly because we haven't been able to properly test enterprise versions without a license past those
  - unsupported versions still remain, we will probably become more aggressive about dropping them in the future
  - while dropping these from CI doesn't mean that `hvac` won't work against these versions, it does mean we don't test against them and don't enforce new or edited code to be compatible with them
