### PR TITLE
update the KV documentation

### DIFF
--- a/docs/usage/secrets_engines/kv.rst
+++ b/docs/usage/secrets_engines/kv.rst
@@ -1,35 +1,31 @@
 KV Secrets Engines
 ==================
 
-The :py:class:`hvac.api.secrets_engines.Kv` instance under the :py:attr:`Client class's kv attribute<hvac.v1.Client.kv>` is a wrapper to expose either version 1 (:py:class:`KvV1<hvac.api.secrets_engines.KvV1>`) or version 2 of the key/value secrets engines' API methods (:py:class:`KvV2<hvac.api.secrets_engines.KvV2>`). At present, this class defaults to version 2 when accessing methods on the instance.
+The :py:class:`hvac.api.secrets_engines.Kv` instance under the :py:attr:`Client class's secrets.kv attribute<hvac.v1.Client.secrets.kv>` is a wrapper to expose either version 1 (:py:class:`KvV1<hvac.api.secrets_engines.KvV1>`) or version 2 of the key/value secrets engines' API methods (:py:class:`KvV2<hvac.api.secrets_engines.KvV2>`). At present, this class defaults to version 2 when accessing methods on the instance.
 
 
 
 Setting the Default KV Version
 ------------------------------
 
-:py:meth:`hvac.api.secrets_engines.KvV1.read_secret`
-
 .. code:: python
 
     import hvac
     client = hvac.Client()
 
-    client.kv.default_kv_version = 1
-    client.kv.read_secret(path='hvac')  # => calls hvac.api.secrets_engines.KvV1.read_secret
+    client.secrets.kv.default_kv_version = 1
+    client.secrets.kv.read_secret(path='hvac')  # => calls hvac.api.secrets_engines.KvV1.read_secret
 
 Explicitly Calling a KV Version Method
 --------------------------------------
 
-:py:meth:`hvac.api.secrets_engines.KvV1.list_secrets`
-
 .. code:: python
 
     import hvac
     client = hvac.Client()
 
-    client.kv.v1.read_secret(path='hvac')
-    client.kv.v2.read_secret_version(path='hvac')
+    client.secrets.kv.v1.read_secret(path='hvac')
+    client.secrets.kv.v2.read_secret_version(path='hvac')
 
 
 Specific KV Version Usage


### PR DESCRIPTION
Fixes #1113 

Fixes some mistakes the documentation from its inception and then the subsequent removal of the `Client.kv` member:
- https://github.com/hvac/hvac/pull/260
- https://github.com/hvac/hvac/pull/311

