### PR TITLE
docs: fix AppRole.login docstring

### DIFF
--- a/hvac/api/auth_methods/approle.py
+++ b/hvac/api/auth_methods/approle.py
@@ -496,7 +496,7 @@ class AppRole(VaultApiBase):
         :type use_token: bool
         :param mount_point: The "path" the method/backend was mounted on.
         :type mount_point: str | unicode
-        :return: The JSON response of the read_role_id request.
+        :return: The JSON response of the login request.
         :rtype: dict
         """
         params = {"role_id": role_id, "secret_id": secret_id}


### PR DESCRIPTION
Corrects the return description in the docstring of of `api.auth_methods.AppRole.login`