### PR TITLE
Add get_leader method to get the leader node from a list of vault urls

### DIFF
--- a/docs/usage/system_backend/leader.rst
+++ b/docs/usage/system_backend/leader.rst
@@ -54,7 +54,7 @@ Get Leader
 Examples
 ````````
 
-.. testcode:: sys_get_leader
+.. code:: python
 
     import hvac
     client = hvac.Client(cluster_url=['https://127.0.0.1:8200', 'https://127.0.0.1:8202','https://127.0.0.1:8204'])
@@ -63,7 +63,5 @@ Examples
     print('Leader: %s' % leader)
 
 Example output:
-
-.. testoutput:: sys_get_leader
 
     Leader is: https://127.0.0.1:8200

--- a/docs/usage/system_backend/leader.rst
+++ b/docs/usage/system_backend/leader.rst
@@ -44,3 +44,26 @@ Examples
 
     client = hvac.Client(url='https://127.0.0.1:8200')
     client.sys.step_down()
+
+Get Leader
+------------------
+
+.. automethod:: hvac.api.system_backend.Leader.get_leader
+   :noindex:
+
+Examples
+````````
+
+.. testcode:: sys_get_leader
+
+    import hvac
+    client = hvac.Client(cluster_url=['https://127.0.0.1:8200', 'https://127.0.0.1:8202','https://127.0.0.1:8204'])
+
+    leader = client.sys.get_leader()
+    print('Leader: %s' % leader)
+
+Example output:
+
+.. testoutput:: sys_get_leader
+
+    Leader is: https://127.0.0.1:8200

--- a/hvac/adapters.py
+++ b/hvac/adapters.py
@@ -28,6 +28,7 @@ class Adapter(metaclass=ABCMeta):
 
         return cls(
             base_uri=adapter.base_uri,
+            cluster_uri=adapter.cluster_uri,
             token=adapter.token,
             cert=adapter._kwargs.get("cert"),
             verify=adapter._kwargs.get("verify"),
@@ -44,6 +45,7 @@ class Adapter(metaclass=ABCMeta):
     def __init__(
         self,
         base_uri=DEFAULT_URL,
+        cluster_uri=[],
         token=None,
         cert=None,
         verify=True,
@@ -60,6 +62,8 @@ class Adapter(metaclass=ABCMeta):
 
         :param base_uri: Base URL for the Vault instance being addressed.
         :type base_uri: str
+        :param cluster_uri: List of URLs for the Vault cluster being addressed.
+        :type cluster_uri: list
         :param token: Authentication token to include in requests sent to Vault.
         :type token: str
         :param cert: Certificates for use in requests sent to the Vault instance. This should be a tuple with the
@@ -101,6 +105,7 @@ class Adapter(metaclass=ABCMeta):
                 proxies = session.proxies
 
         self.base_uri = base_uri
+        self.cluster_uri = cluster_uri
         self.token = token
         self.namespace = namespace
         self.session = session

--- a/hvac/exceptions.py
+++ b/hvac/exceptions.py
@@ -83,3 +83,7 @@ class BadGateway(VaultError):
 
 class ParamValidationError(VaultError):
     pass
+
+
+class LeaderNotFoundError(Exception):
+    pass

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -69,6 +69,7 @@ class Client:
     def __init__(
         self,
         url=None,
+        cluster_url=None,
         token=None,
         cert=None,
         verify=None,
@@ -84,6 +85,8 @@ class Client:
 
         :param url: Base URL for the Vault instance being addressed.
         :type url: str
+        :param cluster_url: List of Vault cluster URIs.
+        :type cluster_url: list
         :param token: Authentication token to include in requests sent to Vault.
         :type token: str
         :param cert: Certificates for use in requests sent to the Vault instance. This should be a tuple with the
@@ -112,6 +115,7 @@ class Client:
 
         token = token if token is not None else utils.get_token_from_env()
         url = url if url else os.getenv("VAULT_ADDR", DEFAULT_URL)
+        cluster_url = cluster_url if cluster_url else []
 
         if cert is None and VAULT_CLIENT_CERT:
             cert = (
@@ -135,6 +139,7 @@ class Client:
 
         self._adapter = adapter(
             base_uri=url,
+            cluster_uri=cluster_url,
             token=token,
             cert=cert,
             verify=verify,
@@ -175,6 +180,14 @@ class Client:
     @url.setter
     def url(self, url):
         self._adapter.base_uri = url
+
+    @property
+    def cluster_url(self):
+        return self._adapter.cluster_uri
+
+    @cluster_url.setter
+    def cluster_url(self, cluster_url):
+        self._adapter.cluster_uri = cluster_url
 
     @property
     def token(self):

--- a/tests/integration_tests/api/system_backend/test_get_leader.py
+++ b/tests/integration_tests/api/system_backend/test_get_leader.py
@@ -1,10 +1,7 @@
-import logging
 from unittest import TestCase
 
-from parameterized import parameterized, param
 from tests.utils import create_client
 from tests.utils.hvac_integration_test_case import HvacIntegrationTestCase
-from hvac import Client
 
 
 class TestGetLeader(HvacIntegrationTestCase, TestCase):

--- a/tests/integration_tests/api/system_backend/test_get_leader.py
+++ b/tests/integration_tests/api/system_backend/test_get_leader.py
@@ -1,0 +1,56 @@
+import logging
+from unittest import TestCase
+
+from parameterized import parameterized, param
+from tests.utils import create_client
+from tests.utils.hvac_integration_test_case import HvacIntegrationTestCase
+from hvac import Client
+
+
+class TestGetLeader(HvacIntegrationTestCase, TestCase):
+    enable_vault_ha = True
+
+    def tearDown(self):
+        # If one of our test cases left the Vault cluster sealed, unseal it here.
+        self.manager.unseal()
+        super().tearDown()
+
+    def test_get_leader(
+        self,
+        use_standby_node=True,
+        seal_first=False,
+        ha_required=True
+    ):
+        """Test the system backend class's "get_leader" method.
+
+        :param use_standby_node: If True, send the request to a standby Vault node address
+        :type use_standby_node: bool
+        :param seal_first: If True, seal the Vault node(s) before running the test cases.
+        :type seal_first: bool
+        :param ha_required: If True, skip the test case when consul / a HA Vault integration cluster is unavailable.
+        :type ha_required: bool
+        """
+        if ha_required and not self.enable_vault_ha:
+            # Conditional to allow folks to run this test class without requiring consul to be installed locally.
+            self.skipTest("Skipping test case, Vault HA required but not available.")
+        if seal_first:
+            # Standby nodes can't be sealed directly.
+            # I.e.: "vault cannot seal when in standby mode; please restart instead"
+            self.manager.restart_vault_cluster()
+
+        # Set a fake Vault address to ensure that the client is forced to use the address we provide.
+        fake_vault_addr = "https://does.not.exist:8200"
+        # Grab a Vault node address for our desired standby status and create a one-off client configured for that address.
+        standby_vault_addr = self.get_vault_addr_by_standby_status(
+            standby_status=True
+        )
+
+        leader_vault_addr = self.get_vault_addr_by_standby_status(
+            standby_status=False
+        )
+
+        cluster_url = [fake_vault_addr, standby_vault_addr, leader_vault_addr]
+        client = create_client(url=standby_vault_addr, cluster_url=cluster_url)
+        leader = client.sys.get_leader()
+
+        self.assertEqual(first=leader_vault_addr, second=leader)

--- a/tests/integration_tests/api/system_backend/test_get_leader.py
+++ b/tests/integration_tests/api/system_backend/test_get_leader.py
@@ -16,10 +16,7 @@ class TestGetLeader(HvacIntegrationTestCase, TestCase):
         super().tearDown()
 
     def test_get_leader(
-        self,
-        use_standby_node=True,
-        seal_first=False,
-        ha_required=True
+        self, use_standby_node=True, seal_first=False, ha_required=True
     ):
         """Test the system backend class's "get_leader" method.
 
@@ -41,13 +38,9 @@ class TestGetLeader(HvacIntegrationTestCase, TestCase):
         # Set a fake Vault address to ensure that the client is forced to use the address we provide.
         fake_vault_addr = "https://does.not.exist:8200"
         # Grab a Vault node address for our desired standby status and create a one-off client configured for that address.
-        standby_vault_addr = self.get_vault_addr_by_standby_status(
-            standby_status=True
-        )
+        standby_vault_addr = self.get_vault_addr_by_standby_status(standby_status=True)
 
-        leader_vault_addr = self.get_vault_addr_by_standby_status(
-            standby_status=False
-        )
+        leader_vault_addr = self.get_vault_addr_by_standby_status(standby_status=False)
 
         cluster_url = [fake_vault_addr, standby_vault_addr, leader_vault_addr]
         client = create_client(url=standby_vault_addr, cluster_url=cluster_url)


### PR DESCRIPTION
This PR fixes #552 by adding a simple, client-side way to handle high availability with Vault. Basically, it figures out the leader node from a list of Vault URLs, so smaller organizations don’t have to worry about setting up (or paying for) a separate load balancer.

This PR is blocked by #1209 , the integration test will always fail with `Read time out` message when using consul 1.20.2 and 1.20.1