### PR TITLE
Add License class for /sys/license/status endpoint

### DIFF
--- a/docs/usage/system_backend/index.rst
+++ b/docs/usage/system_backend/index.rst
@@ -11,6 +11,7 @@ System Backend
    key
    leader
    lease
+   license
    mount
    namespace
    policies

--- a/docs/usage/system_backend/license.rst
+++ b/docs/usage/system_backend/license.rst
@@ -1,0 +1,22 @@
+License
+=======
+
+.. contents::
+   :local:
+   :depth: 1
+
+Read License Status
+-------------------
+
+.. automethod:: hvac.api.system_backend.License.read_license_status
+   :noindex:
+
+Examples
+````````
+
+.. code:: python
+
+    import hvac
+    client = hvac.Client(url='https://127.0.0.1:8200')
+
+    client.sys.read_license_status()

--- a/hvac/api/system_backend/__init__.py
+++ b/hvac/api/system_backend/__init__.py
@@ -1,4 +1,5 @@
 """Collection of Vault system backend API endpoint classes."""
+
 import logging
 
 from hvac.api.system_backend.audit import Audit
@@ -9,6 +10,7 @@ from hvac.api.system_backend.init import Init
 from hvac.api.system_backend.key import Key
 from hvac.api.system_backend.leader import Leader
 from hvac.api.system_backend.lease import Lease
+from hvac.api.system_backend.license import License
 from hvac.api.system_backend.mount import Mount
 from hvac.api.system_backend.namespace import Namespace
 from hvac.api.system_backend.policies import Policies
@@ -29,6 +31,7 @@ __all__ = (
     "Key",
     "Leader",
     "Lease",
+    "License",
     "Mount",
     "Namespace",
     "Policies",
@@ -55,6 +58,7 @@ class SystemBackend(
     Key,
     Leader,
     Lease,
+    License,
     Mount,
     Namespace,
     Policies,
@@ -73,6 +77,7 @@ class SystemBackend(
         Key,
         Leader,
         Lease,
+        License,
         Mount,
         Namespace,
         Policies,

--- a/hvac/api/system_backend/license.py
+++ b/hvac/api/system_backend/license.py
@@ -1,0 +1,17 @@
+from hvac.api.system_backend.system_backend_mixin import SystemBackendMixin
+
+
+class License(SystemBackendMixin):
+    def read_license_status(self):
+        """Read the status of the current Vault Enterprise license.
+
+        Supported methods:
+            GET: /sys/license/status. Produces: 200 application/json
+
+        :return: The JSON response of the request.
+        :rtype: dict
+        """
+        api_path = "/v1/sys/license/status"
+        return self._adapter.get(
+            url=api_path,
+        )

--- a/tests/integration_tests/api/system_backend/test_license.py
+++ b/tests/integration_tests/api/system_backend/test_license.py
@@ -1,0 +1,19 @@
+import logging
+from unittest import TestCase, skipIf
+
+from tests import utils
+from tests.utils.hvac_integration_test_case import HvacIntegrationTestCase
+
+
+@skipIf(
+    not utils.is_enterprise() or utils.vault_version_lt("1.10.0"),
+    "License status requires Enterprise Vault 1.10+",
+)
+class TestLicense(HvacIntegrationTestCase, TestCase):
+    def test_read_license_status(self):
+        read_license_status_response = self.client.sys.read_license_status()
+        logging.debug("read_license_status_response: %s" % read_license_status_response)
+        data = read_license_status_response.get("data", {})
+        self.assertIn("autoloaded_license", data)
+        license_info = data.get("license", {})
+        self.assertTrue(license_info.get("license_id"))


### PR DESCRIPTION
Closes #1244

## What this adds

A new `License` class in `hvac/api/system_backend/license.py` with one method:

- `read_license_status()` — `GET /v1/sys/license/status`

The class is wired into `SystemBackend` alongside the other system backend mixins. An integration test is in `tests/integration_tests/api/system_backend/test_license.py`, guarded by `@skipIf(not is_enterprise(), ...)`.

This is as small as it gets — a single read-only endpoint. Happy to add anything the project needs or adjust if there's a preferred location or naming convention. Thanks for your time!