### PR TITLE
Add read_namespace and patch_namespace to sys/namespaces

### DIFF
--- a/docs/usage/system_backend/namespace.rst
+++ b/docs/usage/system_backend/namespace.rst
@@ -60,6 +60,42 @@ Example output:
     {"request_id":"<redacted>","lease_id":"","renewable":false,"lease_duration":0,"data":{"key_info":{"testns/":{"id":"ekiUn","path":"testns/"}},"keys":["testns/"]},"wrap_info":null,"warnings":null,"auth":null}
 
 
+Read Namespace
+--------------
+
+.. automethod:: hvac.api.system_backend.Namespace.read_namespace
+   :noindex:
+
+Examples
+````````
+
+.. testcode:: sys_namespace
+    :skipif: not test_utils.is_enterprise()
+
+    import hvac
+    client = hvac.Client(url='https://127.0.0.1:8200')
+
+    client.sys.read_namespace(path='testns')
+
+Patch Namespace
+---------------
+
+.. automethod:: hvac.api.system_backend.Namespace.patch_namespace
+   :noindex:
+
+Examples
+````````
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client(url='https://127.0.0.1:8200')
+
+    client.sys.patch_namespace(
+        path='testns',
+        custom_metadata={'env': 'production'},
+    )
+
 Delete Namespace
 ----------------
 

--- a/hvac/api/system_backend/namespace.py
+++ b/hvac/api/system_backend/namespace.py
@@ -9,6 +9,8 @@ class Namespace(SystemBackendMixin):
         Supported methods:
             POST: /sys/namespaces/{path}. Produces: 200 application/json
 
+        :param path: Path of the namespace to create.
+        :type path: str | unicode
         :return: The response of the request.
         :rtype: requests.Response
         """
@@ -31,12 +33,58 @@ class Namespace(SystemBackendMixin):
             url=api_path,
         )
 
+    def read_namespace(self, path):
+        """Read the namespace at the given path.
+
+        Supported methods:
+            GET: /sys/namespaces/{path}. Produces: 200 application/json
+
+        :param path: Path of the namespace to read.
+        :type path: str | unicode
+        :return: The JSON response of the request.
+        :rtype: dict
+        """
+        api_path = utils.format_url("/v1/sys/namespaces/{path}", path=path)
+        return self._adapter.get(
+            url=api_path,
+        )
+
+    def patch_namespace(self, path, custom_metadata=None):
+        """Update an existing namespace at the given path.
+
+        If ``custom_metadata`` is omitted, Vault receives an empty patch and silently no-ops.
+
+        Supported methods:
+            PATCH: /sys/namespaces/{path}. Produces: 200 application/json
+
+        :param path: Path of the namespace to update.
+        :type path: str | unicode
+        :param custom_metadata: A map of arbitrary string-to-string valued user-provided metadata meant to describe the namespace.
+        :type custom_metadata: dict
+        :return: The JSON response of the request.
+        :rtype: dict
+        """
+        api_path = utils.format_url("/v1/sys/namespaces/{path}", path=path)
+        params = utils.remove_nones(
+            {
+                "custom_metadata": custom_metadata,
+            }
+        )
+        return self._adapter.request(
+            method="PATCH",
+            url=api_path,
+            json=params,
+            headers={"Content-Type": "application/merge-patch+json"},
+        )
+
     def delete_namespace(self, path):
         """Delete a namespaces. You cannot delete a namespace with existing child namespaces.
 
         Supported methods:
             DELETE: /sys/namespaces. Produces: 204 (empty body)
 
+        :param path: Path of the namespace to delete.
+        :type path: str | unicode
         :return: The response of the request.
         :rtype: requests.Response
         """

--- a/tests/integration_tests/api/system_backend/test_namespace.py
+++ b/tests/integration_tests/api/system_backend/test_namespace.py
@@ -7,6 +7,43 @@ from tests.utils.hvac_integration_test_case import HvacIntegrationTestCase
 
 @skipIf(not utils.is_enterprise(), "Namespaces only supported with Enterprise Vault")
 class TestNamespace(HvacIntegrationTestCase, TestCase):
+    def test_read_namespace(self):
+        test_namespace_name = "python-hvac-read"
+        self.client.sys.create_namespace(path=test_namespace_name)
+
+        read_namespace_response = self.client.sys.read_namespace(
+            path=test_namespace_name
+        )
+        logging.debug("read_namespace_response: %s" % read_namespace_response)
+        self.assertEqual(
+            first="%s/" % test_namespace_name,
+            second=read_namespace_response["data"]["path"],
+        )
+
+        self.client.sys.delete_namespace(path=test_namespace_name)
+
+    @skipIf(
+        utils.vault_version_lt("1.12.0"),
+        "PATCH /sys/namespaces support added in Vault 1.12.0",
+    )
+    def test_patch_namespace(self):
+        test_namespace_name = "python-hvac-patch"
+        self.client.sys.create_namespace(path=test_namespace_name)
+
+        self.client.sys.patch_namespace(
+            path=test_namespace_name,
+            custom_metadata={"env": "test"},
+        )
+
+        read_response = self.client.sys.read_namespace(path=test_namespace_name)
+        logging.debug("read_response: %s" % read_response)
+        self.assertEqual(
+            first={"env": "test"},
+            second=read_response["data"]["custom_metadata"],
+        )
+
+        self.client.sys.delete_namespace(path=test_namespace_name)
+
     def test_list_namespaces(self):
         test_namespace_name = "python-hvac"
         create_namespace_response = self.client.sys.create_namespace(


### PR DESCRIPTION
Closes #1242

## What this adds

- `read_namespace(path)` — `GET /v1/sys/namespaces/{path}` to retrieve a single namespace's metadata
- `patch_namespace(path, custom_metadata=None)` — `PATCH /v1/sys/namespaces/{path}` to update namespace custom metadata in place

Both follow the existing patterns in `namespace.py` and `system_backend_mixin.py`. Integration tests are included under `tests/integration_tests/api/system_backend/test_namespace.py` with an `@skipIf(not is_enterprise(), ...)` guard, matching the existing test style.

The diff is intentionally minimal — no docs, no changelog, no unrelated changes. Happy to add anything the project needs or adjust based on feedback. Thank you for your time reviewing this!