### PR TITLE
Add support for password policy API

### DIFF
--- a/docs/usage/system_backend/passwordpolicy.rst
+++ b/docs/usage/system_backend/passwordpolicy.rst
@@ -1,0 +1,89 @@
+Policies
+========
+
+.. contents::
+   :local:
+   :depth: 1
+
+.. testsetup:: sys_policies
+
+    client.sys.enable_secrets_engine(
+    backend_type="kv",
+    path="test",
+    )
+
+Read ACL Policy
+---------------
+
+.. automethod:: hvac.api.system_backend.PasswordPolicy.read_acl_policy
+   :noindex:
+
+Examples
+````````
+
+.. testcode:: sys_policies
+
+    import hvac
+    client = hvac.Client(url="https://127.0.0.1:8200")
+
+    # Create PasswordPolicy Policy
+    client.sys.create_or_update_pp_policy(
+            name="test-passwd-policy", policy='length=14\nrule \"charset\" {\"charset\" = \"abcdefght\"\nmin-char=4\n}',
+        )
+
+    client.sys.read_pp_policy("test-passwd-policy")
+
+Create or Update Password Policy
+---------------------------
+
+.. automethod:: hvac.api.system_backend.PasswordPolicy.create_or_update_pp_policy
+   :noindex:
+
+.. testcode:: sys_policies
+
+    import hvac
+    client = hvac.Client(url="https://127.0.0.1:8200")
+
+    # Create Password Policy
+    client.sys.create_or_update_pp_policy(
+            name="test-password-policy", policy='length=14\nrule \"charset\" {\"charset\" = \"abcdefght\"\nmin-char=4\n}',
+        )
+
+    # Update Password Policy Policy
+    client.sys.create_or_update_pp_policy(
+            name="test-password-policy", policy='length=14\nrule \"charset\" {\"charset\" = \"abcdefght\"\nmin-char=4\n}',
+        )
+
+List Password Policies
+-----------------
+
+.. automethod:: hvac.api.system_backend.PasswordPolicy.list_pp_policies
+   :noindex:
+
+Examples
+````````
+
+.. testcode:: sys_policies
+
+    import hvac
+    client = hvac.Client(url="https://127.0.0.1:8200")
+    
+    client.sys.create_or_update_pp_policy(
+            name="test-password-policy", policy='length=14\nrule \"charset\" {\"charset\" = \"abcdefght\"\nmin-char=4\n}',
+        )
+    client.sys.list_pp_policies()
+
+Delete Password Policy
+-----------------
+
+.. automethod:: hvac.api.system_backend.PasswordPolicy.delete_pp_policy
+   :noindex:
+
+Examples
+````````
+
+.. testcode:: sys_policies
+
+    import hvac
+    client = hvac.Client(url="https://127.0.0.1:8200")
+    client.sys.delete_pp_policy("test-password-policy")

--- a/hvac/api/system_backend/__init__.py
+++ b/hvac/api/system_backend/__init__.py
@@ -13,12 +13,14 @@ from hvac.api.system_backend.mount import Mount
 from hvac.api.system_backend.namespace import Namespace
 from hvac.api.system_backend.policies import Policies
 from hvac.api.system_backend.policy import Policy
+from hvac.api.system_backend.passwordpolicy import PasswdPolicy
 from hvac.api.system_backend.quota import Quota
 from hvac.api.system_backend.raft import Raft
 from hvac.api.system_backend.seal import Seal
 from hvac.api.system_backend.system_backend_mixin import SystemBackendMixin
 from hvac.api.system_backend.wrapping import Wrapping
 from hvac.api.vault_api_category import VaultApiCategory
+
 
 __all__ = (
     "Audit",
@@ -32,6 +34,7 @@ __all__ = (
     "Mount",
     "Namespace",
     "Policies",
+    "PasswdPolicy",
     "Policy",
     "Quota",
     "Raft",
@@ -58,6 +61,7 @@ class SystemBackend(
     Mount,
     Namespace,
     Policies,
+    PasswdPolicy,
     Policy,
     Quota,
     Raft,
@@ -76,6 +80,7 @@ class SystemBackend(
         Mount,
         Namespace,
         Policies,
+        PasswdPolicy,
         Policy,
         Quota,
         Raft,

--- a/hvac/api/system_backend/passwordpolicy.py
+++ b/hvac/api/system_backend/passwordpolicy.py
@@ -1,0 +1,88 @@
+import json
+from hvac import utils
+from hvac.api.system_backend.system_backend_mixin import SystemBackendMixin
+class PasswdPolicy(SystemBackendMixin):
+    """
+    HVAC does not have password policy so written a module based on ACL polcy.
+    """    
+    def list_pp_policies(self):
+        """
+        List all configures password policies. 
+
+        Supported Methos:
+            GET: /sys/policies/password?list=true  Produces 200 Application/json
+
+            :return: The Json response of the request
+            :rtype: dict
+            
+        """
+        api_path="/sys/policies/password?list=true"
+        return self._adaper.get(
+            url=api_path,
+        )
+    
+    def get_pp_policies(self,name):
+        """
+        Retrive the password policy for the names policy
+
+        supported method: GET /sys/policies/password/:name Produces 200 Application/json
+
+            :return: The Json response of the request
+            :rtype: dict
+            
+        """
+        api_path = utils.format_url("/sys/policies/password/{name}",name=name)
+        return self._adaper.get(
+            url=api_path,
+        )
+
+    def create_or_update_pp_policy(self,name,policy,pretty_print=True):
+        """Add a new or update an existing policy.
+
+        Once a policy is updated, it takes effect immediately to all associated users.
+
+        Supported methods:
+            PUT: /sys/policies/password/{name}. Produces: 204 (empty body)
+
+        :param name: Specifies the name of the password policy to create.
+        :type name: str | unicode
+        :param policy: Specifies the policy document.
+        :type policy: str | unicode | dict
+        :param pretty_print: If True, and provided a dict for the policy argument, send the policy JSON to Vault with
+            "pretty" formatting.
+        :type pretty_print: bool
+        :return: The response of the request.
+        :rtype: requests.Response
+        """
+        if isinstance(policy,dict):
+            if pretty_print:
+                policy = json.dumps(policy,indent=4,sort_keys=4)
+            else:
+                policy = json.dumps(policy)                
+        params = {
+            "policy": policy
+        }
+        api_path = utils.format_url(f"/v1/sys/policies/password/{name}", name=name)
+        return self._adapter.put(
+            url=api_path,
+            json=params,
+        )
+    
+    def delete_pp_policy(self,name):
+        """
+        Delete the password policy with the given name.
+
+        This will immediately affect all users associated with this policy.
+
+        Supported methods:
+            DELETE: /sys/policies/password/{name}. Produces: 204 (empty body)
+
+        :param name: Specifies the name of the password policy to delete.
+        :type name: str | unicode
+        :return: The response of the request.
+        :rtype: requests.Response
+        """
+        api_path = utils.format_url("/v1/sys/policies/password/{name}", name=name)
+        return self._adapter.delete(
+            url=api_path,
+        )       


### PR DESCRIPTION
Hello for my work I need to interact with password policy of Hashi Vault as documented in https://developer.hashicorp.com/vault/api-docs/system/policies-password.   This customize the password generator capability of Hashi Vault.

The module is Just like ACL policy today we have.

Below are the files changes.
Created 2 files
      docs/usage/system_backend/passwordpolicy.rst   - Documentation for the password policy usage.
      hvac/api/system_backend/passwordpolicy.py     - Actual code to manage the password policy
Updated one file
     hvac/api/system_backend/passwordpolicy.py
                    Added PasswordPolicy  to link the PasswordPolicy to sys backedn.


