### PR TITLE
Update jwt.py

### DIFF
--- a/hvac/api/auth_methods/jwt.py
+++ b/hvac/api/auth_methods/jwt.py
@@ -406,11 +406,6 @@ class JWT(VaultApiBase):
         :return: The response of the _callback request.
         :rtype: requests.Response
         """
-        params = {
-            "state": state,
-            "nonce": nonce,
-            "code": code,
-        }
         api_path = utils.format_url(
             "/v1/auth/{path}/oidc/callback?state={state}&nonce={nonce}&code={code}",
             path=self.resolve_path(path),
@@ -420,7 +415,6 @@ class JWT(VaultApiBase):
         )
         return self._adapter.get(
             url=api_path,
-            json=params,
         )
 
     def jwt_login(self, role, jwt, use_token=True, path=None):


### PR DESCRIPTION
The GET Call have all data in Query string its not needed to send a body with a GET request, this behaviour is also forbidden by some Loadbalancers, e.g. google applicaiton loadbalancer. GET Request shouldn't have any data in body.