### PR TITLE
add support for Vault Raft auto-snapshot endpoints.

### DIFF
--- a/docs/usage/system_backend/raft.rst
+++ b/docs/usage/system_backend/raft.rst
@@ -47,3 +47,73 @@ Remove Raft Node
     client.sys.remove_raft_node(
         server_id='i-somenodeid',
     )
+
+Read Raft Auto-Snapshot Status
+------------------------------
+
+:py:meth:`hvac.api.system_backend.Raft.read_raft_auto_snapshot_status`
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    client.sys.read_raft_auto_snapshot_status("my-local-auto-snapshot")
+
+Read Raft Auto-Snapshot Configuration
+-------------------------------------
+
+:py:meth:`hvac.api.system_backend.Raft.read_raft_auto_snapshot_config`
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    client.sys.read_raft_auto_snapshot_config("my-local-auto-snapshot")
+
+List Raft Auto-Snapshot Configurations
+--------------------------------------
+
+:py:meth:`hvac.api.system_backend.Raft.list_raft_auto_snapshot_configs`
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    client.sys.list_raft_auto_snapshot_configs()
+
+Create or Update Raft Auto-Snapshot Configuration
+-------------------------------------------------
+
+:py:meth:`hvac.api.system_backend.Raft.create_or_update_raft_auto_snapshot_config`
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    client.sys.create_or_update_raft_auto_snapshot_config(
+        name="my-local-auto-snapshot",
+        interval="1d",
+        storage_type="local",
+        retain=5,
+        local_max_space="100000",
+        path_prefix="/opt/vault/backups",
+        file_prefix="vault-raft-auto-snapshot"
+    )
+
+Delete Raft Auto-Snapshot Configuration
+---------------------------------------
+
+:py:meth:`hvac.api.system_backend.Raft.delete_raft_auto_snapshot_config`
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    client.sys.delete_raft_auto_snapshot_config(
+        name="my-local-auto-snapshot",
+    )

--- a/hvac/api/system_backend/raft.py
+++ b/hvac/api/system_backend/raft.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """Raft methods module."""
+from hvac import adapters, utils
 from hvac.api.system_backend.system_backend_mixin import SystemBackendMixin
-from hvac import utils, adapters
 
 
 class Raft(SystemBackendMixin):
@@ -152,4 +152,102 @@ class Raft(SystemBackendMixin):
         return self._adapter.post(
             url=api_path,
             data=snapshot,
+        )
+
+    def read_raft_auto_snapshot_status(self, name):
+        """Read the status of the raft auto snapshot.
+
+        Supported methods:
+            GET: /sys/storage/raft/snapshot-auto/status/:name. Produces: 200 application/json
+
+        :param name: The name of the snapshot configuration.
+        :type name: str
+        :return: The response of the read_raft_auto_snapshot_status request.
+        :rtype: requests.Response
+        """
+        api_path = f"/v1/sys/storage/raft/snapshot-auto/status/{name}"
+        return self._adapter.get(
+            url=api_path,
+        )
+
+    def read_raft_auto_snapshot_config(self, name):
+        """Read the configuration of the raft auto snapshot.
+
+        Supported methods:
+            GET: /sys/storage/raft/snapshot-auto/config/:name. Produces: 200 application/json
+
+        :param name: The name of the snapshot configuration.
+        :type name: str
+        :return: The response of the read_raft_auto_snapshot_config request.
+        :rtype: requests.Response
+        """
+        api_path = f"/v1/sys/storage/raft/snapshot-auto/config/{name}"
+        return self._adapter.get(
+            url=api_path,
+        )
+
+    def list_raft_auto_snapshot_configs(self):
+        """List the configurations of the raft auto snapshot.
+
+        Supported methods:
+            LIST: /sys/storage/raft/snapshot-auto/config. Produces: 200 application/json
+
+        :return: The response of the list_raft_auto_snapshot_configs request.
+        :rtype: requests.Response
+        """
+        api_path = "/v1/sys/storage/raft/snapshot-auto/config"
+        return self._adapter.list(
+            url=api_path,
+        )
+
+    def create_or_update_raft_auto_snapshot_config(
+        self, name, interval, storage_type, retain=1, **kwargs
+    ):
+        """Create or update the configuration of the raft auto snapshot.
+
+        Supported methods:
+            POST: /sys/storage/raft/snapshot-auto/config/:name. Produces: 204 application/json
+
+        :param name: The name of the snapshot configuration.
+        :type name: str
+        :param interval: The interval at which snapshots should be taken.
+        :type interval: str
+        :param storage_type: The type of storage to use for the snapshot.
+        :type storage_type: str
+        :param retain: The number of snapshots to retain. Default is 1
+        :type retain: int
+        :param kwargs: Additional parameters to send in the request. Should be params specific to the storage type.
+        :type kwargs: dict
+        :return: The response of the create_or_update_raft_auto_snapshot_config request.
+        :rtype: requests.Response
+        """
+        params = utils.remove_nones(
+            {
+                "interval": interval,
+                "storage_type": storage_type,
+                "retain": retain,
+                **kwargs,
+            }
+        )
+
+        api_path = f"/v1/sys/storage/raft/snapshot-auto/config/{name}"
+        return self._adapter.post(
+            url=api_path,
+            json=params,
+        )
+
+    def delete_raft_auto_snapshot_config(self, name):
+        """Delete the configuration of the raft auto snapshot.
+
+        Supported methods:
+            DELETE: /sys/storage/raft/snapshot-auto/config/:name. Produces: 204 application/json
+
+        :param name: The name of the snapshot configuration.
+        :type name: str
+        :return: The response of the delete_raft_auto_snapshot_config request.
+        :rtype: requests.Response
+        """
+        api_path = f"/v1/sys/storage/raft/snapshot-auto/config/{name}"
+        return self._adapter.delete(
+            url=api_path,
         )

--- a/hvac/api/system_backend/raft.py
+++ b/hvac/api/system_backend/raft.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """Raft methods module."""
-from hvac import adapters, utils
 from hvac.api.system_backend.system_backend_mixin import SystemBackendMixin
+from hvac import utils, adapters
 
 
 class Raft(SystemBackendMixin):

--- a/tests/integration_tests/api/system_backend/test_raft.py
+++ b/tests/integration_tests/api/system_backend/test_raft.py
@@ -1,4 +1,3 @@
-import logging
 from unittest import TestCase, skipIf
 
 from tests import utils
@@ -21,16 +20,14 @@ class TestRaft(HvacIntegrationTestCase, TestCase):
             "file_prefix": "vault-raft-auto-snapshot",
         }
 
-        create_or_update_raft_auto_config_response = (
-            self.client.sys.create_or_update_raft_auto_snapshot_config(
-                name=raft_configs_dict["name"],
-                interval=raft_configs_dict["interval"],
-                storage_type=raft_configs_dict["storage_type"],
-                retain=raft_configs_dict["retain"],
-                local_max_space=raft_configs_dict["local_max_space"],
-                path_prefix=raft_configs_dict["path_prefix"],
-                file_prefix=raft_configs_dict["file_prefix"],
-            )
+        self.client.sys.create_or_update_raft_auto_snapshot_config(
+            name=raft_configs_dict["name"],
+            interval=raft_configs_dict["interval"],
+            storage_type=raft_configs_dict["storage_type"],
+            retain=raft_configs_dict["retain"],
+            local_max_space=raft_configs_dict["local_max_space"],
+            path_prefix=raft_configs_dict["path_prefix"],
+            file_prefix=raft_configs_dict["file_prefix"],
         )
 
         self.assertEqual(

--- a/tests/integration_tests/api/system_backend/test_raft.py
+++ b/tests/integration_tests/api/system_backend/test_raft.py
@@ -1,0 +1,233 @@
+import logging
+from unittest import TestCase, skipIf
+
+from tests import utils
+from tests.utils.hvac_integration_test_case import HvacIntegrationTestCase
+
+
+class TestRaft(HvacIntegrationTestCase, TestCase):
+    @skipIf(
+        not utils.is_enterprise() or utils.vault_version_lt("1.8.0"),
+        "Raft automated snapshots only supported in Enterprise Vault",
+    )
+    def test_create_raft_auto_config(self):
+        raft_configs_dict = {
+            "name": "my-local-auto-snapshot",
+            "interval": "86400",
+            "storage_type": "local",
+            "retain": 5,
+            "local_max_space": "100000",
+            "path_prefix": "/opt/vault/backups",
+            "file_prefix": "vault-raft-auto-snapshot",
+        }
+
+        create_or_update_raft_auto_config_response = (
+            self.client.sys.create_or_update_raft_auto_snapshot_config(
+                name=raft_configs_dict["name"],
+                interval=raft_configs_dict["interval"],
+                storage_type=raft_configs_dict["storage_type"],
+                retain=raft_configs_dict["retain"],
+                local_max_space=raft_configs_dict["local_max_space"],
+                path_prefix=raft_configs_dict["path_prefix"],
+                file_prefix=raft_configs_dict["file_prefix"],
+            )
+        )
+
+        self.assertEqual(
+            first=raft_configs_dict,
+            second=self.client.sys.read_raft_auto_snapshot_config(
+                raft_configs_dict["name"]
+            )["data"],
+        )
+
+    @skipIf(
+        not utils.is_enterprise() or utils.vault_version_lt("1.8.0"),
+        "Raft automated snapshots only supported in Enterprise Vault",
+    )
+    def test_update_raft_auto_config(self):
+        raft_configs_dict = {
+            "name": "my-local-auto-snapshot",
+            "interval": "86400",
+            "storage_type": "local",
+            "retain": 5,
+            "local_max_space": "100000",
+            "path_prefix": "/opt/vault/backups",
+            "file_prefix": "vault-raft-auto-snapshot",
+        }
+
+        # Create initial configuration
+        self.client.sys.create_or_update_raft_auto_snapshot_config(
+            name=raft_configs_dict["name"],
+            interval=raft_configs_dict["interval"],
+            storage_type=raft_configs_dict["storage_type"],
+            retain=raft_configs_dict["retain"],
+            local_max_space=raft_configs_dict["local_max_space"],
+            path_prefix=raft_configs_dict["path_prefix"],
+            file_prefix=raft_configs_dict["file_prefix"],
+        )
+
+        raft_configs_dict["path_prefix"] = "/opt/vault/backups2"
+
+        # Update configuration
+        self.client.sys.create_or_update_raft_auto_snapshot_config(
+            name=raft_configs_dict["name"],
+            interval=raft_configs_dict["interval"],
+            storage_type=raft_configs_dict["storage_type"],
+            retain=raft_configs_dict["retain"],
+            local_max_space=raft_configs_dict["local_max_space"],
+            path_prefix=raft_configs_dict["path_prefix"],
+            file_prefix=raft_configs_dict["file_prefix"],
+        )
+
+        self.assertEqual(
+            first=raft_configs_dict,
+            second=self.client.sys.read_raft_auto_snapshot_config(
+                raft_configs_dict["name"]
+            )["data"],
+        )
+
+    @skipIf(
+        not utils.is_enterprise() or utils.vault_version_lt("1.8.0"),
+        "Raft automated snapshots only supported in Enterprise Vault",
+    )
+    def test_read_raft_auto_config(self):
+        raft_configs_dict = {
+            "name": "my-local-auto-snapshot",
+            "interval": "86400",
+            "storage_type": "local",
+            "retain": 5,
+            "local_max_space": "100000",
+            "path_prefix": "/opt/vault/backups",
+            "file_prefix": "vault-raft-auto-snapshot",
+        }
+
+        # Create initial configuration
+        self.client.sys.create_or_update_raft_auto_snapshot_config(
+            name=raft_configs_dict["name"],
+            interval=raft_configs_dict["interval"],
+            storage_type=raft_configs_dict["storage_type"],
+            retain=raft_configs_dict["retain"],
+            local_max_space=raft_configs_dict["local_max_space"],
+            path_prefix=raft_configs_dict["path_prefix"],
+            file_prefix=raft_configs_dict["file_prefix"],
+        )
+
+        self.assertEqual(
+            first=raft_configs_dict,
+            second=self.client.sys.read_raft_auto_snapshot_config(
+                raft_configs_dict["name"]
+            )["data"],
+        )
+
+    @skipIf(
+        not utils.is_enterprise() or utils.vault_version_lt("1.8.0"),
+        "Raft automated snapshots only supported in Enterprise Vault",
+    )
+    def test_list_raft_auto_configs(self):
+        raft_configs_dict = {
+            "name": "my-local-auto-snapshot",
+            "interval": "86400",
+            "storage_type": "local",
+            "retain": 5,
+            "local_max_space": "100000",
+            "path_prefix": "/opt/vault/backups",
+            "file_prefix": "vault-raft-auto-snapshot",
+        }
+
+        # Create initial configuration
+        self.client.sys.create_or_update_raft_auto_snapshot_config(
+            name=raft_configs_dict["name"],
+            interval=raft_configs_dict["interval"],
+            storage_type=raft_configs_dict["storage_type"],
+            retain=raft_configs_dict["retain"],
+            local_max_space=raft_configs_dict["local_max_space"],
+            path_prefix=raft_configs_dict["path_prefix"],
+            file_prefix=raft_configs_dict["file_prefix"],
+        )
+
+        self.assertIn(
+            member=raft_configs_dict["name"],
+            container=self.client.sys.list_raft_auto_snapshot_configs()["data"]["keys"],
+        )
+
+    @skipIf(
+        not utils.is_enterprise() or utils.vault_version_lt("1.8.0"),
+        "Raft automated snapshots only supported in Enterprise Vault",
+    )
+    def test_delete_raft_auto_config(self):
+        raft_configs_dict = {
+            "name": "my-local-auto-snapshot",
+            "interval": "86400",
+            "storage_type": "local",
+            "retain": 5,
+            "local_max_space": "100000",
+            "path_prefix": "/opt/vault/backups",
+            "file_prefix": "vault-raft-auto-snapshot",
+        }
+
+        # Create initial configuration
+        self.client.sys.create_or_update_raft_auto_snapshot_config(
+            name=raft_configs_dict["name"],
+            interval=raft_configs_dict["interval"],
+            storage_type=raft_configs_dict["storage_type"],
+            retain=raft_configs_dict["retain"],
+            local_max_space=raft_configs_dict["local_max_space"],
+            path_prefix=raft_configs_dict["path_prefix"],
+            file_prefix=raft_configs_dict["file_prefix"],
+        )
+
+        # Path and file prefix can't be shared between configs
+        raft_configs_dict["file_prefix"] = "vault-raft-auto-snapshot2"
+        raft_configs_dict["path_prefix"] = "/opt/vault/backups2"
+
+        # Create a second config because list endpoint raises a 404 if no configs exist
+        self.client.sys.create_or_update_raft_auto_snapshot_config(
+            name="my-local-auto-snapshot2",
+            interval=raft_configs_dict["interval"],
+            storage_type=raft_configs_dict["storage_type"],
+            retain=raft_configs_dict["retain"],
+            local_max_space=raft_configs_dict["local_max_space"],
+            path_prefix=raft_configs_dict["path_prefix"],
+            file_prefix=raft_configs_dict["file_prefix"],
+        )
+
+        self.client.sys.delete_raft_auto_snapshot_config(name=raft_configs_dict["name"])
+
+        self.assertNotIn(
+            member=raft_configs_dict,
+            container=self.client.sys.list_raft_auto_snapshot_configs()["data"]["keys"],
+        )
+
+    @skipIf(
+        not utils.is_enterprise() or utils.vault_version_lt("1.8.0"),
+        "Raft automated snapshots only supported in Enterprise Vault",
+    )
+    def test_read_auto_snapshot_status(self):
+        raft_configs_dict = {
+            "name": "my-local-auto-snapshot",
+            "interval": "86400",
+            "storage_type": "local",
+            "retain": 5,
+            "local_max_space": "100000",
+            "path_prefix": "/opt/vault/backups",
+            "file_prefix": "vault-raft-auto-snapshot",
+        }
+
+        # Create initial configuration
+        self.client.sys.create_or_update_raft_auto_snapshot_config(
+            name=raft_configs_dict["name"],
+            interval=raft_configs_dict["interval"],
+            storage_type=raft_configs_dict["storage_type"],
+            retain=raft_configs_dict["retain"],
+            local_max_space=raft_configs_dict["local_max_space"],
+            path_prefix=raft_configs_dict["path_prefix"],
+            file_prefix=raft_configs_dict["file_prefix"],
+        )
+
+        # Confirm that key "data" exists within the response
+        self.assertIn(
+            member="data",
+            container=self.client.sys.read_raft_auto_snapshot_status(
+                raft_configs_dict["name"]
+            ),
+        )


### PR DESCRIPTION
These endpoints are only accessible within Vault Enterprise and were introduced in version 1.6.

Adding methods, documentation and integration tests for the following endpoints - read raft auto snapshot status, read raft auto snapshot config, list raft auto snapshot configs, create or update raft auto snapshot config, and delete raft auto snapshot config

Resolves #1150