### PR TITLE
Add support for setting lease count through the API

### DIFF
--- a/docs/usage/system_backend/quota.rst
+++ b/docs/usage/system_backend/quota.rst
@@ -40,11 +40,14 @@ Create or Update Quota
     import hvac
     client = hvac.Client(url='https://127.0.0.1:8200')
 
-    # Create file quota
+    # Create rate quota
     client.sys.create_or_update_quota(name="quota1", rate=100.0)
 
     # Update quota that already exists
     client.sys.create_or_update_quota(name="quota1", rate=101.0)
+
+    # Create lease count quota, inheritable over the namespace
+    client.sys.create_or_update_lease_quota(name="quota2", max_leases=1000, path="mynamespace/", inheritable=True)
 
 List Quotas
 ---------------
@@ -80,3 +83,4 @@ Examples
     client = hvac.Client(url='https://127.0.0.1:8200')
     
     client.sys.delete_quota(name="quota1")
+    client.sys.delete_lease_quota(name="quota2")

--- a/tests/integration_tests/api/system_backend/test_quota.py
+++ b/tests/integration_tests/api/system_backend/test_quota.py
@@ -56,7 +56,7 @@ class TestQuota(HvacIntegrationTestCase, TestCase):
             )
 
     @skipIf(
-        utils.vault_version_lt("1.12.0") or utils.vault_version_ge("1.15.0"),
+        utils.vault_version_lt("1.12.0") or (not utils.is_enterprise() and utils.vault_version_ge("1.15.0")),
         "Newer version of quota JSON changes path structure and adds role. Route only works on enterprise from 1.15 onwards",
     )
     def test_create_quota(self):
@@ -138,7 +138,7 @@ class TestQuota(HvacIntegrationTestCase, TestCase):
         )
 
     @skipIf(
-        utils.vault_version_lt("1.12.0") or utils.vault_version_ge("1.15.0"),
+        utils.vault_version_lt("1.12.0") or (not utils.is_enterprise() and utils.vault_version_ge("1.15.0")),
         "Newer version of quota JSON changes path structure and adds role. Route only works on enterprise from 1.15 onwards",
     )
     def test_update_quota(self):
@@ -217,7 +217,7 @@ class TestQuota(HvacIntegrationTestCase, TestCase):
         )
 
     @skipIf(
-        utils.vault_version_lt("1.12.0") or utils.vault_version_ge("1.15.0"),
+        utils.vault_version_lt("1.12.0") or (not utils.is_enterprise() and utils.vault_version_ge("1.15.0")),
         "Newer version of quota JSON changes path structure and adds role. Route only works on enterprise from 1.15 onwards",
     )
     def test_read_quota(self):
@@ -255,7 +255,7 @@ class TestQuota(HvacIntegrationTestCase, TestCase):
         )
 
     @skipIf(
-        utils.vault_version_lt("1.12.0") or utils.vault_version_ge("1.15.0"),
+        utils.vault_version_lt("1.12.0") or (not utils.is_enterprise() and utils.vault_version_ge("1.15.0")),
         "Newer version of quota JSON changes path structure and adds role. Route only works on enterprise from 1.15 onwards",
     )
     def test_list_quotas(self):
@@ -324,7 +324,7 @@ class TestQuota(HvacIntegrationTestCase, TestCase):
             )
 
     @skipIf(
-        utils.vault_version_lt("1.12.0") or utils.vault_version_ge("1.15.0"),
+        utils.vault_version_lt("1.12.0") or (not utils.is_enterprise() and utils.vault_version_ge("1.15.0")),
         "Newer version of quota JSON changes path structure and adds role. Route only works on enterprise from 1.15 onwards",
     )
     def test_delete_quota(self):


### PR DESCRIPTION
Currently whilst there is a `type` parameter for `create_or_update_quota` it's unused in the path and sent as data to the rate limit endpoint (https://developer.hashicorp.com/vault/api-docs/system/rate-limit-quotas) which isn't a valid parameter. Hence it's also unused by the tests. This removes that parameter that could never have worked in the first place and instead uses a new method to fulfil the lease quotas endpoint (as it has separate parameters)