### PR TITLE
update codecov to v4 and use upload token

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -275,3 +275,4 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -272,4 +272,6 @@ jobs:
         uses: actions/download-artifact@v3
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Codecov v3 has stopped working properly, we will update to v4, but v4 does not support tokenless uploading except on PRs from forks, so I have also added the token as a repository secret (also in dependabot secrets).
- https://github.com/codecov/codecov-action/issues/1359

I've also set it so that CI fails if there's an error reporting coverage. I hadn't even noticed the issue until now because CI was passing.