### PR TITLE
Add num_uses and ttl parameters to Approle auth secret id generation

### DIFF
--- a/hvac/api/auth_methods/approle.py
+++ b/hvac/api/auth_methods/approle.py
@@ -237,6 +237,8 @@ class AppRole(VaultApiBase):
         metadata=None,
         cidr_list=None,
         token_bound_cidrs=None,
+        num_uses=None,
+        ttl=None,
         mount_point=DEFAULT_MOUNT_POINT,
         wrap_ttl=None,
     ):
@@ -256,6 +258,12 @@ class AppRole(VaultApiBase):
         :type token_bound_cidrs: list
         :param mount_point: The "path" the method/backend was mounted on.
         :type mount_point: str | unicode
+        :param num_uses: Maximum number of times a generated secret id may be used. A value of zero
+            allows unlimited uses.
+        :type num_uses: int
+        :param ttl: Incremental lifetime for generated secret id. This can be specified
+            as an integer number of seconds or as a duration value like "5m".
+        :type ttl: str | unicode
         :param wrap_ttl: Returns the request as a response-wrapping token.
             Can be either an integer number of seconds or a string duration of seconds (`15s`), minutes (`20m`), or hours (`25h`).
         :type wrap_ttl: int | str
@@ -287,6 +295,15 @@ class AppRole(VaultApiBase):
             if param_argument is not None:
                 params[param_name] = list_to_comma_delimited(param_argument)
 
+        params.update(
+            utils.remove_nones(
+                {
+                    "num_uses": num_uses,
+                    "ttl": ttl,
+                }
+            )
+        )
+
         api_path = utils.format_url(
             "/v1/auth/{mount_point}/role/{role_name}/secret-id",
             mount_point=mount_point,
@@ -301,6 +318,8 @@ class AppRole(VaultApiBase):
         metadata=None,
         cidr_list=None,
         token_bound_cidrs=None,
+        num_uses=None,
+        ttl=None,
         mount_point=DEFAULT_MOUNT_POINT,
         wrap_ttl=None,
     ):
@@ -320,6 +339,12 @@ class AppRole(VaultApiBase):
         :type cidr_list: list
         :param token_bound_cidrs: Blocks of IP addresses which can authenticate successfully.
         :type token_bound_cidrs: list
+        :param num_uses: Maximum number of times a created secret id may be used. A value of zero
+            allows unlimited uses.
+        :type num_uses: int
+        :param ttl: Incremental lifetime for created secret id. This can be specified
+            as an integer number of seconds or as a duration value like "5m".
+        :type ttl: str | unicode
         :param mount_point: The "path" the method/backend was mounted on.
         :type mount_point: str | unicode
         :param wrap_ttl: Returns the request as a response-wrapping token.
@@ -353,6 +378,15 @@ class AppRole(VaultApiBase):
             )
             if param_argument is not None:
                 params[param_name] = list_to_comma_delimited(param_argument)
+
+        params.update(
+            utils.remove_nones(
+                {
+                    "num_uses": num_uses,
+                    "ttl": ttl,
+                }
+            )
+        )
 
         api_path = utils.format_url(
             "/v1/auth/{mount_point}/role/{role_name}/custom-secret-id",


### PR DESCRIPTION
Add the `num_uses` and `ttl` parameters to the `generate_secret_id` and `create_custom_secret_id` api methods instead of relying  on the approle default values for these parameters.