### PR TITLE
Validate that session argument is a session object (#499)

### DIFF
--- a/hvac/adapters.py
+++ b/hvac/adapters.py
@@ -7,7 +7,7 @@ from abc import ABCMeta, abstractmethod
 import requests
 import requests.exceptions
 
-from hvac import utils
+from hvac import exceptions, utils
 from hvac.constants.client import DEFAULT_URL
 
 
@@ -90,6 +90,13 @@ class Adapter(metaclass=ABCMeta):
         if not session:
             session = requests.Session()
             session.cert, session.verify, session.proxies = cert, verify, proxies
+        elif not isinstance(session, requests.Session):
+            raise exceptions.ParamValidationError(
+                "unsupported session type argument provided {arg}, supported types: {supported_types}".format(
+                    arg=session,
+                    supported_types=requests.Session,
+                )
+            )
         # fix for issue 991 using session verify if set
         else:
             if session.verify:

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -2,13 +2,14 @@ import pytest
 
 from unittest import mock
 
+import requests
 from hvac.adapters import Adapter
 
 
 class MockAdapter(Adapter):
     def __init__(self, *args, **kwargs):
         if "session" not in kwargs:
-            kwargs["session"] = mock.MagicMock()
+            kwargs["session"] = mock.MagicMock(spec_set=requests.Session())
         super().__init__(*args, **kwargs)
 
     def request(self, *args, **kwargs):

--- a/tests/unit_tests/test_adapters.py
+++ b/tests/unit_tests/test_adapters.py
@@ -319,3 +319,10 @@ class TestAdapterVerify(TestCase):
             c = Client()
         assert c._adapter.session.proxies == proxies
         assert c._adapter.session
+
+    def test_session_object_validation(self):
+        s = {"hello": "world"}
+        with self.assertRaises(exceptions.ParamValidationError) as context:
+            c = Client(session=s)
+
+        self.assertTrue("unsupported session type argument provided" in str(context.exception))


### PR DESCRIPTION
This PR is for Issue #499 and adds both a check that the session parameter is of the correct object and a test case that the correct exception is thrown when a non-session object is passed in. It also updates the test suite to ensure that the session mocks are of the correct type.