### PR TITLE
Revamp integration tests, run in parallel

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -161,6 +161,7 @@ jobs:
     - name: pytest tests/unit_tests
       run: |
         poetry run pytest \
+          -rsxfE \
           --cov=hvac \
           --cov-report=xml:reports/coverage_units_py${{ matrix.python-version }}.xml \
           tests/unit_tests
@@ -242,6 +243,7 @@ jobs:
         COVFILE: coverage_integration_py${{ matrix.python-version }}_${{ matrix.vault-version }}.xml
       run: |
         poetry run pytest \
+          -rsxfE \
           --cov=hvac \
           --cov-report=xml:reports/${COVFILE//[^A-Za-z0-9\-_\.]/_} \
           tests/integration_tests

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -109,13 +109,13 @@ Read and write to secrets engines
 KV Secrets Engine - Version 2
 """""""""""""""""""""""""""""
 
+.. testsetup:: kvv2
+
+    client = manager.client
 
 .. doctest:: kvv2
    :skipif: client.sys.retrieve_mount_option('secret', 'version', '1') != '2'
 
-    >>> # Retrieve an authenticated hvac.Client() instance
-    >>> client = test_utils.create_client()
-    >>>
     >>> # Write a k/v pair under path: secret/foo
     >>> create_response = client.secrets.kv.v2.create_or_update_secret(
     ...     path='foo',

--- a/poetry.lock
+++ b/poetry.lock
@@ -447,6 +447,20 @@ files = [
 test = ["pytest (>=6)"]
 
 [[package]]
+name = "execnet"
+version = "2.0.2"
+description = "execnet: rapid multi-Python deployment"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "execnet-2.0.2-py3-none-any.whl", hash = "sha256:88256416ae766bc9e8895c76a87928c0012183da3cc4fc18016e6f050e025f41"},
+    {file = "execnet-2.0.2.tar.gz", hash = "sha256:cc59bc4423742fd71ad227122eb0dd44db51efb3dc4095b45ac9a08c770096af"},
+]
+
+[package.extras]
+testing = ["hatch", "pre-commit", "pytest", "tox"]
+
+[[package]]
 name = "flake8"
 version = "5.0.4"
 description = "the modular source code checker: pep8 pyflakes and co"
@@ -1017,6 +1031,26 @@ pytest = ">=5.0"
 dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.3.1"
+description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-xdist-3.3.1.tar.gz", hash = "sha256:d5ee0520eb1b7bcca50a60a518ab7a7707992812c578198f8b44fdfac78e8c93"},
+    {file = "pytest_xdist-3.3.1-py3-none-any.whl", hash = "sha256:ff9daa7793569e6a68544850fd3927cd257cc03a7ef76c95e86915355e82b5f2"},
+]
+
+[package.dependencies]
+execnet = ">=1.1"
+pytest = ">=6.2.0"
+
+[package.extras]
+psutil = ["psutil (>=3.0)"]
+setproctitle = ["setproctitle"]
+testing = ["filelock"]
+
+[[package]]
 name = "python-ldap-test"
 version = "0.3.1"
 description = "Tool for testing code speaking with LDAP server. Allows to easily configure and run an embedded, in-memory LDAP server. Uses UnboundID LDAP SDK through Py4J."
@@ -1532,4 +1566,4 @@ parser = ["pyhcl"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "9e4929bbf116a4f7b50561a7356414449eee106963bfd968d0314198f84a2b9c"
+content-hash = "f0da8d606a81fd30e6c06f5a0e9dda1b9764bd0495facfa4efb307196ea91919"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,10 @@ greenlet = "^3.0.0"
 jwcrypto = "^1.5.0"
 typos = "^1.16.11"
 pytest-mock = "^3.11.1"
+pytest-xdist = "^3.3.1"
+
+[tool.pytest.ini_options]
+addopts = "-n auto --dist worksteal"
 
 [tool.typos.default.extend-words]
 Hashi = "Hashi"

--- a/tests/config_files/generated/.gitignore
+++ b/tests/config_files/generated/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/config_files/vault-doctest.hcl
+++ b/tests/config_files/vault-doctest.hcl
@@ -2,6 +2,7 @@ backend "inmem" {
 }
 
 listener "tcp" {
+  address = "127.0.0.1:8200"
   tls_cert_file = "../tests/config_files/server-cert.pem"
   tls_key_file  = "../tests/config_files/server-key.pem"
 }

--- a/tests/config_files/vault-ha-node1.hcl
+++ b/tests/config_files/vault-ha-node1.hcl
@@ -9,7 +9,7 @@ disable_mlock = true
 default_lease_ttl = "768h"
 max_lease_ttl = "768h"
 
-// storage "consul" {
-//   address = "127.0.0.1:8500"
-//   path    = "vault_123/"
-// }
+storage "consul" {
+  address = "127.0.0.1:8500"
+  path    = "vault_123/"
+}

--- a/tests/config_files/vault-ha-node1.hcl
+++ b/tests/config_files/vault-ha-node1.hcl
@@ -1,5 +1,5 @@
 listener "tcp" {
-  address = "127.0.0.1:8200"
+  // address = "127.0.0.1:8200"
   tls_cert_file = "tests/config_files/server-cert.pem"
   tls_key_file  = "tests/config_files/server-key.pem"
 }
@@ -9,7 +9,7 @@ disable_mlock = true
 default_lease_ttl = "768h"
 max_lease_ttl = "768h"
 
-storage "consul" {
-  address = "127.0.0.1:8500"
-  path    = "vault"
-}
+// storage "consul" {
+//   address = "127.0.0.1:8500"
+//   path    = "vault_123/"
+// }

--- a/tests/config_files/vault-ha-node2.hcl
+++ b/tests/config_files/vault-ha-node2.hcl
@@ -10,7 +10,7 @@ disable_mlock = true
 default_lease_ttl = "768h"
 max_lease_ttl = "768h"
 
-// storage "consul" {
-//   address = "127.0.0.1:8500"
-//   path    = "vault_123/"
-// }
+storage "consul" {
+  address = "127.0.0.1:8500"
+  path    = "vault_123/"
+}

--- a/tests/config_files/vault-ha-node2.hcl
+++ b/tests/config_files/vault-ha-node2.hcl
@@ -1,6 +1,6 @@
 listener "tcp" {
-  address = "127.0.0.1:8199"
-  cluster_address = "127.0.0.1:8201"
+  // address = "127.0.0.1:8198"
+  # cluster_address = "127.0.0.1:8201"
   tls_cert_file = "tests/config_files/server-cert.pem"
   tls_key_file  = "tests/config_files/server-key.pem"
 }
@@ -10,7 +10,7 @@ disable_mlock = true
 default_lease_ttl = "768h"
 max_lease_ttl = "768h"
 
-storage "consul" {
-  address = "127.0.0.1:8500"
-  path    = "vault"
-}
+// storage "consul" {
+//   address = "127.0.0.1:8500"
+//   path    = "vault_123/"
+// }

--- a/tests/doctest/__init__.py
+++ b/tests/doctest/__init__.py
@@ -11,14 +11,15 @@ from tests.utils.server_manager import ServerManager
 
 
 def doctest_global_setup():
-    client = test_utils.create_client()
     manager = ServerManager(
         config_paths=[test_utils.get_config_file_path("vault-doctest.hcl")],
-        client=client,
+        patch_config=False,
     )
     manager.start()
     manager.initialize()
     manager.unseal()
+
+    client = manager.client
 
     mocker = Mocker(real_http=True)
     mocker.start()
@@ -27,7 +28,7 @@ def doctest_global_setup():
         f"ldap/login/{MockLdapServer.ldap_user_name}",
     ]
     for auth_method_path in auth_method_paths:
-        mock_url = f"https://127.0.0.1:8200/v1/auth/{auth_method_path}"
+        mock_url = f"{client.url}/v1/auth/{auth_method_path}"
         mock_response = {
             "auth": {
                 "client_token": manager.root_token,

--- a/tests/integration_tests/api/auth_methods/test_cert.py
+++ b/tests/integration_tests/api/auth_methods/test_cert.py
@@ -10,7 +10,7 @@ class TestCert(HvacIntegrationTestCase, TestCase):
     TEST_MOUNT_POINT = "cert-test"
     TEST_ROLE_NAME = "testrole"
     TEST_CLIENT_CERTIFICATE_FILE = utils.get_config_file_path("client-cert.pem")
-    cert = utils.create_client()._adapter._kwargs.get("cert")
+    cert = utils.create_client(url="fake")._adapter._kwargs.get("cert")
     with open(TEST_CLIENT_CERTIFICATE_FILE, "r") as fp:
         TEST_CERTIFICATE = fp.read()
 

--- a/tests/integration_tests/api/auth_methods/test_jwt.py
+++ b/tests/integration_tests/api/auth_methods/test_jwt.py
@@ -37,11 +37,12 @@ class TestJWT(HvacIntegrationTestCase, TestCase):
         [
             param(
                 "configure using vault identity OIDC",
-                issuer="https://localhost:8200",
+                # issuer="https://localhost:8200",
             ),
         ]
     )
-    def test_configure(self, label, issuer):
+    def test_configure(self, label): #, issuer):
+        issuer = self.client.url
         oidc_discovery_url = f"{issuer}/v1/identity/oidc"
         self.client.secrets.identity.configure_tokens_backend(
             issuer=issuer,
@@ -63,11 +64,12 @@ class TestJWT(HvacIntegrationTestCase, TestCase):
         [
             param(
                 "configure using vault identity OIDC",
-                issuer="https://localhost:8200",
+                # issuer="https://localhost:8200",
             ),
         ]
     )
-    def test_read_config(self, label, issuer):
+    def test_read_config(self, label): #, issuer):
+        issuer = self.client.url
         oidc_discovery_url = f"{issuer}/v1/identity/oidc"
         self.client.secrets.identity.configure_tokens_backend(
             issuer=issuer,
@@ -94,12 +96,13 @@ class TestJWT(HvacIntegrationTestCase, TestCase):
             param(
                 "success",
                 role_name="hvac",
-                allowed_redirect_uris=["https://localhost:8200/jwt-test/callback"],
+                allowed_redirect_uris=["{url}/jwt-test/callback"],
                 user_claim="https://vault/user",
             ),
         ]
     )
     def test_create_role(self, label, role_name, allowed_redirect_uris, user_claim):
+        allowed_redirect_uris = [uri.format(url=self.client.url) for uri in allowed_redirect_uris]
         response = self.client.auth.jwt.create_role(
             name=role_name,
             allowed_redirect_uris=allowed_redirect_uris,
@@ -124,12 +127,13 @@ class TestJWT(HvacIntegrationTestCase, TestCase):
             param(
                 "success",
                 role_name="hvac",
-                allowed_redirect_uris=["https://localhost:8200/jwt-test/callback"],
+                allowed_redirect_uris=["{url}/jwt-test/callback"],
                 user_claim="https://vault/user",
             ),
         ]
     )
     def test_read_role(self, label, role_name, allowed_redirect_uris, user_claim):
+        allowed_redirect_uris = [uri.format(url=self.client.url) for uri in allowed_redirect_uris]
         create_role_response = self.client.auth.jwt.create_role(
             name=role_name,
             allowed_redirect_uris=allowed_redirect_uris,
@@ -153,12 +157,13 @@ class TestJWT(HvacIntegrationTestCase, TestCase):
             param(
                 "success",
                 role_name="hvac",
-                allowed_redirect_uris=["https://localhost:8200/jwt-test/callback"],
+                allowed_redirect_uris=["{url}/jwt-test/callback"],
                 user_claim="https://vault/user",
             ),
         ]
     )
     def test_list_roles(self, label, role_name, allowed_redirect_uris, user_claim):
+        allowed_redirect_uris = [uri.format(url=self.client.url) for uri in allowed_redirect_uris]
         create_role_response = self.client.auth.jwt.create_role(
             name=role_name,
             allowed_redirect_uris=allowed_redirect_uris,
@@ -181,12 +186,13 @@ class TestJWT(HvacIntegrationTestCase, TestCase):
             param(
                 "success",
                 role_name="hvac",
-                allowed_redirect_uris=["https://localhost:8200/jwt-test/callback"],
+                allowed_redirect_uris=["{url}/jwt-test/callback"],
                 user_claim="https://vault/user",
             ),
         ]
     )
     def test_delete_role(self, label, role_name, allowed_redirect_uris, user_claim):
+        allowed_redirect_uris = [uri.format(url=self.client.url) for uri in allowed_redirect_uris]
         create_role_response = self.client.auth.jwt.create_role(
             name=role_name,
             allowed_redirect_uris=allowed_redirect_uris,
@@ -209,16 +215,18 @@ class TestJWT(HvacIntegrationTestCase, TestCase):
         [
             param(
                 "success",
-                issuer="https://localhost:8200",
+                # issuer="https://localhost:8200",
                 role_name="hvac-jwt",
-                allowed_redirect_uris=["https://localhost:8200/jwt-test/oidc/callback"],
+                allowed_redirect_uris=["{url}/jwt-test/oidc/callback"],
                 user_claim="sub",
             ),
         ]
     )
     def test_jwt_login(
-        self, label, issuer, role_name, allowed_redirect_uris, user_claim
-    ):
+        self, label, role_name, allowed_redirect_uris, user_claim
+    ): # issuer
+        issuer = self.client.url
+        allowed_redirect_uris = [uri.format(url=self.client.url) for uri in allowed_redirect_uris]
         if "%s/" % self.TEST_APPROLE_PATH not in self.client.sys.list_auth_methods():
             self.client.sys.enable_auth_method(
                 method_type="approle",
@@ -253,10 +261,10 @@ class TestJWT(HvacIntegrationTestCase, TestCase):
         logging.debug("create_named_key response: %s" % create_named_key_response)
 
         self.client.secrets.identity.configure_tokens_backend(
-            issuer="https://localhost:8200",
+            issuer=issuer,
         )
         response = self.client.auth.jwt.configure(
-            jwks_url="https://localhost:8200/v1/identity/oidc/.well-known/keys",
+            jwks_url=f"{issuer}/v1/identity/oidc/.well-known/keys",
             jwks_ca_pem="".join(
                 open(utils.get_config_file_path("server-cert.pem")).readlines()
             ),

--- a/tests/integration_tests/api/auth_methods/test_jwt.py
+++ b/tests/integration_tests/api/auth_methods/test_jwt.py
@@ -41,7 +41,7 @@ class TestJWT(HvacIntegrationTestCase, TestCase):
             ),
         ]
     )
-    def test_configure(self, label): #, issuer):
+    def test_configure(self, label):  # , issuer):
         issuer = self.client.url
         oidc_discovery_url = f"{issuer}/v1/identity/oidc"
         self.client.secrets.identity.configure_tokens_backend(
@@ -68,7 +68,7 @@ class TestJWT(HvacIntegrationTestCase, TestCase):
             ),
         ]
     )
-    def test_read_config(self, label): #, issuer):
+    def test_read_config(self, label):  # , issuer):
         issuer = self.client.url
         oidc_discovery_url = f"{issuer}/v1/identity/oidc"
         self.client.secrets.identity.configure_tokens_backend(
@@ -102,7 +102,9 @@ class TestJWT(HvacIntegrationTestCase, TestCase):
         ]
     )
     def test_create_role(self, label, role_name, allowed_redirect_uris, user_claim):
-        allowed_redirect_uris = [uri.format(url=self.client.url) for uri in allowed_redirect_uris]
+        allowed_redirect_uris = [
+            uri.format(url=self.client.url) for uri in allowed_redirect_uris
+        ]
         response = self.client.auth.jwt.create_role(
             name=role_name,
             allowed_redirect_uris=allowed_redirect_uris,
@@ -133,7 +135,9 @@ class TestJWT(HvacIntegrationTestCase, TestCase):
         ]
     )
     def test_read_role(self, label, role_name, allowed_redirect_uris, user_claim):
-        allowed_redirect_uris = [uri.format(url=self.client.url) for uri in allowed_redirect_uris]
+        allowed_redirect_uris = [
+            uri.format(url=self.client.url) for uri in allowed_redirect_uris
+        ]
         create_role_response = self.client.auth.jwt.create_role(
             name=role_name,
             allowed_redirect_uris=allowed_redirect_uris,
@@ -163,7 +167,9 @@ class TestJWT(HvacIntegrationTestCase, TestCase):
         ]
     )
     def test_list_roles(self, label, role_name, allowed_redirect_uris, user_claim):
-        allowed_redirect_uris = [uri.format(url=self.client.url) for uri in allowed_redirect_uris]
+        allowed_redirect_uris = [
+            uri.format(url=self.client.url) for uri in allowed_redirect_uris
+        ]
         create_role_response = self.client.auth.jwt.create_role(
             name=role_name,
             allowed_redirect_uris=allowed_redirect_uris,
@@ -192,7 +198,9 @@ class TestJWT(HvacIntegrationTestCase, TestCase):
         ]
     )
     def test_delete_role(self, label, role_name, allowed_redirect_uris, user_claim):
-        allowed_redirect_uris = [uri.format(url=self.client.url) for uri in allowed_redirect_uris]
+        allowed_redirect_uris = [
+            uri.format(url=self.client.url) for uri in allowed_redirect_uris
+        ]
         create_role_response = self.client.auth.jwt.create_role(
             name=role_name,
             allowed_redirect_uris=allowed_redirect_uris,
@@ -224,9 +232,11 @@ class TestJWT(HvacIntegrationTestCase, TestCase):
     )
     def test_jwt_login(
         self, label, role_name, allowed_redirect_uris, user_claim
-    ): # issuer
+    ):  # issuer
         issuer = self.client.url
-        allowed_redirect_uris = [uri.format(url=self.client.url) for uri in allowed_redirect_uris]
+        allowed_redirect_uris = [
+            uri.format(url=self.client.url) for uri in allowed_redirect_uris
+        ]
         if "%s/" % self.TEST_APPROLE_PATH not in self.client.sys.list_auth_methods():
             self.client.sys.enable_auth_method(
                 method_type="approle",

--- a/tests/integration_tests/api/auth_methods/test_jwt.py
+++ b/tests/integration_tests/api/auth_methods/test_jwt.py
@@ -37,11 +37,10 @@ class TestJWT(HvacIntegrationTestCase, TestCase):
         [
             param(
                 "configure using vault identity OIDC",
-                # issuer="https://localhost:8200",
             ),
         ]
     )
-    def test_configure(self, label):  # , issuer):
+    def test_configure(self, label):
         issuer = self.client.url
         oidc_discovery_url = f"{issuer}/v1/identity/oidc"
         self.client.secrets.identity.configure_tokens_backend(
@@ -64,11 +63,10 @@ class TestJWT(HvacIntegrationTestCase, TestCase):
         [
             param(
                 "configure using vault identity OIDC",
-                # issuer="https://localhost:8200",
             ),
         ]
     )
-    def test_read_config(self, label):  # , issuer):
+    def test_read_config(self, label):
         issuer = self.client.url
         oidc_discovery_url = f"{issuer}/v1/identity/oidc"
         self.client.secrets.identity.configure_tokens_backend(
@@ -223,16 +221,13 @@ class TestJWT(HvacIntegrationTestCase, TestCase):
         [
             param(
                 "success",
-                # issuer="https://localhost:8200",
                 role_name="hvac-jwt",
                 allowed_redirect_uris=["{url}/jwt-test/oidc/callback"],
                 user_claim="sub",
             ),
         ]
     )
-    def test_jwt_login(
-        self, label, role_name, allowed_redirect_uris, user_claim
-    ):  # issuer
+    def test_jwt_login(self, label, role_name, allowed_redirect_uris, user_claim):
         issuer = self.client.url
         allowed_redirect_uris = [
             uri.format(url=self.client.url) for uri in allowed_redirect_uris

--- a/tests/integration_tests/api/auth_methods/test_oidc.py
+++ b/tests/integration_tests/api/auth_methods/test_oidc.py
@@ -41,11 +41,10 @@ class TestOIDC(HvacIntegrationTestCase, TestCase):
         [
             param(
                 "configure using vault identity OIDC",
-                # issuer="https://localhost:8200",
             ),
         ]
     )
-    def test_configure(self, label):  # , issuer):
+    def test_configure(self, label):
         issuer = self.client.url
         oidc_discovery_url = f"{issuer}/v1/identity/oidc"
         self.client.secrets.identity.configure_tokens_backend(
@@ -68,11 +67,10 @@ class TestOIDC(HvacIntegrationTestCase, TestCase):
         [
             param(
                 "configure using vault identity OIDC",
-                # issuer="https://localhost:8200",
             ),
         ]
     )
-    def test_read_config(self, label):  # , issuer):
+    def test_read_config(self, label):
         issuer = self.client.url
         oidc_discovery_url = f"{issuer}/v1/identity/oidc"
         self.client.secrets.identity.configure_tokens_backend(
@@ -191,7 +189,6 @@ class TestOIDC(HvacIntegrationTestCase, TestCase):
         [
             param(
                 "success",
-                # issuer="https://localhost:8200",
                 role_name="hvac",
                 allowed_redirect_uris=["{url}/oidc-test/callback"],
                 user_claim="https://vault/user",
@@ -200,7 +197,7 @@ class TestOIDC(HvacIntegrationTestCase, TestCase):
     )
     def test_oidc_authorization_url_request(
         self, label, role_name, allowed_redirect_uris, user_claim
-    ):  # issuer
+    ):
         issuer = self.client.url
         allowed_redirect_uris = [
             uri.format(url=self.client.url) for uri in allowed_redirect_uris

--- a/tests/integration_tests/api/auth_methods/test_oidc.py
+++ b/tests/integration_tests/api/auth_methods/test_oidc.py
@@ -41,11 +41,12 @@ class TestOIDC(HvacIntegrationTestCase, TestCase):
         [
             param(
                 "configure using vault identity OIDC",
-                issuer="https://localhost:8200",
+                # issuer="https://localhost:8200",
             ),
         ]
     )
-    def test_configure(self, label, issuer):
+    def test_configure(self, label): #, issuer):
+        issuer = self.client.url
         oidc_discovery_url = f"{issuer}/v1/identity/oidc"
         self.client.secrets.identity.configure_tokens_backend(
             issuer=issuer,
@@ -67,11 +68,12 @@ class TestOIDC(HvacIntegrationTestCase, TestCase):
         [
             param(
                 "configure using vault identity OIDC",
-                issuer="https://localhost:8200",
+                # issuer="https://localhost:8200",
             ),
         ]
     )
-    def test_read_config(self, label, issuer):
+    def test_read_config(self, label): #, issuer):
+        issuer = self.client.url
         oidc_discovery_url = f"{issuer}/v1/identity/oidc"
         self.client.secrets.identity.configure_tokens_backend(
             issuer=issuer,
@@ -98,12 +100,13 @@ class TestOIDC(HvacIntegrationTestCase, TestCase):
             param(
                 "success",
                 role_name="hvac",
-                allowed_redirect_uris=["https://localhost:8200/oidc-test/callback"],
+                allowed_redirect_uris=["{url}/oidc-test/callback"],
                 user_claim="https://vault/user",
             ),
         ]
     )
     def test_read_role(self, label, role_name, allowed_redirect_uris, user_claim):
+        allowed_redirect_uris = [uri.format(url=self.client.url) for uri in allowed_redirect_uris]
         create_role_response = self.client.auth.oidc.create_role(
             name=role_name,
             allowed_redirect_uris=allowed_redirect_uris,
@@ -126,12 +129,13 @@ class TestOIDC(HvacIntegrationTestCase, TestCase):
             param(
                 "success",
                 role_name="hvac",
-                allowed_redirect_uris=["https://localhost:8200/oidc-test/callback"],
+                allowed_redirect_uris=["{url}/oidc-test/callback"],
                 user_claim="https://vault/user",
             ),
         ]
     )
     def test_list_roles(self, label, role_name, allowed_redirect_uris, user_claim):
+        allowed_redirect_uris = [uri.format(url=self.client.url) for uri in allowed_redirect_uris]
         create_role_response = self.client.auth.oidc.create_role(
             name=role_name,
             allowed_redirect_uris=allowed_redirect_uris,
@@ -153,12 +157,13 @@ class TestOIDC(HvacIntegrationTestCase, TestCase):
             param(
                 "success",
                 role_name="hvac",
-                allowed_redirect_uris=["https://localhost:8200/oidc-test/callback"],
+                allowed_redirect_uris=["{url}/oidc-test/callback"],
                 user_claim="https://vault/user",
             ),
         ]
     )
     def test_delete_role(self, label, role_name, allowed_redirect_uris, user_claim):
+        allowed_redirect_uris = [uri.format(url=self.client.url) for uri in allowed_redirect_uris]
         create_role_response = self.client.auth.oidc.create_role(
             name=role_name,
             allowed_redirect_uris=allowed_redirect_uris,
@@ -180,16 +185,18 @@ class TestOIDC(HvacIntegrationTestCase, TestCase):
         [
             param(
                 "success",
-                issuer="https://localhost:8200",
+                # issuer="https://localhost:8200",
                 role_name="hvac",
-                allowed_redirect_uris=["https://localhost:8200/oidc-test/callback"],
+                allowed_redirect_uris=["{url}/oidc-test/callback"],
                 user_claim="https://vault/user",
             ),
         ]
     )
     def test_oidc_authorization_url_request(
-        self, label, issuer, role_name, allowed_redirect_uris, user_claim
-    ):
+        self, label, role_name, allowed_redirect_uris, user_claim
+    ): # issuer
+        issuer = self.client.url
+        allowed_redirect_uris = [uri.format(url=self.client.url) for uri in allowed_redirect_uris]
         if "%s/" % self.TEST_APPROLE_PATH not in self.client.sys.list_auth_methods():
             self.client.sys.enable_auth_method(
                 method_type="approle",
@@ -269,13 +276,14 @@ class TestOIDC(HvacIntegrationTestCase, TestCase):
                 "success",
                 role_name="hvac-oidc",
                 allowed_redirect_uris=[
-                    "https://localhost:8200/v1/auth/oidc-test/oidc/callback"
+                    "{url}/v1/auth/oidc-test/oidc/callback"
                 ],
                 user_claim="sub",
             ),
         ]
     )
     def test_oidc_callback(self, label, role_name, allowed_redirect_uris, user_claim):
+        allowed_redirect_uris = [uri.format(url=self.client.url) for uri in allowed_redirect_uris]
         self.oidc_server = MockOauthProviderServerThread()
         self.oidc_server.start()
         oidc_details = create_user_session_and_client(

--- a/tests/integration_tests/api/auth_methods/test_oidc.py
+++ b/tests/integration_tests/api/auth_methods/test_oidc.py
@@ -45,7 +45,7 @@ class TestOIDC(HvacIntegrationTestCase, TestCase):
             ),
         ]
     )
-    def test_configure(self, label): #, issuer):
+    def test_configure(self, label):  # , issuer):
         issuer = self.client.url
         oidc_discovery_url = f"{issuer}/v1/identity/oidc"
         self.client.secrets.identity.configure_tokens_backend(
@@ -72,7 +72,7 @@ class TestOIDC(HvacIntegrationTestCase, TestCase):
             ),
         ]
     )
-    def test_read_config(self, label): #, issuer):
+    def test_read_config(self, label):  # , issuer):
         issuer = self.client.url
         oidc_discovery_url = f"{issuer}/v1/identity/oidc"
         self.client.secrets.identity.configure_tokens_backend(
@@ -106,7 +106,9 @@ class TestOIDC(HvacIntegrationTestCase, TestCase):
         ]
     )
     def test_read_role(self, label, role_name, allowed_redirect_uris, user_claim):
-        allowed_redirect_uris = [uri.format(url=self.client.url) for uri in allowed_redirect_uris]
+        allowed_redirect_uris = [
+            uri.format(url=self.client.url) for uri in allowed_redirect_uris
+        ]
         create_role_response = self.client.auth.oidc.create_role(
             name=role_name,
             allowed_redirect_uris=allowed_redirect_uris,
@@ -135,7 +137,9 @@ class TestOIDC(HvacIntegrationTestCase, TestCase):
         ]
     )
     def test_list_roles(self, label, role_name, allowed_redirect_uris, user_claim):
-        allowed_redirect_uris = [uri.format(url=self.client.url) for uri in allowed_redirect_uris]
+        allowed_redirect_uris = [
+            uri.format(url=self.client.url) for uri in allowed_redirect_uris
+        ]
         create_role_response = self.client.auth.oidc.create_role(
             name=role_name,
             allowed_redirect_uris=allowed_redirect_uris,
@@ -163,7 +167,9 @@ class TestOIDC(HvacIntegrationTestCase, TestCase):
         ]
     )
     def test_delete_role(self, label, role_name, allowed_redirect_uris, user_claim):
-        allowed_redirect_uris = [uri.format(url=self.client.url) for uri in allowed_redirect_uris]
+        allowed_redirect_uris = [
+            uri.format(url=self.client.url) for uri in allowed_redirect_uris
+        ]
         create_role_response = self.client.auth.oidc.create_role(
             name=role_name,
             allowed_redirect_uris=allowed_redirect_uris,
@@ -194,9 +200,11 @@ class TestOIDC(HvacIntegrationTestCase, TestCase):
     )
     def test_oidc_authorization_url_request(
         self, label, role_name, allowed_redirect_uris, user_claim
-    ): # issuer
+    ):  # issuer
         issuer = self.client.url
-        allowed_redirect_uris = [uri.format(url=self.client.url) for uri in allowed_redirect_uris]
+        allowed_redirect_uris = [
+            uri.format(url=self.client.url) for uri in allowed_redirect_uris
+        ]
         if "%s/" % self.TEST_APPROLE_PATH not in self.client.sys.list_auth_methods():
             self.client.sys.enable_auth_method(
                 method_type="approle",
@@ -275,15 +283,15 @@ class TestOIDC(HvacIntegrationTestCase, TestCase):
             param(
                 "success",
                 role_name="hvac-oidc",
-                allowed_redirect_uris=[
-                    "{url}/v1/auth/oidc-test/oidc/callback"
-                ],
+                allowed_redirect_uris=["{url}/v1/auth/oidc-test/oidc/callback"],
                 user_claim="sub",
             ),
         ]
     )
     def test_oidc_callback(self, label, role_name, allowed_redirect_uris, user_claim):
-        allowed_redirect_uris = [uri.format(url=self.client.url) for uri in allowed_redirect_uris]
+        allowed_redirect_uris = [
+            uri.format(url=self.client.url) for uri in allowed_redirect_uris
+        ]
         self.oidc_server = MockOauthProviderServerThread()
         self.oidc_server.start()
         oidc_details = create_user_session_and_client(

--- a/tests/integration_tests/api/secrets_engines/test_pki.py
+++ b/tests/integration_tests/api/secrets_engines/test_pki.py
@@ -774,9 +774,9 @@ class TestPki(HvacIntegrationTestCase, TestCase):
             mount_point=self.TEST_MOUNT_POINT,
         )
 
-        self.assertEqual(
-            first=pki_update_response["data"]["usage"],
-            second=pki_read_response["data"]["usage"],
+        self.assertCountEqual(
+            first=pki_update_response["data"]["usage"].split(","),
+            second=pki_read_response["data"]["usage"].split(","),
         )
 
     # Revoke issuer

--- a/tests/integration_tests/api/system_backend/test_key.py
+++ b/tests/integration_tests/api/system_backend/test_key.py
@@ -31,6 +31,7 @@ class TestKey(HvacIntegrationTestCase, TestCase):
         new_root_token = utils.decode_generated_root_token(
             encoded_token=last_generate_root_response["encoded_root_token"],
             otp=test_otp,
+            url=self.client.url,
         )
         logging.debug("new_root_token: %s" % new_root_token)
         token_lookup_resp = self.client.lookup_token(token=new_root_token)

--- a/tests/integration_tests/v1/test_integration.py
+++ b/tests/integration_tests/v1/test_integration.py
@@ -152,22 +152,22 @@ class IntegrationTest(HvacIntegrationTestCase, TestCase):
         self.client.delete("secret/foo")
 
     def test_missing_token(self):
-        client = utils.create_client()
+        client = utils.create_client(url=self.client.url)
         assert not client.is_authenticated()
 
     def test_invalid_token(self):
-        client = utils.create_client(token="not-a-real-token")
+        client = utils.create_client(url=self.client.url, token="not-a-real-token")
         assert not client.is_authenticated()
 
     def test_illegal_token(self):
-        client = utils.create_client(token="token-with-new-line\n")
+        client = utils.create_client(url=self.client.url, token="token-with-new-line\n")
         try:
             client.is_authenticated()
         except ValueError as e:
             assert "Invalid header value" in str(e)
 
     def test_broken_token(self):
-        client = utils.create_client(token="\x1b")
+        client = utils.create_client(url=self.client.url, token="\x1b")
         try:
             client.is_authenticated()
         except exceptions.InvalidRequest as e:

--- a/tests/integration_tests/v1/test_system_backend.py
+++ b/tests/integration_tests/v1/test_system_backend.py
@@ -327,6 +327,7 @@ class TestSystemBackend(HvacIntegrationTestCase, TestCase):
         new_root_token = utils.decode_generated_root_token(
             encoded_token=last_generate_root_response["encoded_root_token"],
             otp=test_otp,
+            url=self.client.url,
         )
         logging.debug("new_root_token: %s" % new_root_token)
         token_lookup_resp = self.client.auth.token.lookup(token=new_root_token)

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -123,7 +123,11 @@ class PortGetter:
 
     class PortGetterProtocol(t.Protocol):
         def __call__(
-            self, *, address: t.Optional[str] = None, port: t.Optional[int] = None
+            self,
+            *,
+            address: t.Optional[str] = None,
+            port: t.Optional[int] = None,
+            proto: socket.SocketKind = socket.SOCK_STREAM,
         ) -> int:
             pass
 

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -128,7 +128,7 @@ class PortGetter:
             address: t.Optional[str] = None,
             port: t.Optional[int] = None,
             proto: socket.SocketKind = socket.SOCK_STREAM,
-        ) -> int:
+        ) -> t.Tuple[str, int]:
             pass
 
     def get_port(

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -123,10 +123,18 @@ class PortGetter:
         self._default_addr = default_address
 
     class PortGetterProtocol(t.Protocol):
-        def __call__(self, *, address: t.Optional[str] = None, port: t.Optional[int] = None) -> int:
+        def __call__(
+            self, *, address: t.Optional[str] = None, port: t.Optional[int] = None
+        ) -> int:
             pass
 
-    def get_port(self, *, address: t.Optional[str] = None, port: t.Optional[int] = None, proto: socket.SocketKind = socket.SOCK_STREAM) -> t.Tuple[str, int]:
+    def get_port(
+        self,
+        *,
+        address: t.Optional[str] = None,
+        port: t.Optional[int] = None,
+        proto: socket.SocketKind = socket.SOCK_STREAM,
+    ) -> t.Tuple[str, int]:
         if not self._entered:
             raise RuntimeError("Enter the context manager before calling get_port.")
 
@@ -148,16 +156,18 @@ class PortGetter:
 
     def __enter__(self):
         if self._entered:
-            raise RuntimeError("This context manager can only be entered once at a time. Exit first or use a new instance.")
+            raise RuntimeError(
+                "This context manager can only be entered once at a time. Exit first or use a new instance."
+            )
         self._entered = True
         self._sockets.clear()
         return self
 
     def __exit__(self, exc_type, exc_value, exc_tb):
-        for socket in self._sockets:
+        for sock in self._sockets:
             try:
-                socket.close()
-            except:
+                sock.close()
+            except Exception:
                 pass
         self._sockets.clear()
         self._entered = False

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -80,7 +80,6 @@ def get_generate_root_otp():
     return test_otp
 
 
-# ="https://localhost:8200"
 def create_client(url, use_env=False, **kwargs):
     """Small helper to instantiate a :py:class:`hvac.v1.Client` class with the appropriate parameters for the test env.
 
@@ -174,6 +173,7 @@ class PortGetter:
 
 
 def get_free_port():
+    # TODO: deprecated: remove in favor of port getter class once LDAP mock is refactored
     """Small helper method used to discover an open port to use by mock API HTTP servers.
 
     :return: An available port number.
@@ -203,7 +203,7 @@ def load_config_file(filename):
 def get_config_file_path(*components):
     """Get the path to a config file under the "tests/config_files" directory.
 
-     I.e., the directory containing self-signed certificates, configuration files, etc. that are used for various tests.
+    I.e., the directory containing self-signed certificates, configuration files, etc. that are used for various tests.
 
     :param components: One or more path components, the last of which is usually the name of the test data file.
     :type components: str | unicode
@@ -238,7 +238,6 @@ def decode_generated_root_token(encoded_token, otp, url):
             "generate-root",
             "-address",
             url,
-            # "https://127.0.0.1:8200",
             "-tls-skip-verify",
             "-decode",
             encoded_token,

--- a/tests/utils/hvac_integration_test_case.py
+++ b/tests/utils/hvac_integration_test_case.py
@@ -41,7 +41,6 @@ class HvacIntegrationTestCase:
             ]
         cls.manager = ServerManager(
             config_paths=config_paths,
-            # client=create_client(),
             use_consul=cls.enable_vault_ha,
         )
         while True:
@@ -70,7 +69,6 @@ class HvacIntegrationTestCase:
 
     def setUp(self):
         """Set the client attribute to an authenticated hvac Client instance."""
-        # self.client = create_client(token=self.manager.root_token, use_env=self.use_env)
         self.client = self.manager.client
 
     def tearDown(self):

--- a/tests/utils/hvac_integration_test_case.py
+++ b/tests/utils/hvac_integration_test_case.py
@@ -8,6 +8,7 @@ from tests.utils.server_manager import ServerManager
 import distutils.spawn
 from hvac import Client
 
+
 class HvacIntegrationTestCase:
     """Base class intended to be used by all hvac integration test cases."""
 
@@ -50,7 +51,9 @@ class HvacIntegrationTestCase:
                 cls.manager.unseal()
             except Exception as e:
                 cls.manager.stop()
-                logging.debug(f"Failure in ServerManager (retries remaining: {cls.server_retry_count})\n{str(e)}")
+                logging.debug(
+                    f"Failure in ServerManager (retries remaining: {cls.server_retry_count})\n{str(e)}"
+                )
                 if cls.server_retry_count > 0:
                     cls.server_retry_count -= 1
                     time.sleep(cls.server_retry_delay_seconds)

--- a/tests/utils/hvac_integration_test_case.py
+++ b/tests/utils/hvac_integration_test_case.py
@@ -37,7 +37,7 @@ class HvacIntegrationTestCase:
             ]
         cls.manager = ServerManager(
             config_paths=config_paths,
-            client=create_client(),
+            # client=create_client(),
             use_consul=cls.enable_vault_ha,
         )
         try:
@@ -56,7 +56,8 @@ class HvacIntegrationTestCase:
 
     def setUp(self):
         """Set the client attribute to an authenticated hvac Client instance."""
-        self.client = create_client(token=self.manager.root_token, use_env=self.use_env)
+        # self.client = create_client(token=self.manager.root_token, use_env=self.use_env)
+        self.client = self.manager.client
 
     def tearDown(self):
         """Ensure the hvac Client instance's root token is reset after any auth method tests that may have modified it.

--- a/tests/utils/server_manager.py
+++ b/tests/utils/server_manager.py
@@ -5,18 +5,34 @@ import subprocess
 import time
 import requests
 import hcl
+import typing as t
 
 import distutils.spawn
 from unittest import SkipTest
-from tests.utils import get_config_file_path, load_config_file, create_client
+from tests.utils import get_config_file_path, load_config_file, create_client, PortGetter
 
 logger = logging.getLogger(__name__)
+
+
+class TestProcessInfo:
+    name: str
+    process: subprocess.Popen
+    extra: t.List[str]
+
+    def __init__(self, name: str, process: subprocess.Popen, *extra: t.List[str]) -> None:
+        self.name = name
+        self.process = process
+        self.extra = extra
+
+    def log_name(self, index: int, *suffixes: t.List[str], ext: str = ".log"):
+        segmented = "_".join([self.name, str(index), *self.extra, *suffixes])
+        return f"{segmented}{ext}"
 
 
 class ServerManager:
     """Runs vault process running with test configuration and associates a hvac Client instance with this process."""
 
-    def __init__(self, config_paths, client, use_consul=False):
+    def __init__(self, config_paths, client=None, use_consul=False):
         """Set up class attributes for managing a vault server process.
 
         :param config_paths: Full path to the Vault config to use when launching `vault server`.
@@ -24,6 +40,8 @@ class ServerManager:
         :param client: Hvac Client that is used to initialize the vault server process.
         :type client: hvac.v1.Client
         """
+
+        self.active_config_paths = None
         self.config_paths = config_paths
         self.client = client
         self.use_consul = use_consul
@@ -31,33 +49,91 @@ class ServerManager:
         self.keys = None
         self.root_token = None
 
-        self._processes = []
+        self._processes: t.List[TestProcessInfo] = []
+
+    def patch_config_port(self, config_file: str, *, port_getter: PortGetter.PortGetterProtocol, insert: bool = False, address: str = None, additional_sections: t.Optional[t.Dict[str, t.Any]] = None, output_dir: str = "generated"):
+        worker = os.getenv("PYTEST_XDIST_WORKER", "solo")
+        config_parent = os.path.dirname(config_file)
+        if not os.path.isabs(output_dir):
+            output_dir = os.path.join(config_parent, output_dir)
+        output_file = os.path.join(output_dir, os.path.basename(config_file).replace(".hcl", f"_{worker}.json"))
+
+        with open(config_file, "r") as f:
+            config: dict = hcl.load(f)
+
+        if "listener" in config:
+            listeners = config["listener"]
+            if not isinstance(listeners, list):
+                listeners = [listeners]
+            for linstances in listeners:
+                if "tcp" in linstances:
+                    listener = linstances["tcp"]
+                    if "address" in listener:
+                        addr, port = listener["address"].split(":")
+                        if address is not None:
+                            addr = address
+                        addr, port = port_getter(address=addr, port=int(port))
+                        listener["address"] = ":".join((addr, str(port)))
+                    elif insert:
+                        addr, port = port_getter(address=address)
+                        listener["address"] = ":".join((addr, str(port)))
+
+        if additional_sections is not None:
+            config.update(additional_sections)
+
+        with open(output_file, "w") as f:
+            hcl.api.json.dump(config, f, indent=4)
+
+        return output_file
 
     def start(self):
-        """Launch the vault server process and wait until its online and ready."""
+        # with TCPPortGetter() as g:
+        consul_config = None
         if self.use_consul:
-            self.start_consul()
+            consul_addr = self.start_consul()
+            consul_config = {
+                "storage": {
+                    "consul": {
+                        "address": consul_addr,
+                        "path": "vault_whatever/",
+                    }
+                }
+            }
+        self.start_vault(consul_config=consul_config)
 
+    def start_vault(self, *, consul_config: dict = None, attempt=1, max_attempts=3, delay_s=1): # port_getter: TCPPortGetter.PortGetterProtocol
+        """Launch the vault server process and wait until its online and ready."""
         if distutils.spawn.find_executable("vault") is None:
             raise SkipTest("Vault executable not found")
 
-        # If a vault server is already running then we won't be able to start another one.
-        # If we can't start our vault server then we don't know what we're testing against.
-        try:
-            self.client.sys.is_initialized()
-        except Exception:
-            pass
-        else:
-            raise Exception("Vault server already running")
+        with PortGetter() as g:
+            self.active_config_paths = [
+                self.patch_config_port(config_path, port_getter=g.get_port, insert=True, additional_sections=consul_config)
+                for config_path in self.config_paths
+            ]
 
         cluster_ready = False
-        for config_path in self.config_paths:
+        for config_path in self.active_config_paths:
+            this_addr = self.get_config_vault_address(config_path)
+            this_client = create_client(url=this_addr)
+            if self.client is None:
+                self.client = this_client
+
+            # If a vault server is already running then we won't be able to start another one.
+            # If we can't start our vault server then we don't know what we're testing against.
+            # try:
+            #     this_client.sys.is_initialized()
+            # except Exception:
+            #     pass
+            # else:
+            #     raise Exception("Vault server already running")
+
             command = ["vault", "server", "-config=" + config_path]
             logger.debug(f"Starting vault server with command: {command}")
             process = subprocess.Popen(
                 command, stdout=subprocess.PIPE, stderr=subprocess.PIPE
             )
-            self._processes.append(process)
+            self._processes.append(TestProcessInfo("vault", process, os.path.basename(config_path)))
             logger.debug(f"Spawned vault server with PID {process.pid}")
 
             attempts_left = 20
@@ -65,12 +141,19 @@ class ServerManager:
             while attempts_left > 0 and not cluster_ready:
                 try:
                     logger.debug("Checking if vault is ready...")
-                    self.client.sys.is_initialized()
+                    this_client.sys.is_initialized()
                     cluster_ready = True
                     break
                 except Exception as ex:
                     if process.poll() is not None:
-                        raise Exception("Vault server terminated before becoming ready")
+                        # stdout, stderr = process.communicate()
+                        stdout, stderr = process.stdout, process.stderr
+                        if attempt < max_attempts:
+                            logger.debug(f"Starting Vault failed (attempt {attempt} of {max_attempts}):\n{last_exception}\n{stdout}\n{stderr}")
+                            time.sleep(delay_s)
+                            self.start_vault(attempt=(attempt+1), max_attempts=max_attempts, delay_s=delay_s)
+                        else:
+                            raise Exception("Vault server terminated before becoming ready")
                     logger.debug("Waiting for Vault to start")
                     time.sleep(0.5)
                     attempts_left -= 1
@@ -79,55 +162,82 @@ class ServerManager:
                 if process.poll() is None:
                     process.kill()
                 stdout, stderr = process.communicate()
-                raise Exception(
-                    "Unable to start Vault in background:\n{err}\n{stdout}\n{stderr}".format(
-                        err=last_exception,
-                        stdout=stdout,
-                        stderr=stderr,
+                if attempt < max_attempts:
+                    logger.debug(f"Vault never became ready (attempt {attempt} of {max_attempts}):\n{last_exception}\n{stdout}\n{stderr}")
+                    time.sleep(delay_s)
+                    self.start_vault(attempt=(attempt+1), max_attempts=max_attempts, delay_s=delay_s)
+                else:
+                    raise Exception(
+                        "Unable to start Vault in background:\n{err}\n{stdout}\n{stderr}".format(
+                            err=last_exception,
+                            stdout=stdout,
+                            stderr=stderr,
+                        )
                     )
-                )
 
-    def start_consul(self):
+    def start_consul(self) -> str: #, *, port_getter: TCPPortGetter.PortGetterProtocol):
         if distutils.spawn.find_executable("consul") is None:
             raise SkipTest("Consul executable not found")
 
-        try:
-            requests.get("http://127.0.0.1:8500/v1/catalog/nodes")
-        except Exception:
-            pass
-        else:
-            raise Exception("Consul service already running")
+        # try:
+        #     requests.get("http://127.0.0.1:8500/v1/catalog/nodes")
+        # except Exception:
+        #     pass
+        # else:
+        #     raise Exception("Consul service already running")
 
-        command = ["consul", "agent", "-dev"]
+        with PortGetter() as g:
+            http_addr, http_port = g.get_port()
+            _, server_port = g.get_port(address=http_addr)
+            _, serf_lan_port = g.get_port(address=http_addr)
+            _, serf_wan_port = g.get_port(address=http_addr)
+            consul_addr = f"{http_addr}:{http_port}"
+            command = [
+                "consul",
+                "agent",
+                "-dev",
+                "-disable-host-node-id",
+                f"-serf-lan-port={serf_lan_port}",
+                f"-serf-wan-port={serf_wan_port}",
+                f"-server-port={server_port}",
+                "-grpc-port=-1",
+                "-grpc-tls-port=-1",
+                # "-hcl=tls { grpc { use_auto_cert = false } }",
+                # "-hcl=ports { grpc_tls = -1 }",
+                f"-bind={http_addr}",
+                f"-http-port={http_port}",
+                "-dns-port=-1"
+            ]
+
         logger.debug(f"Starting consul service with command: {command}")
         process = subprocess.Popen(
             command, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
-        self._processes.append(process)
+        self._processes.append(TestProcessInfo("consul", process, os.getenv("PYTEST_XDIST_WORKER", "solo")))
         attempts_left = 20
         last_exception = None
         while attempts_left > 0:
             try:
                 catalog_nodes_response = requests.get(
-                    "http://127.0.0.1:8500/v1/catalog/nodes"
+                    f"http://{consul_addr}/v1/catalog/nodes"
                 )
                 nodes_list = catalog_nodes_response.json()
                 logger.debug(
-                    "JSON response from request to consul/v1/catalog/noses: {resp}".format(
+                    "JSON response from request to consul/v1/catalog/nodes: {resp}".format(
                         resp=nodes_list
                     )
                 )
                 node_name = nodes_list[0]["Node"]
                 logger.debug(f"Current consul node name: {node_name}")
                 node_health_response = requests.get(
-                    f"http://127.0.0.1:8500/v1/health/node/{node_name}"
+                    f"http://{consul_addr}/v1/health/node/{node_name}"
                 )
                 node_health = node_health_response.json()
                 logger.debug(f"Node health response: {node_health}")
                 assert (
                     node_health[0]["Status"] == "passing"
                 ), f'Node {node_name} status != "passing"'
-                return True
+                return consul_addr
             except Exception as error:
                 if process.poll() is not None:
                     raise Exception("Consul service terminated before becoming ready")
@@ -144,28 +254,45 @@ class ServerManager:
 
     def stop(self):
         """Stop the vault server process being managed by this class."""
-        for process_num, process in enumerate(self._processes):
-            logger.debug(f"Terminating vault server with PID {process.pid}")
-            if process.poll() is None:
-                process.kill()
+        self.client = None
+        for process_num, pinfo in reversed(list(enumerate(self._processes))):
+            logger.debug(f"Terminating {pinfo.name} server with PID {pinfo.process.pid}")
+            if pinfo.process.poll() is None:
+                pinfo.process.kill()
+
             if os.getenv("HVAC_OUTPUT_VAULT_STDERR", False):
-                stdout_lines, stderr_lines = process.communicate()
-                stderr_filename = f"vault{process_num}_stderr.log"
-                with open(get_config_file_path(stderr_filename), "w") as f:
-                    logger.debug(stderr_lines.decode())
-                    f.writelines(stderr_lines.decode())
-                stdout_filename = f"vault{process_num}_stdout.log"
-                with open(get_config_file_path(stdout_filename), "w") as f:
-                    logger.debug(stdout_lines.decode())
-                    f.writelines(stdout_lines.decode())
+                try:
+                    stdout_lines, stderr_lines = pinfo.process.communicate()
+                except ValueError:
+                    pass
+                else:
+                    log_dir = get_config_file_path("generated", "logs")
+                    try:
+                        os.mkdir(log_dir)
+                    except FileExistsError:
+                        pass
+                    # stderr_filename = f"vault{process_num}_stderr.log"
+                    stderr_filename = pinfo.log_name(process_num, "stderr")
+                    stderr_path = get_config_file_path(log_dir, stderr_filename)
+                    with open(stderr_path, "w") as f:
+                        logger.debug(stderr_lines.decode())
+                        f.writelines(stderr_lines.decode())
+                    # stdout_filename = f"vault{process_num}_stdout.log"
+                    stdout_filename = pinfo.log_name(process_num, "stdout")
+                    stdout_path = get_config_file_path(log_dir, stdout_filename)
+                    with open(get_config_file_path(stdout_path), "w") as f:
+                        logger.debug(stdout_lines.decode())
+                        f.writelines(stdout_lines.decode())
 
     def initialize(self):
         """Perform initialization of the vault server process and record the provided unseal keys and root token."""
-        assert not self.client.sys.is_initialized()
+        # assert not self.client.sys.is_initialized()
+        if self.client.sys.is_initialized():
+            raise RuntimeError(f"Vault is already initialized: {self.get_active_vault_addresses()}")
 
-        result = self.client.sys.initialize()
+        result = self.client.sys.initialize(secret_shares=5, secret_threshold=3)
 
-        self.root_token = result["root_token"]
+        self.root_token = self.client.token = result["root_token"]
         self.keys = result["keys"]
 
     def restart_vault_cluster(self, perform_init=True):
@@ -174,29 +301,36 @@ class ServerManager:
         if perform_init:
             self.initialize()
 
+    def get_config_vault_address(self, config_path: str) -> str:
+        config_hcl = load_config_file(config_path)
+        config = hcl.loads(config_hcl)
+        try:
+            vault_address = "https://{addr}".format(
+                addr=config["listener"]["tcp"]["address"]
+            )
+        except KeyError as error:
+            logger.debug(
+                "Unable to find explicit Vault address in config file {path}: {err}".format(
+                    path=config_path,
+                    err=error,
+                )
+            )
+            vault_address = "https://127.0.0.1:8200"
+            logger.debug(f"Using default address: {vault_address}")
+        return vault_address
+
     def get_active_vault_addresses(self):
         vault_addresses = []
-        for config_path in self.config_paths:
-            config_hcl = load_config_file(config_path)
-            config = hcl.loads(config_hcl)
-            try:
-                vault_address = "https://{addr}".format(
-                    addr=config["listener"]["tcp"]["address"]
-                )
-            except KeyError as error:
-                logger.debug(
-                    "Unable to find explicit Vault address in config file {path}: {err}".format(
-                        path=config_path,
-                        err=error,
-                    )
-                )
-                vault_address = "https://127.0.0.1:8200"
-                logger.debug(f"Using default address: {vault_address}")
-            vault_addresses.append(vault_address)
+        config_paths = self.active_config_paths if self.active_config_paths is not None else self.config_paths
+        for config_path in config_paths:
+            vault_addresses.append(self.get_config_vault_address(config_path))
         return vault_addresses
 
     def unseal(self):
         """Unseal the vault server process."""
+        assert self.client.sys.is_initialized()
         vault_addresses = self.get_active_vault_addresses()
         for vault_address in vault_addresses:
-            create_client(url=vault_address).sys.submit_unseal_keys(self.keys)
+            client = create_client(url=vault_address)
+            assert client.sys.is_initialized(), f"'{client.url}' == '{self.client.url}'"
+            client.sys.submit_unseal_keys(self.keys)


### PR DESCRIPTION
I started looking at improving the performance of tests, especially integration tests. Since they run serially and have to spin up Vault and/or Consul, they tend to take a while to run.

On my local machine, they take a little over **1 minute** to run, in CI more like **1m40s** or so. Not bad, but when you're iterating locally it can be a slog, and in CI we'd like to add more platforms to test against, and possibly more python versions for integration, so speedier test times will add up.
(unit tests were already very fast, ~3s on my machine, ~10s or less in CI)

[`pytest-xdist`](https://pypi.org/project/pytest-xdist/) seemed like a good choice for parallelizing the tests and taking advantage of multiple cores.

The challenges came with the Vault and Consul servers that needed to be started up, and assumptions made in the tests themselves: the way everything was written hardcoded TCP port numbers and IP addresses, and assumed that if a server existed on those addresses already that it was an error state.

So this PR makes a whole lot of changes to that process, so that we can start multiple Vault and Consul servers simultaneously without them stepping on each other.

For this, the configuration files for each of them are now patched and generated at test run time, with the help of a new class that works as a context manager to find free port numbers. 

The context manager usage helps in the case of launching a Vault cluster where we need to launch two instances of Vault and one instance of Consul, all with ports that don't conflict with each other, and we need to know those ports before they start so we can write configs before those servers actually use the ports.

This also means that tests that assume vault is always available on `127.0.0.1:8200` needed to be updated to dynamically use the Vault server launched for that test, and this required changes in the server manager class and the test case class to ensure that all the right things got to the right places.

The result: integration tests take **~16s** on my 6-core machine with 12 test workers.
In CI **~30s**

It's worth noting that GitHub's Ubuntu runners are supposed to have 2 vCPUs. Since xdist is configured by default to auto-detect the number of CPUs or hyperthreads, and set the worker count to that, I noticed that some test runs were choosing 2, and some were choosing 4.

I have not been able to find official word, but it seems like GitHub is slowly increasing the number of vCPUs on its runners (perhaps also the performance per vCPU, but that is harder for me to tell). Some independent research led me to find evidence that Ubuntu and Windows runners are going from 2 -> 4 vCPUs, and MacOS runners are going from 3 -> 4 vCPUs.

This GitHub action which shows the number of cores available runs itself in its own CI once a week, and you can look at the history of runs to see some evidence: https://github.com/SimenB/github-actions-cpu-cores/actions

Anyway all the above means is that this is a great time parallelize the tests, because we get even more gain from that change!

Unit tests are also set to use xdist now, but the times on both my local machine and in CI are roughly the same, because they were already so fast and any parallelized time savings are eaten up by the fixed overhead of setting up the workers and distributing test load, but if we use unit tests more, we'll see benefit in the future.

---

## Other changes:
- https://github.com/hvac/hvac/pull/1105/commits/2a6a90e4c5e43c090c80f4aec18481a929ba3c16 -- we've started to see test failures for one of the PKI tests because apparently a field returned by Vault that's a comma-separated string of values does not have guaranteed order, and the order returned by Vault suddenly changed.
- Although all of our integration tests do run in CI, every individual run skips some tests or another, and we didn't have good visibility into that so I've changed the CI invocation to show exactly which tests are skipped.
- Generally add more retries and reporting when launching processes. With tests running in parallel, there is still a small chance of port conflicts since test workers don't talk to each other and don't synchronize, so the retries should handle those rare cases.

---

## Other notes

- I originally started out seeing if we could replace use of local binaries with containers instead, using docker compose. It was interesting and we might pursue it later but due to how much was already built-in to use binaries and to assume open communication between the launched processes, I decided to put that aside and build on what's here.
- Doctests (the thing that runs code examples in the documentation) are still slow, and single-threaded. 
  - First of all, they don't run in pytest, they run in the sphinx doctest plugin, but it does still use the server manager component for launching instances that we use in the integration tests.
  - I spent a lot of time trying to get the doctests to even use the dynamic port stuff I put in place (without parallelization) and it kept running into weird conflicts, despite the fact that it was dynamically choosing ports and launching processes. I could not figure out why.
  - I also spent time trying to get our doctests running in pytest. It already supports running doctest tests, including in RST files, but the sphinx doctest plugin has a number of differences that make our tests incompatible.
  - I did take some steps to try to convert them and make _that_ work but it would have meant rewriting almost all of our examples (even to work without dynamic ports, and without parallelization) so I also put that aside. 
  - We also use some kind of vendored/hacked version of doctest which could further complicate it.
  - Instead, that work of moving doctests to pytest could possibly go hand-in-hand with other docs modernization things:
  - https://github.com/hvac/hvac/issues/1076
- As part of this I also explored running our integration tests in CI in MacOS and Windows in addition to Ubuntu.
  - The first challenge was that our CI step to install Vault and Consul is Ubuntu-specific: it uses `apt`.
  - I did manage to come up with a PowerShell script for this that works across all 3 platforms. I am thinking about making that its own GitHub action.
  - Once that was done, the MacOS tests ran successfully, however GitHub Actions free usage limits us to 5 concurrent MacOS jobs at a time, and we run more than 5, so there is some contention there. As we reduce the number of Vault versions we test against that should be alleviated.
  - Windows had some other problems. First, there's a bug in Poetry that has nothing to do with Windows but seemed to come up more frequently, and it caused failures in installing dependencies. It seems to be fixed in Poetry 1.7.0.
  - After working through that and getting the tests to actually run we hit the problem I expected: the tests freeze up indefinitely, as described here:
  - #1007 
  - Mainly, I wanted to see what else we might run into and if there were any other blockers to running against Windows, and I think I have a good handle on what those are, so I've removed all the other platform stuff from this PR, and we'll get to that in another one.