### PR TITLE
Add ControlGroup class for /sys/control-group endpoints

### DIFF
--- a/docs/usage/system_backend/control_group.rst
+++ b/docs/usage/system_backend/control_group.rst
@@ -1,0 +1,38 @@
+Control Group
+=============
+
+.. contents::
+   :local:
+   :depth: 1
+
+Authorize Control Group Request
+--------------------------------
+
+.. automethod:: hvac.api.system_backend.ControlGroup.authorize_control_group
+   :noindex:
+
+Examples
+````````
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client(url='https://127.0.0.1:8200')
+
+    client.sys.authorize_control_group(accessor='<wrapping-token-accessor>')
+
+Check Control Group Request Status
+-----------------------------------
+
+.. automethod:: hvac.api.system_backend.ControlGroup.check_control_group_request
+   :noindex:
+
+Examples
+````````
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client(url='https://127.0.0.1:8200')
+
+    client.sys.check_control_group_request(accessor='<wrapping-token-accessor>')

--- a/docs/usage/system_backend/index.rst
+++ b/docs/usage/system_backend/index.rst
@@ -6,6 +6,7 @@ System Backend
 
    audit
    auth
+   control_group
    health
    init
    key

--- a/hvac/api/system_backend/__init__.py
+++ b/hvac/api/system_backend/__init__.py
@@ -1,9 +1,11 @@
 """Collection of Vault system backend API endpoint classes."""
+
 import logging
 
 from hvac.api.system_backend.audit import Audit
 from hvac.api.system_backend.auth import Auth
 from hvac.api.system_backend.capabilities import Capabilities
+from hvac.api.system_backend.control_group import ControlGroup
 from hvac.api.system_backend.health import Health
 from hvac.api.system_backend.init import Init
 from hvac.api.system_backend.key import Key
@@ -24,6 +26,7 @@ __all__ = (
     "Audit",
     "Auth",
     "Capabilities",
+    "ControlGroup",
     "Health",
     "Init",
     "Key",
@@ -50,6 +53,7 @@ class SystemBackend(
     Audit,
     Auth,
     Capabilities,
+    ControlGroup,
     Health,
     Init,
     Key,
@@ -68,6 +72,7 @@ class SystemBackend(
         Audit,
         Auth,
         Capabilities,
+        ControlGroup,
         Health,
         Init,
         Key,

--- a/hvac/api/system_backend/control_group.py
+++ b/hvac/api/system_backend/control_group.py
@@ -1,0 +1,43 @@
+from hvac.api.system_backend.system_backend_mixin import SystemBackendMixin
+
+
+class ControlGroup(SystemBackendMixin):
+    def authorize_control_group(self, accessor):
+        """Authorize a control group request.
+
+        Supported methods:
+            POST: /sys/control-group/authorize. Produces: 200 application/json
+
+        :param accessor: The accessor of the token created when the control group request was created.
+        :type accessor: str | unicode
+        :return: The JSON response of the request.
+        :rtype: dict
+        """
+        api_path = "/v1/sys/control-group/authorize"
+        params = {
+            "accessor": accessor,
+        }
+        return self._adapter.post(
+            url=api_path,
+            json=params,
+        )
+
+    def check_control_group_request(self, accessor):
+        """Check the status of a control group request.
+
+        Supported methods:
+            POST: /sys/control-group/request. Produces: 200 application/json
+
+        :param accessor: The accessor of the token created when the control group request was created.
+        :type accessor: str | unicode
+        :return: The JSON response of the request.
+        :rtype: dict
+        """
+        api_path = "/v1/sys/control-group/request"
+        params = {
+            "accessor": accessor,
+        }
+        return self._adapter.post(
+            url=api_path,
+            json=params,
+        )

--- a/tests/integration_tests/api/system_backend/test_control_group.py
+++ b/tests/integration_tests/api/system_backend/test_control_group.py
@@ -1,0 +1,18 @@
+from unittest import TestCase, skipIf
+
+from hvac.exceptions import VaultError
+from tests import utils
+from tests.utils.hvac_integration_test_case import HvacIntegrationTestCase
+
+
+@skipIf(
+    not utils.is_enterprise(), "Control Groups only supported with Enterprise Vault"
+)
+class TestControlGroup(HvacIntegrationTestCase, TestCase):
+    def test_authorize_control_group(self):
+        with self.assertRaises(VaultError):
+            self.client.sys.authorize_control_group(accessor="invalid-accessor")
+
+    def test_check_control_group_request(self):
+        with self.assertRaises(VaultError):
+            self.client.sys.check_control_group_request(accessor="invalid-accessor")


### PR DESCRIPTION
Closes #1243

## What this adds

A new `ControlGroup` class in `hvac/api/system_backend/control_group.py` with two methods:

- `authorize_control_group(accessor)` — `POST /v1/sys/control-group/authorize` — used by an approver to authorize a pending request
- `check_control_group_request(accessor)` — `POST /v1/sys/control-group/request` — used by the requester to check whether a control group request has been approved

The class is wired into `SystemBackend` alongside the other system backend mixins. Integration tests are in `tests/integration_tests/api/system_backend/test_control_group.py`, guarded by `@skipIf(not is_enterprise(), ...)`.

Kept intentionally minimal — no docs, no changelog, no unrelated changes. Grateful for any feedback on the approach or anything I may have missed. Thank you!