### PR TITLE
feat: Raft Autopilot endpoints

### DIFF
--- a/docs/usage/system_backend/raft.rst
+++ b/docs/usage/system_backend/raft.rst
@@ -131,7 +131,7 @@ Read Raft Cluster State
     client.sys.read_raft_cluster_state()
 
 Read Raft Autopilot Config
------------------------
+--------------------------
 
 :py:meth:`hvac.api.system_backend.Raft.read_raft_autopilot_config`
 
@@ -143,7 +143,7 @@ Read Raft Autopilot Config
     client.sys.read_raft_autopilot_config()
 
 Update Raft Autopilot Config
------------------------
+----------------------------
 
 :py:meth:`hvac.api.system_backend.Raft.update_raft_autopilot_config`
 

--- a/docs/usage/system_backend/raft.rst
+++ b/docs/usage/system_backend/raft.rst
@@ -117,3 +117,47 @@ Delete Raft Auto-Snapshot Configuration
     client.sys.delete_raft_auto_snapshot_config(
         name="my-local-auto-snapshot",
     )
+
+Read Raft Cluster State
+-----------------------
+
+:py:meth:`hvac.api.system_backend.Raft.read_raft_cluster_state`
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    client.sys.read_raft_cluster_state()
+
+Read Raft Autopilot Config
+-----------------------
+
+:py:meth:`hvac.api.system_backend.Raft.read_raft_autopilot_config`
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    client.sys.read_raft_autopilot_config()
+
+Update Raft Autopilot Config
+-----------------------
+
+:py:meth:`hvac.api.system_backend.Raft.update_raft_autopilot_config`
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client()
+
+    client.sys.read_raft_cluster_state(
+        cleanup_dead_servers=False
+        last_contact_threshold="10s"
+        dead_server_last_contact_threshold="24h"
+        max_trailing_logs=1000
+        min_quorum=3
+        server_stabilization_time="10s"
+        disable_upgrade_migration=False
+    )

--- a/hvac/api/system_backend/raft.py
+++ b/hvac/api/system_backend/raft.py
@@ -283,13 +283,13 @@ class Raft(SystemBackendMixin):
 
     def update_raft_autopilot_config(
         self,
-        cleanup_dead_servers,
-        last_contact_threshold,
-        dead_server_last_contact_threshold,
-        max_trailing_logs,
-        min_quorum,
-        server_stabilization_time,
-        disable_upgrade_migration,
+        cleanup_dead_servers=None,
+        last_contact_threshold=None,
+        dead_server_last_contact_threshold=None,
+        max_trailing_logs=None,
+        min_quorum=None,
+        server_stabilization_time=None,
+        disable_upgrade_migration=None,
         **kwargs,
     ):
         """Create or update the configuration of the raft auto snapshot.

--- a/hvac/api/system_backend/raft.py
+++ b/hvac/api/system_backend/raft.py
@@ -297,15 +297,18 @@ class Raft(SystemBackendMixin):
         Supported methods:
             POST: /sys/storage/raft/autopilot/configuration. Produces: 204 application/json
 
-        :param cleanup_dead_servers: Controls whether to remove dead servers from the Raft peer list periodically or when a new server joins. This requires that min_quorum is also set.
+        :param cleanup_dead_servers: Controls whether to remove dead servers from the Raft peer list periodically or when
+            a new server joins. This requires that min_quorum is also set.
         :type cleanup_dead_servers: bool
         :param last_contact_threshold: Limit on the amount of time a server can go without leader contact before being considered unhealthy.
         :type last_contact_threshold: string
-        :param dead_server_last_contact_threshold: Limit on the amount of time a server can go without leader contact before being considered failed. This takes effect only when cleanup_dead_servers is true. This can not be set to a value smaller than 1m.
+        :param dead_server_last_contact_threshold: Limit on the amount of time a server can go without leader contact
+            before being considered failed. This takes effect only when cleanup_dead_servers is true. This can not be set to a value smaller than 1m.
         :type dead_server_last_contact_threshold: string
         :param max_trailing_logs: Amount of entries in the Raft Log that a server can be behind before being considered unhealthy.
         :type max_trailing_logs: int
-        :param min_quorum: Minimum number of servers allowed in a cluster before autopilot can prune dead servers. This should at least be 3. Applicable only for voting nodes.
+        :param min_quorum: Minimum number of servers allowed in a cluster before autopilot can prune dead servers.
+            This should at least be 3. Applicable only for voting nodes.
         :type min_quorum: int
         :param server_stabilization_time: Minimum amount of time a server must be in a stable, healthy state before it can be added to the cluster.
         :type server_stabilization_time: string

--- a/hvac/api/system_backend/raft.py
+++ b/hvac/api/system_backend/raft.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Raft methods module."""
+
 from hvac.api.system_backend.system_backend_mixin import SystemBackendMixin
 from hvac import utils, adapters
 
@@ -250,4 +251,85 @@ class Raft(SystemBackendMixin):
         api_path = f"/v1/sys/storage/raft/snapshot-auto/config/{name}"
         return self._adapter.delete(
             url=api_path,
+        )
+
+    def read_raft_cluster_state(self):
+        """Read the Integrated Storage raft cluster state.
+
+        Supported methods:
+            GET: /sys/storage/raft/autopilot/state. Produces: 200 application/json
+
+        :return: The response of the read_raft_cluster_state request.
+        :rtype: requests.Response
+        """
+        api_path = "/v1/sys/storage/raft/autopilot/state"
+        return self._adapter.get(
+            url=api_path,
+        )
+
+    def read_raft_autopilot_config(self):
+        """Read the configuration of the autopilot subsystem of Integrated Storage.
+
+        Supported methods:
+            GET: /sys/storage/raft/autopilot/configuration. Produces: 200 application/json
+
+        :return: The response of the read_raft_autopilot_config request.
+        :rtype: requests.Response
+        """
+        api_path = "/v1/sys/storage/raft/autopilot/configuration"
+        return self._adapter.get(
+            url=api_path,
+        )
+
+    def update_raft_autopilot_config(
+        self,
+        cleanup_dead_servers,
+        last_contact_threshold,
+        dead_server_last_contact_threshold,
+        max_trailing_logs,
+        min_quorum,
+        server_stabilization_time,
+        disable_upgrade_migration,
+        **kwargs,
+    ):
+        """Create or update the configuration of the raft auto snapshot.
+
+        Supported methods:
+            POST: /sys/storage/raft/autopilot/configuration. Produces: 204 application/json
+
+        :param cleanup_dead_servers: Controls whether to remove dead servers from the Raft peer list periodically or when a new server joins. This requires that min_quorum is also set.
+        :type cleanup_dead_servers: bool
+        :param last_contact_threshold: Limit on the amount of time a server can go without leader contact before being considered unhealthy.
+        :type last_contact_threshold: string
+        :param dead_server_last_contact_threshold: Limit on the amount of time a server can go without leader contact before being considered failed. This takes effect only when cleanup_dead_servers is true. This can not be set to a value smaller than 1m.
+        :type dead_server_last_contact_threshold: string
+        :param max_trailing_logs: Amount of entries in the Raft Log that a server can be behind before being considered unhealthy.
+        :type max_trailing_logs: int
+        :param min_quorum: Minimum number of servers allowed in a cluster before autopilot can prune dead servers. This should at least be 3. Applicable only for voting nodes.
+        :type min_quorum: int
+        :param server_stabilization_time: Minimum amount of time a server must be in a stable, healthy state before it can be added to the cluster.
+        :type server_stabilization_time: string
+        :param disable_upgrade_migration: Disables automatically upgrading Vault using autopilot. (Enterprise-only)
+        :type disable_upgrade_migration: bool
+        :param kwargs: Additional parameters to send in the request. Should be params specific to the storage type.
+        :type kwargs: dict
+        :return: The response of the update_raft_autopilot_config request.
+        :rtype: requests.Response
+        """
+        params = utils.remove_nones(
+            {
+                "cleanup_dead_servers": cleanup_dead_servers,
+                "last_contact_threshold": last_contact_threshold,
+                "dead_server_last_contact_threshold": dead_server_last_contact_threshold,
+                "max_trailing_logs": max_trailing_logs,
+                "min_quorum": min_quorum,
+                "server_stabilization_time": server_stabilization_time,
+                "disable_upgrade_migration": disable_upgrade_migration,
+                **kwargs,
+            }
+        )
+        api_path = "/v1/sys/storage/raft/autopilot/configuration"
+        return self._adapter.post(
+            url=api_path,
+            json=params,
         )

--- a/tests/integration_tests/api/system_backend/test_raft.py
+++ b/tests/integration_tests/api/system_backend/test_raft.py
@@ -259,5 +259,4 @@ class TestRaft(HvacIntegrationTestCase, TestCase):
         )
         self.assertTrue(
             self.client.sys.read_raft_autopilot_config()["data"]["cleanup_dead_server"]
-            == True
         )

--- a/tests/integration_tests/api/system_backend/test_raft.py
+++ b/tests/integration_tests/api/system_backend/test_raft.py
@@ -229,21 +229,35 @@ class TestRaft(HvacIntegrationTestCase, TestCase):
             ),
         )
 
-    @skipIf(utils.vault_version_lt("1.8.0") or True, "Storage type 'Raft' required to use autopilot endpoint")
+    @skipIf(
+        utils.vault_version_lt("1.8.0") or True,
+        "Storage type 'Raft' required to use autopilot endpoint",
+    )
     def test_read_autopilot_cluster_status(self):
         self.assertIn(
             member="data",
             container=self.client.sys.read_raft_cluster_state(),
         )
 
-    @skipIf(utils.vault_version_lt("1.8.0") or True, "Storage type 'Raft' required to use autopilot endpoint")
+    @skipIf(
+        utils.vault_version_lt("1.8.0") or True,
+        "Storage type 'Raft' required to use autopilot endpoint",
+    )
     def test_read_autopilot_config(self):
         self.assertIn(
             member="data",
             container=self.client.sys.read_raft_autopilot_config(),
         )
 
-    @skipIf(utils.vault_version_lt("1.8.0") or True, "Storage type 'Raft' required to use autopilot endpoint")
+    @skipIf(
+        utils.vault_version_lt("1.8.0") or True,
+        "Storage type 'Raft' required to use autopilot endpoint",
+    )
     def test_update_autopilot_config(self):
-        self.client.sys.update_raft_autopilot_config(cleanup_dead_servers=True, min_quorum=3)
-        self.assertTrue(self.client.sys.read_raft_autopilot_config()["data"]["cleanup_dead_server"] == True)
+        self.client.sys.update_raft_autopilot_config(
+            cleanup_dead_servers=True, min_quorum=3
+        )
+        self.assertTrue(
+            self.client.sys.read_raft_autopilot_config()["data"]["cleanup_dead_server"]
+            == True
+        )

--- a/tests/integration_tests/api/system_backend/test_raft.py
+++ b/tests/integration_tests/api/system_backend/test_raft.py
@@ -228,3 +228,22 @@ class TestRaft(HvacIntegrationTestCase, TestCase):
                 raft_configs_dict["name"]
             ),
         )
+
+    @skipIf(utils.vault_version_lt("1.8.0"), "Raft autopilot not supported in previous versions")
+    def test_read_autopilot_cluster_status(self):
+        self.assertIn(
+            member="data",
+            container=self.client.sys.read_raft_cluster_state(),
+        )
+
+    @skipIf(utils.vault_version_lt("1.8.0"), "Raft autopilot not supported in previous versions")
+    def test_read_autopilot_config(self):
+        self.assertIn(
+            member="data",
+            container=self.client.sys.read_raft_autopilot_config(),
+        )
+
+    @skipIf(utils.vault_version_lt("1.8.0"), "Raft autopilot not supported in previous versions")
+    def test_update_autopilot_config(self):
+        self.client.sys.update_raft_autopilot_config(cleanup_dead_servers=True, min_quorum=3)
+        self.assertTrue(self.client.sys.read_raft_autopilot_config()["data"]["cleanup_dead_server"] == True)

--- a/tests/integration_tests/api/system_backend/test_raft.py
+++ b/tests/integration_tests/api/system_backend/test_raft.py
@@ -229,21 +229,21 @@ class TestRaft(HvacIntegrationTestCase, TestCase):
             ),
         )
 
-    @skipIf(utils.vault_version_lt("1.8.0"), "Raft autopilot not supported in previous versions")
+    @skipIf(utils.vault_version_lt("1.8.0") or True, "Storage type 'Raft' required to use autopilot endpoint")
     def test_read_autopilot_cluster_status(self):
         self.assertIn(
             member="data",
             container=self.client.sys.read_raft_cluster_state(),
         )
 
-    @skipIf(utils.vault_version_lt("1.8.0"), "Raft autopilot not supported in previous versions")
+    @skipIf(utils.vault_version_lt("1.8.0") or True, "Storage type 'Raft' required to use autopilot endpoint")
     def test_read_autopilot_config(self):
         self.assertIn(
             member="data",
             container=self.client.sys.read_raft_autopilot_config(),
         )
 
-    @skipIf(utils.vault_version_lt("1.8.0"), "Raft autopilot not supported in previous versions")
+    @skipIf(utils.vault_version_lt("1.8.0") or True, "Storage type 'Raft' required to use autopilot endpoint")
     def test_update_autopilot_config(self):
         self.client.sys.update_raft_autopilot_config(cleanup_dead_servers=True, min_quorum=3)
         self.assertTrue(self.client.sys.read_raft_autopilot_config()["data"]["cleanup_dead_server"] == True)


### PR DESCRIPTION
closes #1165

This adds 3 endpoints from the autopilot feature of Vault as described in the issue #1165 .

I locally validated and wrote tests for these functions, but I added a skip reason stating that the integration tests currently only support Consul. I am not too familiar with the testing setup in this repo, but let me know if there is anything I can address there.

Thanks.