### PR TITLE
Fix a typo in read_secret_version warning message

### DIFF
--- a/hvac/api/secrets_engines/kv_v2.py
+++ b/hvac/api/secrets_engines/kv_v2.py
@@ -132,7 +132,7 @@ class KvV2(VaultApiBase):
         if raise_on_deleted_version is None:
             msg = (
                 "The raise_on_deleted_version parameter will change its default value to False in hvac v3.0.0. "
-                "The current default of True will presere previous behavior. "
+                "The current default of True will preserve previous behavior. "
                 "To use the old behavior with no warning, explicitly set this value to True. "
                 "See https://github.com/hvac/hvac/pull/907"
             )


### PR DESCRIPTION
Fixing a typo for the word 'presere' in the warning message shown for read_secret_version function.