### PR TITLE
Add skip_import_rotation parameter to LDAP secret engine

### DIFF
--- a/docs/usage/secrets_engines/ldap.rst
+++ b/docs/usage/secrets_engines/ldap.rst
@@ -27,7 +27,8 @@ Source reference: :py:meth:`hvac.api.secrets_engines.ldap.configure`
         userdn='cn=Users,dn=domain,dn=fqdn',
         upndomain='domain.fqdn',
         userattr="cn",
-        schema="openldap"
+        schema="openldap",
+        skip_import_rotation=False
     )
     print(config_response)
 
@@ -84,7 +85,8 @@ Source reference: :py:meth:`hvac.api.secrets_engines.ldap.create_or_update_stati
         name='hvac-role',
         username='sql-service-account',
         dn='cn=sql-service-account,dc=petshop,dc=com',
-        rotation_period="60s")
+        rotation_period="60s"
+        skip_import_rotation=False)
 
 
 Read Static Role

--- a/hvac/api/secrets_engines/ldap.py
+++ b/hvac/api/secrets_engines/ldap.py
@@ -29,6 +29,7 @@ class Ldap(VaultApiBase):
         certificate=None,
         client_tls_cert=None,
         client_tls_key=None,
+        skip_import_rotation=False,
         mount_point=DEFAULT_MOUNT_POINT,
     ):
         """Configure shared information for the ldap secrets engine.
@@ -64,6 +65,9 @@ class Ldap(VaultApiBase):
         :type client_tls_cert: str | unicode
         :param client_tls_key: Client key to provide to the LDAP server, must be x509 PEM encoded.
         :type client_tls_key: str | unicode
+        :param skip_import_rotation: If true, Vault will not rotate the pre-existing password of the associated LDAP entry. 
+            Note: This means that Vault will not be able to supply the password to GET requests until the password is rotated.
+        :type skip_import_rotation: bool
         :param mount_point: The "path" the method/backend was mounted on.
         :type mount_point: str | unicode
         :return: The response of the request.
@@ -86,6 +90,7 @@ class Ldap(VaultApiBase):
                 "certificate": certificate,
                 "client_tls_cert": client_tls_cert,
                 "client_tls_key": client_tls_key,
+                "skip_import_rotation": skip_import_rotation
             }
         )
 
@@ -135,6 +140,7 @@ class Ldap(VaultApiBase):
         username=None,
         dn=None,
         rotation_period=None,
+        skip_import_rotation=False,
         mount_point=DEFAULT_MOUNT_POINT,
     ):
         """This endpoint creates or updates the ldap static role definition.
@@ -151,13 +157,16 @@ class Ldap(VaultApiBase):
             This is provided as a string duration with a time suffix like "30s" or "1h" or as seconds.
             If not provided, the default Vault rotation_period is used.
         :type rotation_period: str | unicode
+        :param skip_import_rotation: If true, Vault will not rotate the pre-existing password of the associated LDAP entry. 
+            Note: This means that Vault will not be able to supply the password to GET requests until the password is rotated.
+        :type skip_import_rotation: bool
         :param mount_point: The "path" the method/backend was mounted on.
         :type mount_point: str | unicode
         :return: The response of the request.
         :rtype: requests.Response
         """
         api_path = utils.format_url("/v1/{}/static-role/{}", mount_point, name)
-        params = {"username": username, "rotation_period": rotation_period}
+        params = {"username": username, "rotation_period": rotation_period, "skip_import_rotation": skip_import_rotation}
         params.update(utils.remove_nones({"dn": dn}))
         return self._adapter.post(
             url=api_path,


### PR DESCRIPTION
2 endpoints in Vault have a skip_import_roation flag that can be set on them in the LDAP engine

- [POST /ldap/static-role:role_name](https://developer.hashicorp.com/vault/api-docs/secret/ldap#static-roles:~:text=skip_import_rotation%20(boolean%3A%20false,both%20are%20set.)
- [POST /ldap/config](https://developer.hashicorp.com/vault/api-docs/secret/ldap#configuration-management:~:text=skip_static_role_import_rotation%20(bool%3A%20false)%20%2D%20The%20default%20value%20to%20use%20for%20skip_import_rotation%20when%20creating%20static%20roles.%20This%20field%20can%20be%20overridden%20on%20an%20individual%20role%20level%20during%20role%20creation.%20See%20the%20static%20roles%20section%20for%20more%20detailed%20information%20and%20caveats.)

Update the configure function and create_or_update_static_role that are apart of the api.secrets_engine.ldap class to reflect these parameters. Defaulting to False as vault defaults these to false.