### PR TITLE
Add method to set the default issuer

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,9 +16,9 @@ copyright = "2018-2020, Ian Unruh, Jeffrey Hogan"
 author = "Ian Unruh, Jeffrey Hogan"
 
 # The short X.Y version
-version = "2.3.0"
+version = "2.4.0"
 # The full version, including alpha/beta/rc tags
-release = "2.3.0"
+release = "2.4.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/usage/secrets_engines/pki.rst
+++ b/docs/usage/secrets_engines/pki.rst
@@ -427,6 +427,20 @@ List Issuers
         issuer_list_response = client.secrets.pki.list_issuers()
 
 
+Set Issuers
+-----------
+
+:py:meth:`hvac.api.secrets_engines.pki.set_issuers`
+
+.. code:: python
+
+	import hvac
+	client = hvac.Client()
+
+        issuer_set_response = client.secrets.pki.set_issuers({
+                'default': 'my_issuer'
+        })
+
 Update Issuer
 -------------
 

--- a/hvac/api/secrets_engines/pki.py
+++ b/hvac/api/secrets_engines/pki.py
@@ -799,7 +799,21 @@ class Pki(VaultApiBase):
         )
 
     def set_issuers(self, params, mount_point=DEFAULT_MOUNT_POINT):
-        """Set issuers configuration"""
+        """Set issuers configuration.
+
+        Configure the default issuer.
+
+        Supported methods:
+
+            POST: /{mount_point}/config/issuers. Produces: 200 application/json
+
+        :param mount_point: The "path" the method/backend was mounted on.
+        :type mount_point: str | unicode
+        :param params: Dictionary with parameters.
+        :type params: dict
+        :return: The JSON response of the request.
+        :rtype: requests.Response
+        """
         api_path = utils.format_url(
             "/v1/{mount_point}/config/issuers", mount_point=mount_point
         )

--- a/hvac/api/secrets_engines/pki.py
+++ b/hvac/api/secrets_engines/pki.py
@@ -798,6 +798,16 @@ class Pki(VaultApiBase):
             url=api_path,
         )
 
+    def set_issuers(self, params, mount_point=DEFAULT_MOUNT_POINT):
+        """Set issuers configuration"""
+        api_path = utils.format_url(
+            "/v1/{mount_point}/config/issuers", mount_point=mount_point
+        )
+        return self._adapter.post(
+            url=api_path,
+            json=params
+        )
+
     def update_issuer(
         self, issuer_ref, extra_params=None, mount_point=DEFAULT_MOUNT_POINT
     ):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hvac"
-version = "2.3.0"
+version = "2.4.0"
 description = "HashiCorp Vault API client"
 readme = "README.md"
 authors = [

--- a/tests/integration_tests/api/secrets_engines/test_pki.py
+++ b/tests/integration_tests/api/secrets_engines/test_pki.py
@@ -729,6 +729,27 @@ class TestPki(HvacIntegrationTestCase, TestCase):
 
         self.assertIn("keys", pki_list_response["data"].keys())
 
+    # Set issuers
+    @skipIf(utils.vault_version_lt("1.11.0"), reason="Support added in version 1.11.0.")
+    def test_set_issuers(self):
+
+        pki_list_response = self.client.secrets.pki.list_issuers(
+            mount_point=self.TEST_MOUNT_POINT
+        )
+
+        logging.debug("pki_list_response: %s" % pki_list_response)
+
+        pki_set_response = self.client.secrets.pki.set_issuers(
+            {
+                'default': pki_list_response["data"]["keys"][0]
+            },
+            mount_point=self.TEST_MOUNT_POINT,
+        )
+
+        logging.debug("pki_set_response: %s" % pki_set_response)
+
+        self.assertIn("default", pki_set_response["data"].keys())
+
     # Update issuer
     @skipIf(utils.vault_version_lt("1.11.0"), reason="Support added in version 1.11.0.")
     def test_update_issuer(self):


### PR DESCRIPTION
Add the missing method `hvac.api.secrets_engines.pki.set_issuers()` to configure the default PKI issuer.

Fixes #1197