### PR TITLE
Add new exception types for HTTP status 405 and 412

### DIFF
--- a/hvac/exceptions.py
+++ b/hvac/exceptions.py
@@ -49,6 +49,14 @@ class InvalidPath(VaultError):
     pass
 
 
+class UnsupportedOperation(VaultError):
+    pass
+
+
+class PreconditionFailed(VaultError):
+    pass
+
+
 class RateLimitExceeded(VaultError):
     pass
 


### PR DESCRIPTION
# HTTP exception type changes

Any HTTP exception in `hvac` which does not have a pre-existing mapped status code to exception will return an `UnexpectedError` exeption.

We would like to add exception types for status codes [412 (`PreconditionFailed`)](#1093) and 405 (`UnsupportedOperation`).

## Breaking change

Existing code that wants to catch those exceptions may be written similarly to this:

```python
try:
    client.do_thing()
except UnexpectedError as e:
    # check status code in e and handle appropriately
```

If we then map those status codes to new exception types, the above code will fail to catch them.

As a result, we will do this change in two stages:

- This PR introduces the new classes, but **does not** map the existing status codes to them, so those exceptions will never be raised. This change will be added to `hvac` 2.2.0.
- #1149 will be introduced in `hvac` 3.0.0 and will map the status codes.

# Action needed

If you currently use `UnexpectedError` to catch status codes 405 or 412, update your code **before v3.0.0** to something like the following (using `UnsupportedOperation` as the example):

```python
try:
   client.do_thing()
except (UnexpectedError, UnsupportedOperation) as e:
    # handle
```

or if you want to handle them differently:

```python
try:
   client.do_thing()
except UnsupportedOperation as e:
    # handle
except UnexpectedError as e:
    # handle
```

This ensures that your code is ready to handle the new exception type. This is especially important if your project intends to support multiple major versions of `hvac`.

# Future exception types

If you are using `UnexpectedError` as a catch-all for any exception without a dedicated type, and you want to future proof against more HTTP exception types being added in the future, you may consider catching the base class `VaultError` instead or in addition to `:

```python
try:
    client.do_thing()
except Unauthorized:
    # handle unauthorized
except Forbidden:
    # handle forbidden
except VaultError as e:
    # conditionally handle any exception not named in a previous except block
```

---

* Prepare for #1093 by adding PreconditionFailed exception for status code 412
* Add UnsupportedOperation exception for status code 405

Adding the UnsupportedOperation exception is a reasonably significant change as there might be quite a bit of code expecting UnexpectedError on a 405. Can take it out if it's too much.