### PR TITLE
add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,13 @@
+# .git-blame-ignore-revs
+
+# Fixing typos
+# - https://github.com/hvac/hvac/commit/b2df800aeee724957b13102e18f7b0aa6f4aeb65
+# - https://github.com/hvac/hvac/pull/1057
+6c31f14cea1eb3f1aca816a78f9e5be56b90e08c
+
+# Introduction of black formatter
+# - https://github.com/hvac/hvac/commit/68aefde34ded8efb3fa29e4eb6c618229717fb8c
+# - https://github.com/hvac/hvac/commit/439f3cfcceae25df9e1b0afcb37caf536222eddb
+# - https://github.com/hvac/hvac/pull/726
+68aefde34ded8efb3fa29e4eb6c618229717fb8c
+439f3cfcceae25df9e1b0afcb37caf536222eddb

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,4 +1,5 @@
 # .git-blame-ignore-revs
+# - https://github.com/hvac/hvac/pull/1087
 
 # Fixing typos
 # - https://github.com/hvac/hvac/commit/b2df800aeee724957b13102e18f7b0aa6f4aeb65


### PR DESCRIPTION
Related:
- https://github.com/hvac/hvac/pull/1057
- https://github.com/hvac/hvac/pull/726

Adding this file to aid in `git blame` operations. We're having it ignore some big repo-wide changes. One of them was when the project switched to `black` and reformatted almost every file, and the other was when we introduced a typo checker and fixed up all the typos throughout the repository.

GitHub will use this file in its blame views: https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view

To use this file locally, you must opt-in to it:
```
git config blame.ignorerevsfile=.git-blame-ignore-revs
```

If you are using other tools that display blame information, they may work correctly by setting git config alone, or they may require additional configuration.
