### PR TITLE
try not skipping on cache hit

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -88,7 +88,7 @@ jobs:
         cache: poetry
 
     - name: Install dependencies
-      run: poetry install --no-interaction --no-root --with dev
+      run: poetry install --no-interaction --no-root --with dev,docs
 
     - name: Install library
       run: poetry install --no-interaction

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -88,8 +88,7 @@ jobs:
         cache: poetry
 
     - name: Install dependencies
-      if: steps.python.outputs.cache-hit != 'true'
-      run: poetry install --no-interaction --no-root --with dev,docs
+      run: poetry install --no-interaction --no-root --with dev
 
     - name: Install library
       run: poetry install --no-interaction


### PR DESCRIPTION
Since #1119 , I've noticed that doctests run are failing, unable to find `sphinx-build`, unless I delete the cache and let it reinstall the dependencies. I guess the caching mechanism is not keeping the bin type files so the command `sphinx-build` just doesn't exist?

Trying to fix without completely uncaching...