### PR TITLE
Release process - use `poetry-bumpversion` instead of `bump2version`

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,8 +1,0 @@
-[bumpversion]
-current_version = 1.2.1
-commit = False
-tag = False
-
-[bumpversion:file:pyproject.toml]
-
-[bumpversion:file:docs/conf.py]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ HVAC uses poetry to manage dependencies, the virtual environment, and versioning
 git clone https://github.com/hvac/hvac.git
 cd hvac
 
-poetry install
+poetry install --with dev
 
 # Run the following command on Linux
 source $(poetry env info --path)/bin/activate
@@ -28,7 +28,7 @@ the latest `vault` binary is available in your `PATH`.
 
 ```
 cd hvac
-poetry install
+poetry install --with dev
 ```
 
 3. Enter the virtual environment
@@ -107,19 +107,23 @@ Ensure your local `main` branch is up to date, and then checkout a new branch to
 
 ### Updating the version
 
+We use the `poetry-bumpversion` plugin for bumping versions. Check the `poetry` documentation for [using plugins](https://python-poetry.org/docs/master/plugins/#using-plugins) for instructions on installing the plugin in your `poetry` environment.
+
 `hvac` uses [semver](https://semver.org/) so be aware of whether the next version is a minor, major, or patch release.
 
 Minor will be most common, but it will depend on the PRs that have been accepted. Ideally, all PRs are added to a milestone and we can refer to those to determine what the next version must be.
 
-Update the version number using [bump2version](https://github.com/c4urself/bump2version), which will update all the places that need to be updated.
+Update the version number in all the places that need to be updated:
 
 ```
-bumpversion {patch|minor|major}
+poetry version {patch|minor|major}
 ```
+
+**IMPORTANT:** if you do not see any line(s) in the output that look like `poetry_bumpversion: processed file <filename>` then you must install the `poetry-bumpversion` plugin. Without that, only `pyproject.toml` is updated, which is not correct.
 
 Choose `minor`, `major`, or `patch` as appropriate.
 
-Review the changed files, and commit the changes to the branch.
+Review the changed files (ensure all files listed in `[tool.poetry_bumpversion.file.*]` entries in `pyproject.toml` are modified), and commit the changes to the branch.
 
 ### Updating the changelog
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -99,17 +99,6 @@ jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
-name = "bump2version"
-version = "1.0.1"
-description = "Version-bump your software with a single command!"
-optional = false
-python-versions = ">=3.5"
-files = [
-    {file = "bump2version-1.0.1-py2.py3-none-any.whl", hash = "sha256:37f927ea17cde7ae2d7baf832f8e80ce3777624554a653006c9144f8017fe410"},
-    {file = "bump2version-1.0.1.tar.gz", hash = "sha256:762cb2bfad61f4ec8e2bdf452c7c267416f8c70dd9ecb1653fd0bbb01fa936e6"},
-]
-
-[[package]]
 name = "certifi"
 version = "2023.7.22"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -1509,4 +1498,4 @@ parser = ["pyhcl"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "9f2617c42d96f069a4225cf021da293698bc3b689d5e92465a73410f3780d76f"
+content-hash = "925d77e78d31845963740602b50d456251150d0a030155b8381c8a21899ef374"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,10 +68,11 @@ sphinx-rtd-theme = "0.5.0"
 mistune = "0.8.4"
 docutils = "<0.18"
 packaging = "<24"
-bump2version = "^1.0.1"
 jinja2 = "<3.1.0"
 jwcrypto = "^1.5.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.poetry_bumpversion.file."docs/conf.py"]


### PR DESCRIPTION
Resolves #1018

No functional changes in this PR, this only affected the release process for maintainers, and removes a dependency for other developers.