### PR TITLE
Implement activedirectory.rotate_credentials and ldap.rotate_static_credentials

### DIFF
--- a/hvac/api/secrets_engines/active_directory.py
+++ b/hvac/api/secrets_engines/active_directory.py
@@ -179,3 +179,18 @@ class ActiveDirectory(VaultApiBase):
         return self._adapter.get(
             url=api_path,
         )
+
+    def rotate_credentials(self, name, mount_point=DEFAULT_MOUNT_POINT):
+        """This endpoint triggers a force rotate LDAP password for the associated account
+
+        :param name: Specifies the name of the role to request credentials from.
+        :type name: str | unicode
+        :param mount_point: Specifies the place where the secrets engine will be accessible (default: ad).
+        :type mount_point: str | unicode
+        :return: The response of the request.
+        :rtype: requests.Response
+        """
+        api_path = utils.format_url("/v1/{}/rotate-role/{}", mount_point, name)
+        return self._adapter.post(
+            url=api_path,
+        )

--- a/hvac/api/secrets_engines/ldap.py
+++ b/hvac/api/secrets_engines/ldap.py
@@ -191,3 +191,18 @@ class Ldap(VaultApiBase):
         return self._adapter.get(
             url=api_path,
         )
+
+    def rotate_static_credentials(self, name, mount_point=DEFAULT_MOUNT_POINT):
+        """This endpoint triggers a force rotate LDAP password for the associated account
+
+        :param name: Specifies the name of the role to request credentials from.
+        :type name: str | unicode
+        :param mount_point: Specifies the place where the secrets engine will be accessible (default: ldap).
+        :type mount_point: str | unicode
+        :return: The response of the request.
+        :rtype: requests.Response
+        """
+        api_path = utils.format_url("/v1/{}/rotate-role/{}", mount_point, name)
+        return self._adapter.post(
+            url=api_path,
+        )

--- a/tests/unit_tests/api/secrets_engines/test_ldap.py
+++ b/tests/unit_tests/api/secrets_engines/test_ldap.py
@@ -250,7 +250,7 @@ class TestLdap(TestCase):
             ("custom mount point", "other-ldap-tree"),
         ]
     )
-    def test_rotate_credentials(self, test_label, mount_point, requests_mocker):
+    def test_rotate_static_credentials(self, test_label, mount_point, requests_mocker):
         expected_status_code = 204
         role_name = "hvac"
         mock_url = "http://localhost:8200/v1/{mount_point}/rotate-role/{name}".format(
@@ -263,7 +263,7 @@ class TestLdap(TestCase):
             status_code=expected_status_code,
         )
         ldap = Ldap(adapter=JSONAdapter())
-        response = ldap.rotate_credentials(
+        response = ldap.rotate_static_credentials(
             name=role_name,
             mount_point=mount_point,
         )


### PR DESCRIPTION
usage: client.secrets.activedirectory.rotate_credentials(name,[mount_point])