### PR TITLE
Add Vault 1.15.x to integration tests

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -188,8 +188,7 @@ jobs:
           - "vault=1.12.*"
           - "vault=1.13.*"
           - "vault=1.14.*"
-          # - "vault=1.15.*"
-          # https://github.com/hvac/hvac/issues/1075
+          - "vault=1.15.*"
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Looks like the requirement to have a valid JWT token was removed in version 1.15.0 [based on this pull request](https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/207). Disabled the jwt error parameter (number 4) for versions 1.15.0 and greater. 

Resolves #1075 