### PR TITLE
Fixed path to always convert nonstandard http LIST method

### DIFF
--- a/hvac/adapters.py
+++ b/hvac/adapters.py
@@ -55,7 +55,9 @@ class Adapter(metaclass=ABCMeta):
         :param ignore_exceptions: If True, _always_ return the response object for a given request. I.e., don't raise an exception
             based on response status code, etc.
         :type ignore_exceptions: bool
-        :param strict_http: If True, use only standard HTTP verbs in request with additional params, otherwise process as is
+        :param strict_http: Deprecated and ignored. Standard HTTP verbs are now always used: LIST
+            requests are sent as ``GET`` with a ``list=true`` param regardless of this setting.
+            Retained so that existing callers passing it do not break.
         :type strict_http: bool
         :param request_header: If true, add the X-Vault-Request header to all requests to protect against SSRF vulnerabilities.
         :type request_header: bool
@@ -149,7 +151,7 @@ class Adapter(metaclass=ABCMeta):
         return self.request("delete", url, **kwargs)
 
     def list(self, url, **kwargs):
-        """Performs a LIST request.
+        """Performs a Vault list request, sent over the wire as ``GET`` with a ``list=true`` param.
 
         :param url: Partial URL path to send the request to. This will be joined to the end of the instance's base_uri
             attribute.
@@ -320,13 +322,12 @@ class RawAdapter(Adapter):
         _kwargs = self._kwargs.copy()
         _kwargs.update(kwargs)
 
-        if self.strict_http and method.lower() in ("list",):
-            # Entry point for standard HTTP substitution
-            params = _kwargs.get("params", {})
-            if method.lower() == "list":
-                method = "get"
-                params.update({"list": "true"})
-            _kwargs["params"] = params
+        if method.lower() == "list":
+            # Vault maps `GET ?list=true` and the non-standard LIST verb to the same
+            # operation, this code path requires a url with a query parameter so strict or not it
+            # needs to be converted to GET
+            method = "get"
+            _kwargs["params"] = {**dict(_kwargs.get("params") or {}), "list": "true"}
 
         response = self.session.request(
             method=method,

--- a/tests/unit_tests/api/auth_methods/test_approle.py
+++ b/tests/unit_tests/api/auth_methods/test_approle.py
@@ -81,7 +81,7 @@ class TestAppRole(TestCase):
             mount_point=mount_point
         )
         requests_mocker.register_uri(
-            method="LIST",
+            method="GET",
             url=mock_url,
             status_code=expected_status_code,
             json=mock_response,
@@ -524,7 +524,7 @@ class TestAppRole(TestCase):
             mount_point=mount_point, role_name=role_name
         )
         requests_mocker.register_uri(
-            method="LIST",
+            method="GET",
             url=mock_url,
             status_code=expected_status_code,
             json=mock_response,

--- a/tests/unit_tests/api/auth_methods/test_ldap.py
+++ b/tests/unit_tests/api/auth_methods/test_ldap.py
@@ -146,7 +146,7 @@ class TestLdap(TestCase):
             mount_point=mount_point,
         )
         requests_mocker.register_uri(
-            method="LIST",
+            method="GET",
             url=mock_url,
             status_code=expected_status_code,
             json=mock_response,
@@ -281,7 +281,7 @@ class TestLdap(TestCase):
             mount_point=mount_point,
         )
         requests_mocker.register_uri(
-            method="LIST",
+            method="GET",
             url=mock_url,
             status_code=expected_status_code,
             json=mock_response,

--- a/tests/unit_tests/test_adapters.py
+++ b/tests/unit_tests/test_adapters.py
@@ -99,7 +99,7 @@ class TestRequest(TestCase):
         }
         expected_status_code = 200
         mock_url = f"{DEFAULT_URL}/{test_path}"
-        requests_mocker.register_uri(method="LIST", url=mock_url, json=mock_response)
+        requests_mocker.register_uri(method="GET", url=mock_url, json=mock_response)
         adapter = adapters.RawAdapter()
         response = adapter.list(
             url=test_path,
@@ -109,6 +109,11 @@ class TestRequest(TestCase):
             second=response.status_code,
         )
         self.assertEqual(first=mock_response, second=response.json())
+        # A list operation must reach Vault as GET with list=true rather than the
+        # non-standard LIST verb, which proxies and gateways may reject.
+        list_request = requests_mocker.last_request
+        self.assertEqual(first="GET", second=list_request.method)
+        self.assertEqual(first=["true"], second=list_request.qs["list"])
 
 
 @pytest.fixture

--- a/tests/unit_tests/v1/test_approle_routes.py
+++ b/tests/unit_tests/v1/test_approle_routes.py
@@ -70,7 +70,7 @@ class TestApproleRoutes(TestCase):
             "approle" if mount_point is None else mount_point,
         )
         requests_mocker.register_uri(
-            method="LIST",
+            method="GET",
             url=mock_url,
             status_code=expected_status_code,
             json=mock_response,
@@ -392,7 +392,7 @@ class TestApproleRoutes(TestCase):
             role_name,
         )
         requests_mocker.register_uri(
-            method="LIST",
+            method="GET",
             url=mock_url,
             status_code=expected_status_code,
             json=mock_response,

--- a/tests/unit_tests/v1/test_aws_ec2_methods.py
+++ b/tests/unit_tests/v1/test_aws_ec2_methods.py
@@ -268,7 +268,7 @@ class TestAwsEc2Methods(TestCase):
             "aws" if mount_point is None else mount_point,
         )
         requests_mocker.register_uri(
-            method="LIST",
+            method="GET",
             url=mock_url,
             json=mock_response,
             status_code=expected_status_code,
@@ -408,7 +408,7 @@ class TestAwsEc2Methods(TestCase):
             "aws" if mount_point is None else mount_point,
         )
         requests_mocker.register_uri(
-            method="LIST",
+            method="GET",
             url=mock_url,
             json=mock_response,
             status_code=expected_status_code,


### PR DESCRIPTION
This converts the nonstandard method as its using a url. Unless talking directly to vault's api this breaks on anything checking the method.  

fixes https://github.com/hvac/hvac/discussions/947#discussioncomment-17923236